### PR TITLE
docs: align action docs with template

### DIFF
--- a/docs/actions/_template.md
+++ b/docs/actions/_template.md
@@ -1,17 +1,21 @@
-# <action-name>
+# \<action-name>
 
 ## Purpose
+
 Briefly describe the action's goal.
 
 ## Parameters
 
 ### Required
+
 - **Param1** (`type`): Description.
 
 ### Optional
+
 - **Param2** (`type`): Description.
 
 ## CLI example
+
 ```powershell
 pwsh -File actions/Invoke-OSAction.ps1 -ActionName <action-name> -ArgsJson '{
   "Param1": "value"
@@ -19,6 +23,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName <action-name> -ArgsJson '{
 ```
 
 ## GitHub Action example
+
 ```yaml
 - name: <action description>
   uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
@@ -31,5 +36,6 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName <action-name> -ArgsJson '{
 ```
 
 ## Return Codes
+
 - `0` – success
 - non‑zero – failure

--- a/docs/actions/apply-vipc.md
+++ b/docs/actions/apply-vipc.md
@@ -1,11 +1,13 @@
 # apply-vipc
 
 ## Purpose
+
 Apply a VI Package Configuration (.vipc) file to a specific LabVIEW installation using g-cli.
 
 ## Parameters
 
 ### Required
+
 - **MinimumSupportedLVVersion** (`string`): LabVIEW version used to apply the VIPC.
 - **VIP_LVVersion** (`string`): LabVIEW version the VIPC targets.
 - **SupportedBitness** (`string`): "32" or "64" bitness of LabVIEW.
@@ -13,9 +15,11 @@ Apply a VI Package Configuration (.vipc) file to a specific LabVIEW installation
 - **VIPCPath** (`string`): Path to the `.vipc` file to apply.
 
 ### Optional
+
 None.
 
 ## CLI example
+
 ```powershell
 pwsh -File actions/Invoke-OSAction.ps1 -ActionName apply-vipc -ArgsJson '{
   "MinimumSupportedLVVersion": "2019",
@@ -27,6 +31,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName apply-vipc -ArgsJson '{
 ```
 
 ## GitHub Action example
+
 ```yaml
 - name: Apply VIPC
   uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
@@ -43,5 +48,6 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName apply-vipc -ArgsJson '{
 ```
 
 ## Return Codes
+
 - `0` – VIPC applied successfully
 - `1` – error applying VIPC or invalid input

--- a/docs/actions/build-lvlibp.md
+++ b/docs/actions/build-lvlibp.md
@@ -1,11 +1,13 @@
 # build-lvlibp
 
 ## Purpose
+
 Build a LabVIEW project’s build specification into a Packed Project Library (.lvlibp).
 
 ## Parameters
 
 ### Required
+
 - **MinimumSupportedLVVersion** (`string`): LabVIEW version used for the build.
 - **SupportedBitness** (`string`): "32" or "64" bitness of LabVIEW.
 - **RelativePath** (`string`): Working directory or project root.
@@ -18,9 +20,11 @@ Build a LabVIEW project’s build specification into a Packed Project Library (.
 - **Commit** (`string`): Commit identifier embedded in the build.
 
 ### Optional
+
 None.
 
 ## CLI example
+
 ```powershell
 pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -ArgsJson '{
   "MinimumSupportedLVVersion": "2020",
@@ -37,6 +41,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -ArgsJson '{
 ```
 
 ## GitHub Action example
+
 ```yaml
 - name: Build Packed Library
   uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
@@ -58,5 +63,6 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -ArgsJson '{
 ```
 
 ## Return Codes
+
 - `0` – build succeeded
 - `1` – build failed or g-cli error

--- a/docs/actions/missing-in-project.md
+++ b/docs/actions/missing-in-project.md
@@ -1,19 +1,23 @@
 # missing-in-project
 
 ## Purpose
+
 Check that all files in a LabVIEW project are present by scanning for items missing from the `.lvproj`.
 
 ## Parameters
 
 ### Required
+
 - **LVVersion** (`string`): LabVIEW version used to open the project.
 - **Arch** (`string`): "32" or "64" bitness of LabVIEW.
 - **ProjectFile** (`string`): Path to the project file to inspect.
 
 ### Optional
+
 None.
 
 ## CLI example
+
 ```powershell
 pwsh -File actions/Invoke-OSAction.ps1 -ActionName missing-in-project -ArgsJson '{
   "LVVersion": "2020",
@@ -23,6 +27,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName missing-in-project -ArgsJson 
 ```
 
 ## GitHub Action example
+
 ```yaml
 - name: Check for Missing Project Items
   uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
@@ -37,6 +42,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName missing-in-project -ArgsJson 
 ```
 
 ## Return Codes
+
 - `0` – no missing files detected
 - `1` – g-cli or VI error
 - `2` – missing files found

--- a/docs/actions/run-unit-tests.md
+++ b/docs/actions/run-unit-tests.md
@@ -1,18 +1,22 @@
 # run-unit-tests
 
 ## Purpose
+
 Run LabVIEW unit tests via the LabVIEW Unit Test Framework CLI and report pass/fail/error using standard exit codes.
 
 ## Parameters
 
 ### Required
+
 - **MinimumSupportedLVVersion** (`string`): LabVIEW version for the test run.
 - **SupportedBitness** (`string`): "32" or "64" bitness of LabVIEW.
 
 ### Optional
+
 None.
 
 ## CLI example
+
 ```powershell
 pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{
   "MinimumSupportedLVVersion": "2020",
@@ -21,6 +25,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{
 ```
 
 ## GitHub Action example
+
 ```yaml
 - name: Run LabVIEW Unit Tests
   uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
@@ -34,10 +39,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{
 ```
 
 ## Return Codes
-Parses `UnitTestReport.xml` to summarize results.
 
 - `0` – all tests passed
 - `2` – tests failed
 - `3` – g-cli or test run error
-
-Use `-DryRun` to log the sequence without executing.

--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -2,25 +2,34 @@
 
 To keep documentation consistent and easy to review, please follow these rules when editing or adding Markdown files.
 
+## Action documentation
+
+When adding a new action, copy `docs/actions/_template.md` to `docs/actions/<action-name>.md` and complete each section: Purpose, Parameters, CLI example, GitHub Action example, and Return Codes.
+
 ## Markdown linting
+
 - Run a Markdown linter such as [`markdownlint`](https://github.com/DavidAnson/markdownlint) before submitting changes.
 - Keep one `#`-level heading at the top of each file and increment heading levels sequentially; do not skip levels.
 
 ## Heading levels
+
 - Use `#` for the document title, then `##`, `###`, and so on.
 - Avoid jumping from a `##` heading directly to `####`.
 
 ## Code block conventions
+
 - Use fenced code blocks with triple backticks.
 - Specify the language for syntax highlighting (for example, use `\`\`\`powershell` to start a PowerShell block).
 - Use `text` for blocks that show output rather than code.
 
 ## Linking requirements
+
 - Use relative links for files within this repository.
 - Provide descriptive link text instead of raw URLs.
 - Check that external links resolve correctly.
 
 ## Spell and linter checks
+
 - Run a spell checker or Markdown linter (if available) before opening a pull request to catch formatting and spelling issues early.
 
 ## Preview the docs locally


### PR DESCRIPTION
## Summary
- note to copy `docs/actions/_template.md` when adding new action docs
- normalize action documentation structure and return codes

## Testing
- `npx markdownlint-cli docs/actions/*.md docs/contributing-docs.md` *(fails: MD013 line length warnings)*
- `mkdocs build`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -CI"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bc1da5fc483298052e4f89c1822b0