### PR TITLE
Set up MkDocs site with GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,40 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [ "actions" ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install mkdocs
+      - name: Build site
+        run: mkdocs build --site-dir site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: site
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 PowerShell-based actions for LabVIEW build and test tasks exposed through a single dispatcher script. See [docs/index.md](docs/index.md) for setup, usage, and action reference.
 
+Documentation is published at [https://<owner>.github.io/open-source-actions/](https://<owner>.github.io/open-source-actions/).
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on contributing to this project. For documentation-specific style rules, refer to [docs/contributing-docs.md](docs/contributing-docs.md) and run a spell checker or Markdown linter before opening a pull request.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,12 @@
+site_name: "LabVIEW Community CI/CD — Unified Dispatcher"
+site_url: "https://<owner>.github.io/open-source-actions/"
+docs_dir: docs
+nav:
+  - Home: index.md
+  - Quickstart: quickstart.md
+  - Unified Dispatcher: UnifiedDispatcher.md
+  - Adapter Authoring: adapter-authoring.md
+  - Versioning: versioning.md
+  - Contributing: contributing-docs.md
+theme:
+  name: readthedocs


### PR DESCRIPTION
## Summary
- configure MkDocs to build documentation from `docs/`
- add workflow to build and deploy docs to GitHub Pages on pushes to the `actions` branch
- link to published documentation in the README

## Testing
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*
- `pwsh -NoLogo -Command "Invoke-Pester"` *(fails: command not found)*
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_689bb9385c288329b2026d5611e9b624