### PR TITLE
chore: add documentation linting

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,0 +1,19 @@
+name: Docs Lint
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'README.md'
+
+jobs:
+  lint-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Lint documentation
+        shell: pwsh
+        run: scripts/lint-docs.ps1

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,7 @@
+{
+  "ignorePatterns": [
+    { "pattern": "^https://open-source-actions.github.io/open-source-actions/" },
+    { "pattern": "^http://127\\.0\\.0\\.1:8000/" },
+    { "pattern": "^https://github.com/ni/g-cli" }
+  ]
+}

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,2 @@
+MD013: false
+MD036: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Contributions of all kinds are welcome. Before submitting pull requests, consider running any available tests and linters.
 
-For documentation updates, follow the [documentation contribution guidelines](docs/contributing-docs.md). Running a spell checker or Markdown linter helps catch issues early.
+For documentation updates, follow the [documentation contribution guidelines](docs/contributing-docs.md). Run `pwsh scripts/lint-docs.ps1` to lint Markdown files and verify links before submitting a pull request.

--- a/scripts/lint-docs.ps1
+++ b/scripts/lint-docs.ps1
@@ -1,0 +1,24 @@
+#!/usr/bin/env pwsh
+<##
+.SYNOPSIS
+Lint Markdown files and verify links.
+
+.DESCRIPTION
+Uses markdownlint to check formatting and markdown-link-check to verify hyperlinks in README and docs.
+##>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Write-Host 'Running markdownlint...'
+# Lint README and documentation Markdown files
+npx --yes markdownlint-cli README.md docs/**/*.md
+
+Write-Host 'Running markdown-link-check...'
+# Check links in README
+npx --yes markdown-link-check -q -c .markdown-link-check.json README.md
+
+# Check links in docs
+Get-ChildItem -Path 'docs' -Recurse -Filter '*.md' | ForEach-Object {
+    npx --yes markdown-link-check -q -c .markdown-link-check.json $_.FullName
+}


### PR DESCRIPTION
## Summary
- add `scripts/lint-docs.ps1` to run markdownlint and markdown-link-check
- create `docs-lint` workflow to run linting for README and docs on pull requests
- mention docs lint step in CONTRIBUTING guidelines

## Testing
- `pwsh scripts/lint-docs.ps1`

------
https://chatgpt.com/codex/tasks/task_e_689bc928cf348329a5d9659dfa0f83da