### PR TITLE
docs: add action documentation

### DIFF
--- a/docs/actions/add-token-to-labview.md
+++ b/docs/actions/add-token-to-labview.md
@@ -1,0 +1,49 @@
+# add-token-to-labview
+
+## Purpose
+
+Add a custom library path token to the LabVIEW INI file so LabVIEW can locate project libraries.
+
+## Parameters
+
+### Required
+
+- **MinimumSupportedLVVersion** (`string`): LabVIEW version used to run g-cli.
+- **SupportedBitness** (`string`): "32" or "64" bitness of LabVIEW.
+- **RelativePath** (`string`): Repository root added to the INI token.
+
+### Optional
+
+None.
+
+## CLI example
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName add-token-to-labview -ArgsJson '{
+  "MinimumSupportedLVVersion": "2021",
+  "SupportedBitness": "64",
+  "RelativePath": "."
+}'
+```
+
+## GitHub Action example
+
+```yaml
+- name: Add library token
+  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: add-token-to-labview
+    args_json: >-
+      {
+        "MinimumSupportedLVVersion": "2021",
+        "SupportedBitness": "64",
+        "RelativePath": "."
+      }
+```
+
+## Return Codes
+
+- `0` – token added successfully
+- non‑zero – g-cli error adding token
+
+For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).

--- a/docs/actions/build-vi-package.md
+++ b/docs/actions/build-vi-package.md
@@ -1,0 +1,73 @@
+# build-vi-package
+
+## Purpose
+
+Update VIPB display information and build a VI package using g-cli.
+
+## Parameters
+
+### Required
+
+- **MinimumSupportedLVVersion** (`string`): Minimum LabVIEW version supported by the package.
+- **SupportedBitness** (`string`): "32" or "64" bitness of LabVIEW.
+- **LabVIEWMinorRevision** (`string`): LabVIEW minor revision (e.g., "3").
+- **RelativePath** (`string`): Repository root used to resolve paths.
+- **VIPBPath** (`string`): Relative path to the VIPB file to build.
+- **Major** (`int`): Major version component.
+- **Minor** (`int`): Minor version component.
+- **Patch** (`int`): Patch version component.
+- **Build** (`int`): Build number component.
+- **Commit** (`string`): Commit identifier for metadata.
+- **DisplayInformationJSON** (`string`): JSON string to merge into the VIPB display information.
+
+### Optional
+
+- **ReleaseNotesFile** (`string`): Path to a release notes file included in the package.
+
+## CLI example
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-vi-package -ArgsJson '{
+  "MinimumSupportedLVVersion": "2023",
+  "SupportedBitness": "64",
+  "LabVIEWMinorRevision": "3",
+  "RelativePath": ".",
+  "VIPBPath": "Tooling/deployment/NI Icon editor.vipb",
+  "Major": 1,
+  "Minor": 0,
+  "Patch": 0,
+  "Build": 2,
+  "Commit": "abcdef",
+  "DisplayInformationJSON": "{\"Package Version\":{\"major\":1,\"minor\":0,\"patch\":0,\"build\":2}}"
+}'
+```
+
+## GitHub Action example
+
+```yaml
+- name: Build VI Package
+  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: build-vi-package
+    args_json: >-
+      {
+        "MinimumSupportedLVVersion": "2023",
+        "SupportedBitness": "64",
+        "LabVIEWMinorRevision": "3",
+        "RelativePath": ".",
+        "VIPBPath": "Tooling/deployment/NI Icon editor.vipb",
+        "Major": 1,
+        "Minor": 0,
+        "Patch": 0,
+        "Build": 2,
+        "Commit": "abcdef",
+        "DisplayInformationJSON": "{\"Package Version\":{\"major\":1,\"minor\":0,\"patch\":0,\"build\":2}}"
+      }
+```
+
+## Return Codes
+
+- `0` – package built successfully
+- non‑zero – g-cli or build error
+
+For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).

--- a/docs/actions/build.md
+++ b/docs/actions/build.md
@@ -1,0 +1,67 @@
+# build
+
+## Purpose
+
+Automate building the LabVIEW Icon Editor project, including cleaning, building libraries, and packaging.
+
+## Parameters
+
+### Required
+
+- **RelativePath** (`string`): Path to the repository root.
+- **Major** (`int`): Major version component.
+- **Minor** (`int`): Minor version component.
+- **Patch** (`int`): Patch version component.
+- **Build** (`int`): Build number component.
+- **Commit** (`string`): Commit identifier embedded in the build.
+- **LabVIEWMinorRevision** (`string`): LabVIEW minor revision (e.g., "3").
+- **CompanyName** (`string`): Name of the company for metadata.
+- **AuthorName** (`string`): Author or organization name for metadata.
+
+### Optional
+
+None.
+
+## CLI example
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName build -ArgsJson '{
+  "RelativePath": ".",
+  "Major": 1,
+  "Minor": 0,
+  "Patch": 0,
+  "Build": 1,
+  "Commit": "abcdef",
+  "LabVIEWMinorRevision": "3",
+  "CompanyName": "Acme Corp",
+  "AuthorName": "Jane Doe"
+}'
+```
+
+## GitHub Action example
+
+```yaml
+- name: Build project
+  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: build
+    args_json: >-
+      {
+        "RelativePath": ".",
+        "Major": 1,
+        "Minor": 0,
+        "Patch": 0,
+        "Build": 1,
+        "Commit": "abcdef",
+        "LabVIEWMinorRevision": "3",
+        "CompanyName": "Acme Corp",
+        "AuthorName": "Jane Doe"
+      }
+```
+
+## Return Codes
+
+- `0` – build completed successfully
+- non‑zero – build script or g-cli error
+
+For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).

--- a/docs/actions/close-labview.md
+++ b/docs/actions/close-labview.md
@@ -1,0 +1,46 @@
+# close-labview
+
+## Purpose
+
+Gracefully close a running LabVIEW instance via g-cli.
+
+## Parameters
+
+### Required
+
+- **MinimumSupportedLVVersion** (`string`): LabVIEW version to close.
+- **SupportedBitness** (`string`): "32" or "64" bitness of LabVIEW.
+
+### Optional
+
+None.
+
+## CLI example
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName close-labview -ArgsJson '{
+  "MinimumSupportedLVVersion": "2021",
+  "SupportedBitness": "64"
+}'
+```
+
+## GitHub Action example
+
+```yaml
+- name: Close LabVIEW
+  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: close-labview
+    args_json: >-
+      {
+        "MinimumSupportedLVVersion": "2021",
+        "SupportedBitness": "64"
+      }
+```
+
+## Return Codes
+
+- `0` – LabVIEW closed successfully
+- non‑zero – g-cli error closing LabVIEW
+
+For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).

--- a/docs/actions/generate-release-notes.md
+++ b/docs/actions/generate-release-notes.md
@@ -1,0 +1,43 @@
+# generate-release-notes
+
+## Purpose
+
+Generate release notes from the git history and write them to a markdown file.
+
+## Parameters
+
+### Required
+
+None.
+
+### Optional
+
+- **OutputPath** (`string`): Path to write the release notes file (default `Tooling/deployment/release_notes.md`).
+
+## CLI example
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName generate-release-notes -ArgsJson '{
+  "OutputPath": "Tooling/deployment/release_notes.md"
+}'
+```
+
+## GitHub Action example
+
+```yaml
+- name: Generate release notes
+  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: generate-release-notes
+    args_json: >-
+      {
+        "OutputPath": "Tooling/deployment/release_notes.md"
+      }
+```
+
+## Return Codes
+
+- `0` – release notes generated
+- non‑zero – git error generating notes
+
+For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).

--- a/docs/actions/modify-vipb-display-info.md
+++ b/docs/actions/modify-vipb-display-info.md
@@ -1,0 +1,73 @@
+# modify-vipb-display-info
+
+## Purpose
+
+Update display information in a VIPB file and rebuild the VI package.
+
+## Parameters
+
+### Required
+
+- **SupportedBitness** (`string`): "32" or "64" bitness of LabVIEW.
+- **RelativePath** (`string`): Path to the repository root.
+- **VIPBPath** (`string`): Relative path to the VIPB file.
+- **MinimumSupportedLVVersion** (`string`): Minimum LabVIEW version supported by the package.
+- **LabVIEWMinorRevision** (`string`): LabVIEW minor revision (e.g., "3").
+- **Major** (`int`): Major version component.
+- **Minor** (`int`): Minor version component.
+- **Patch** (`int`): Patch version component.
+- **Build** (`int`): Build number component.
+- **Commit** (`string`): Commit identifier for metadata.
+- **DisplayInformationJSON** (`string`): JSON string to merge into VIPB display information.
+
+### Optional
+
+- **ReleaseNotesFile** (`string`): Path to a release notes file injected into the build.
+
+## CLI example
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName modify-vipb-display-info -ArgsJson '{
+  "SupportedBitness": "64",
+  "RelativePath": ".",
+  "VIPBPath": "Tooling/deployment/NI Icon editor.vipb",
+  "MinimumSupportedLVVersion": "2023",
+  "LabVIEWMinorRevision": "3",
+  "Major": 1,
+  "Minor": 0,
+  "Patch": 0,
+  "Build": 2,
+  "Commit": "abcdef",
+  "DisplayInformationJSON": "{\"Package Version\":{\"major\":1,\"minor\":0,\"patch\":0,\"build\":2}}"
+}'
+```
+
+## GitHub Action example
+
+```yaml
+- name: Modify VIPB display info
+  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: modify-vipb-display-info
+    args_json: >-
+      {
+        "SupportedBitness": "64",
+        "RelativePath": ".",
+        "VIPBPath": "Tooling/deployment/NI Icon editor.vipb",
+        "MinimumSupportedLVVersion": "2023",
+        "LabVIEWMinorRevision": "3",
+        "Major": 1,
+        "Minor": 0,
+        "Patch": 0,
+        "Build": 2,
+        "Commit": "abcdef",
+        "DisplayInformationJSON": "{\"Package Version\":{\"major\":1,\"minor\":0,\"patch\":0,\"build\":2}}"
+      }
+```
+
+## Return Codes
+
+- `0` – display information updated
+- non‑zero – g-cli or build error
+
+For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).

--- a/docs/actions/prepare-labview-source.md
+++ b/docs/actions/prepare-labview-source.md
@@ -1,0 +1,55 @@
+# prepare-labview-source
+
+## Purpose
+
+Run PrepareIESource.vi via g-cli to unzip components and configure LabVIEW for building.
+
+## Parameters
+
+### Required
+
+- **MinimumSupportedLVVersion** (`string`): LabVIEW version used to run g-cli.
+- **SupportedBitness** (`string`): "32" or "64" bitness of LabVIEW.
+- **RelativePath** (`string`): Path to the repository root.
+- **LabVIEW_Project** (`string`): Name of the LabVIEW project (without extension).
+- **Build_Spec** (`string`): Name of the build specification to prepare.
+
+### Optional
+
+None.
+
+## CLI example
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName prepare-labview-source -ArgsJson '{
+  "MinimumSupportedLVVersion": "2021",
+  "SupportedBitness": "64",
+  "RelativePath": ".",
+  "LabVIEW_Project": "lv_icon_editor",
+  "Build_Spec": "Editor Packed Library"
+}'
+```
+
+## GitHub Action example
+
+```yaml
+- name: Prepare LabVIEW source
+  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: prepare-labview-source
+    args_json: >-
+      {
+        "MinimumSupportedLVVersion": "2021",
+        "SupportedBitness": "64",
+        "RelativePath": ".",
+        "LabVIEW_Project": "lv_icon_editor",
+        "Build_Spec": "Editor Packed Library"
+      }
+```
+
+## Return Codes
+
+- `0` – LabVIEW source prepared
+- non‑zero – g-cli error preparing source
+
+For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).

--- a/docs/actions/rename-file.md
+++ b/docs/actions/rename-file.md
@@ -1,0 +1,46 @@
+# rename-file
+
+## Purpose
+
+Rename a file if it exists.
+
+## Parameters
+
+### Required
+
+- **CurrentFilename** (`string`): Full path to the file to rename.
+- **NewFilename** (`string`): New name (including path) for the file.
+
+### Optional
+
+None.
+
+## CLI example
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName rename-file -ArgsJson '{
+  "CurrentFilename": "C:/path/lv_icon.lvlibp",
+  "NewFilename": "lv_icon_x64.lvlibp"
+}'
+```
+
+## GitHub Action example
+
+```yaml
+- name: Rename file
+  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: rename-file
+    args_json: >-
+      {
+        "CurrentFilename": "C:/path/lv_icon.lvlibp",
+        "NewFilename": "lv_icon_x64.lvlibp"
+      }
+```
+
+## Return Codes
+
+- `0` – file renamed successfully
+- non‑zero – file not found or rename failed
+
+For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).

--- a/docs/actions/restore-setup-lv-source.md
+++ b/docs/actions/restore-setup-lv-source.md
@@ -1,0 +1,55 @@
+# restore-setup-lv-source
+
+## Purpose
+
+Restore the LabVIEW source setup by unzipping the LabVIEW Icon API and removing the INI token.
+
+## Parameters
+
+### Required
+
+- **MinimumSupportedLVVersion** (`string`): LabVIEW version used to run g-cli.
+- **SupportedBitness** (`string`): "32" or "64" bitness of LabVIEW.
+- **RelativePath** (`string`): Path to the repository root.
+- **LabVIEW_Project** (`string`): Name of the LabVIEW project (without extension).
+- **Build_Spec** (`string`): Build specification name within the project.
+
+### Optional
+
+None.
+
+## CLI example
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName restore-setup-lv-source -ArgsJson '{
+  "MinimumSupportedLVVersion": "2021",
+  "SupportedBitness": "64",
+  "RelativePath": ".",
+  "LabVIEW_Project": "lv_icon_editor",
+  "Build_Spec": "Editor Packed Library"
+}'
+```
+
+## GitHub Action example
+
+```yaml
+- name: Restore LabVIEW setup
+  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: restore-setup-lv-source
+    args_json: >-
+      {
+        "MinimumSupportedLVVersion": "2021",
+        "SupportedBitness": "64",
+        "RelativePath": ".",
+        "LabVIEW_Project": "lv_icon_editor",
+        "Build_Spec": "Editor Packed Library"
+      }
+```
+
+## Return Codes
+
+- `0` – setup restored
+- non‑zero – g-cli error restoring setup
+
+For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).

--- a/docs/actions/revert-development-mode.md
+++ b/docs/actions/revert-development-mode.md
@@ -1,0 +1,43 @@
+# revert-development-mode
+
+## Purpose
+
+Restore the repository from development mode by restoring packaged sources and closing LabVIEW.
+
+## Parameters
+
+### Required
+
+- **RelativePath** (`string`): Path to the repository root.
+
+### Optional
+
+None.
+
+## CLI example
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName revert-development-mode -ArgsJson '{
+  "RelativePath": "."
+}'
+```
+
+## GitHub Action example
+
+```yaml
+- name: Revert development mode
+  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: revert-development-mode
+    args_json: >-
+      {
+        "RelativePath": "."
+      }
+```
+
+## Return Codes
+
+- `0` – reverted to packaged state
+- non‑zero – script or g-cli error
+
+For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).

--- a/docs/actions/set-development-mode.md
+++ b/docs/actions/set-development-mode.md
@@ -1,0 +1,43 @@
+# set-development-mode
+
+## Purpose
+
+Configure the repository for development mode by removing packed libraries, adding tokens, preparing sources, and closing LabVIEW.
+
+## Parameters
+
+### Required
+
+- **RelativePath** (`string`): Path to the repository root.
+
+### Optional
+
+None.
+
+## CLI example
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName set-development-mode -ArgsJson '{
+  "RelativePath": "."
+}'
+```
+
+## GitHub Action example
+
+```yaml
+- name: Set development mode
+  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: set-development-mode
+    args_json: >-
+      {
+        "RelativePath": "."
+      }
+```
+
+## Return Codes
+
+- `0` – development mode enabled
+- non‑zero – script or g-cli error
+
+For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).


### PR DESCRIPTION
## Summary
- add Markdown docs for numerous open-source actions
- document purpose, parameters, examples, and return codes

## Testing
- `npx -y markdownlint-cli docs/actions/add-token-to-labview.md docs/actions/build.md docs/actions/build-vi-package.md docs/actions/close-labview.md docs/actions/generate-release-notes.md docs/actions/modify-vipb-display-info.md docs/actions/prepare-labview-source.md docs/actions/rename-file.md docs/actions/restore-setup-lv-source.md docs/actions/revert-development-mode.md docs/actions/set-development-mode.md`


------
https://chatgpt.com/codex/tasks/task_e_689bcbcca4f88329a22b3655a7f7b245