### PR TITLE
docs: add mkdocs config and pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,38 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [actions]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install mkdocs
+      - run: mkdocs build --strict
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LabVIEW Community CI/CD — Unified Dispatcher
 
-PowerShell-based actions for LabVIEW build and test tasks exposed through a single dispatcher script. See [docs/index.md](docs/index.md) for setup, usage, and action reference.
+PowerShell-based actions for LabVIEW build and test tasks exposed through a single dispatcher script. See the [documentation site](https://open-source-actions.github.io/open-source-actions/) for setup, usage, and action reference.
 
 ## Contributing
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,15 @@
+site_name: Open Source Actions
+site_url: https://open-source-actions.github.io/open-source-actions/
+docs_dir: docs
+nav:
+  - Home: index.md
+  - Quickstart: quickstart.md
+  - Unified Dispatcher: UnifiedDispatcher.md
+  - Adapter Authoring: adapter-authoring.md
+  - Versioning: versioning.md
+  - Contributing: contributing-docs.md
+  - Actions:
+      - Apply VIPC: actions/apply-vipc.md
+      - Build LVLIBP: actions/build-lvlibp.md
+      - Missing in Project: actions/missing-in-project.md
+      - Run Unit Tests: actions/run-unit-tests.md


### PR DESCRIPTION
## Summary
- configure MkDocs for docs in repository
- build and deploy documentation to GitHub Pages on pushes to actions branch
- link README to hosted documentation site

## Testing
- `mkdocs build`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester tests/pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bb9385c288329b2026d5611e9b624