### PR TITLE
docs: reference docs index for adapter list

### DIFF
--- a/docs/UnifiedDispatcher.md
+++ b/docs/UnifiedDispatcher.md
@@ -5,7 +5,7 @@ This package adds a single, stable entrypoint to run LabVIEW CI/CD scripts.
 - **Entry script:** `actions/Invoke-OSAction.ps1`
 - **Module:** `actions/OpenSourceActions.psm1/.psd1`
 - **Composite Action:** `actions/abstract-action/action.yml`
-- **Adapters included:** `apply-vipc`, `build-lvlibp`, `missing-in-project`, `run-unit-tests`
+- **Adapters included:** See [docs/index.md](index.md#action-reference) for the authoritative list of adapters
 - **Discovery:** `-ListActions` and `-Describe <name>`
 - **Dry run:** `-DryRun` logs the exact call and skips execution
 - **Exit codes:** Leaf script codes are preserved (e.g., `run-unit-tests` returns `0/2/3`)


### PR DESCRIPTION
## Summary
- reference docs index for authoritative adapter list in UnifiedDispatcher doc

## Testing
- `markdownlint docs/UnifiedDispatcher.md`


------
https://chatgpt.com/codex/tasks/task_e_689bcf7e5e308329833810a96f0ace73