### PR TITLE
docs: add usage and contributing guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,30 @@
 # LabVIEW Community CI/CD — Unified Dispatcher
 
-PowerShell-based actions for LabVIEW build and test tasks exposed through a single dispatcher script. See the [documentation site](https://open-source-actions.github.io/open-source-actions/) for setup, usage, and action reference. For an overview of the project's architecture, see [docs/architecture.md](docs/architecture.md).
+PowerShell-based actions for LabVIEW build and test tasks exposed through a single dispatcher script. See the [documentation site](https://open-source-actions.github.io/open-source-actions/) for setup and action reference. The [quickstart](docs/quickstart.md) shows a full example and [Unified Dispatcher](docs/UnifiedDispatcher.md) describes how the dispatcher works. For an overview of the project's architecture, see [docs/architecture.md](docs/architecture.md).
+
+## Usage
+
+**Composite action**
+
+```yaml
+- name: Run tests
+  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: run-unit-tests
+    args_json: '{ "MinimumSupportedLVVersion": "2021", "SupportedBitness": "64" }'
+```
+
+**CLI**
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{ "MinimumSupportedLVVersion": "2021", "SupportedBitness": "64" }'
+```
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on contributing to this project. For documentation-specific style rules, refer to [docs/contributing-docs.md](docs/contributing-docs.md) and run a spell checker or Markdown linter before opening a pull request.
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for general guidelines and [docs/contributing-docs.md](docs/contributing-docs.md) for documentation rules. To preview docs locally:
+
+```bash
+pip install mkdocs mkdocs-material
+mkdocs serve
+```


### PR DESCRIPTION
## Summary
- document dispatcher usage through composite action and CLI
- link to quickstart and Unified Dispatcher guides
- outline contributing and doc preview steps

## Testing
- `npm test`
- `npx markdownlint README.md` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_689bc6c8b3c483299e499c0f8741abd1