### PR TITLE
docs: add prerequisites and action discovery instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 PowerShell-based actions for LabVIEW build and test tasks exposed through a single dispatcher script. See the [documentation site](https://open-source-actions.github.io/open-source-actions/) for setup and action reference. The [quickstart](docs/quickstart.md) shows a full example and [Unified Dispatcher](docs/UnifiedDispatcher.md) describes how the dispatcher works. For an overview of the project's architecture, see [docs/architecture.md](docs/architecture.md).
 
+## Prerequisites
+
+- PowerShell 7+ (`pwsh`)
+- NI LabVIEW with command-line interface support (g-cli) for LabVIEW-based actions
+- Supported platforms: Windows for LabVIEW tasks; PowerShell-only scripts also run on macOS and Linux
+
 ## Usage
 
 **Composite action**
@@ -18,6 +24,20 @@ PowerShell-based actions for LabVIEW build and test tasks exposed through a sing
 
 ```powershell
 pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{ "MinimumSupportedLVVersion": "2021", "SupportedBitness": "64" }'
+```
+
+### Discovering actions
+
+List all available actions:
+
+```powershell
+pwsh actions/Invoke-OSAction.ps1 -ListActions
+```
+
+Get details about a specific action:
+
+```powershell
+pwsh actions/Invoke-OSAction.ps1 -Describe run-unit-tests
 ```
 
 ## Contributing


### PR DESCRIPTION
## Summary
- document prerequisites and supported platforms in README
- add section showing how to list and describe available actions

## Testing
- `markdownlint README.md`


------
https://chatgpt.com/codex/tasks/task_e_689bd0ae8d148329b9d5d69fabc36112