### PR TITLE
docs: add architecture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # LabVIEW Community CI/CD — Unified Dispatcher
 
-PowerShell-based actions for LabVIEW build and test tasks exposed through a single dispatcher script. See the [documentation site](https://open-source-actions.github.io/open-source-actions/) for setup, usage, and action reference.
+PowerShell-based actions for LabVIEW build and test tasks exposed through a single dispatcher script. See the [documentation site](https://open-source-actions.github.io/open-source-actions/) for setup, usage, and action reference. For an overview of the project's architecture, see [docs/architecture.md](docs/architecture.md).
 
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on contributing to this project. For documentation-specific style rules, refer to [docs/contributing-docs.md](docs/contributing-docs.md) and run a spell checker or Markdown linter before opening a pull request.
-

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,23 @@
+# Architecture
+
+The Open Source Actions project exposes multiple LabVIEW CI/CD steps through a single dispatcher and a set of adapter scripts.
+
+## Dispatcher
+
+`Invoke-OSAction.ps1` routes incoming requests to the appropriate adapter script. The dispatcher discovers available actions, forwards command-line arguments, and preserves exit codes.
+
+## Adapter scripts
+
+Each action lives in a `scripts/<action-name>` folder. These PowerShell scripts implement the build or test work and are invoked by the dispatcher with the JSON arguments supplied by the GitHub Action.
+
+## Composite action layout
+
+Composite actions share a common template in `actions/abstract-action`. Each published action folder wraps the dispatcher, pointing to the relevant adapter script with parameters and metadata.
+
+## Repository layout
+
+- `actions/` – dispatcher and composite action template
+- `docs/` – MkDocs documentation, including this page
+- `scripts/` – adapter scripts invoked by the dispatcher
+- `tests/` – Pester tests and other verification scripts
+- `tools/` – utilities for building or testing actions

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@ Unifies LabVIEW CI/CD scripts behind a single PowerShell dispatcher. Use `Invoke
 
 ## Get Started
 
+- [Architecture](architecture.md)
 - [Quickstart](quickstart.md)
 - [Adapter Authoring Guide](adapter-authoring.md)
 - [Versioning Policy](versioning.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,9 @@ site_name: Open Source Actions
 site_url: https://open-source-actions.github.io/open-source-actions/
 docs_dir: docs
 nav:
-  - Home: index.md
+  - Home:
+    - Overview: index.md
+    - Architecture: architecture.md
   - Quickstart: quickstart.md
   - Unified Dispatcher: UnifiedDispatcher.md
   - Adapter Authoring: adapter-authoring.md
@@ -10,7 +12,7 @@ nav:
   - Changelog: CHANGELOG.md
   - Contributing: contributing-docs.md
   - Actions:
-      - Apply VIPC: actions/apply-vipc.md
-      - Build LVLIBP: actions/build-lvlibp.md
-      - Missing in Project: actions/missing-in-project.md
-      - Run Unit Tests: actions/run-unit-tests.md
+    - Apply VIPC: actions/apply-vipc.md
+    - Build LVLIBP: actions/build-lvlibp.md
+    - Missing in Project: actions/missing-in-project.md
+    - Run Unit Tests: actions/run-unit-tests.md


### PR DESCRIPTION
## Summary
- document dispatcher, adapter scripts, and repository layout
- link architecture page in navigation and other docs

## Testing
- `markdownlint --disable MD013 -- README.md docs/index.md docs/architecture.md`


------
https://chatgpt.com/codex/tasks/task_e_689bc05164f08329936a9ca699649279