### PR TITLE
Add documentation contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+Contributions of all kinds are welcome. Before submitting pull requests, consider running any available tests and linters.
+
+For documentation updates, follow the [documentation contribution guidelines](docs/contributing-docs.md). Running a spell checker or Markdown linter helps catch issues early.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # LabVIEW Community CI/CD — Unified Dispatcher
 
 PowerShell-based actions for LabVIEW build and test tasks exposed through a single dispatcher script. See [docs/index.md](docs/index.md) for setup, usage, and action reference.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on contributing to this project. For documentation-specific style rules, refer to [docs/contributing-docs.md](docs/contributing-docs.md) and run a spell checker or Markdown linter before opening a pull request.
+

--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -1,0 +1,24 @@
+# Documentation Contribution Guidelines
+
+To keep documentation consistent and easy to review, please follow these rules when editing or adding Markdown files.
+
+## Markdown linting
+- Run a Markdown linter such as [`markdownlint`](https://github.com/DavidAnson/markdownlint) before submitting changes.
+- Keep one `#`-level heading at the top of each file and increment heading levels sequentially; do not skip levels.
+
+## Heading levels
+- Use `#` for the document title, then `##`, `###`, and so on.
+- Avoid jumping from a `##` heading directly to `####`.
+
+## Code block conventions
+- Use fenced code blocks with triple backticks.
+- Specify the language for syntax highlighting (for example, use `\`\`\`powershell` to start a PowerShell block).
+- Use `text` for blocks that show output rather than code.
+
+## Linking requirements
+- Use relative links for files within this repository.
+- Provide descriptive link text instead of raw URLs.
+- Check that external links resolve correctly.
+
+## Spell and linter checks
+- Run a spell checker or Markdown linter (if available) before opening a pull request to catch formatting and spelling issues early.


### PR DESCRIPTION
## Summary
- document Markdown style and linking rules
- add CONTRIBUTING.md and reference documentation guidelines from README
- encourage running spell checks or Markdown linters before PRs

## Testing
- `pwsh -NoLogo -NoProfile -File scripts/run-unit-tests/RunUnitTests.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bb7c8ee848329929e50b8aad014aa