### PR TITLE
docs: add common parameters reference

### DIFF
--- a/docs/UnifiedDispatcher.md
+++ b/docs/UnifiedDispatcher.md
@@ -10,6 +10,8 @@ This package adds a single, stable entrypoint to run LabVIEW CI/CD scripts.
 - **Dry run:** `-DryRun` logs the exact call and skips execution
 - **Exit codes:** Leaf script codes are preserved (e.g., `run-unit-tests` returns `0/2/3`)
 
+See [Common Parameters](common-parameters.md) for a complete list of dispatcher flags and environment variables.
+
 ## Cross‑platform
 
 Works on **Windows and Linux** as long as LabVIEW and [g-cli](https://github.com/ni/g-cli) are installed and available on `PATH`. For non‑standard installs, pass `gcliPath` in `args_json` (adapters will prepend it to `PATH`).

--- a/docs/common-parameters.md
+++ b/docs/common-parameters.md
@@ -1,0 +1,64 @@
+# Common Parameters
+
+Calls to `actions/Invoke-OSAction.ps1` share a core set of flags and environment variables.
+
+## Command-line flags
+
+### `-LogLevel`
+Controls logging verbosity. Allowed values: `ERROR`, `WARN`, `INFO` (default), `DEBUG`.
+
+Example:
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{}' -LogLevel DEBUG
+```
+
+### `-DryRun`
+Prints the adapter invocation without executing it.
+
+Example:
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{}' -DryRun
+```
+
+### `-WorkingDirectory`
+Runs the adapter after changing to the specified directory.
+
+Example:
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{}' -WorkingDirectory src
+```
+
+### `-ListActions`
+Lists available actions then exits.
+
+Example:
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ListActions
+```
+
+### `-Describe`
+Shows the parameters for a specific action then exits.
+
+Example:
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -Describe run-unit-tests
+```
+
+## Environment variables
+
+### `gcliPath`
+Optional path to the NI g-cli executable. When provided in `args_json`, the dispatcher prepends it to `PATH`. Default: assumes `g-cli` is already on `PATH`.
+
+Example:
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{"gcliPath":"/opt/gcli/bin"}'
+```
+
+### `PSModulePath`
+PowerShell uses this variable to locate modules. The dispatcher honors the value inherited from the environment. Override it before invoking the dispatcher to load custom modules.
+
+Example:
+```powershell
+$env:PSModulePath = "$PWD/modules"
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{}'
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@ Unifies LabVIEW CI/CD scripts behind a single PowerShell dispatcher. Use `Invoke
 
 - [Architecture](architecture.md)
 - [Quickstart](quickstart.md)
+- [Common Parameters](common-parameters.md)
 - [Adapter Authoring Guide](adapter-authoring.md)
 - [Versioning Policy](versioning.md)
 - [Documentation Changelog](CHANGELOG.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -46,7 +46,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -ArgsJson '{
 }'
 ```
 
-This will import the **OpenSourceActions** module and run the **Build** adapter. On completion, the script returns with an exit code (0 for success or a non-zero error code). You can include optional flags like `-WorkingDirectory` to change directory before execution, or `-DryRun` to simulate the action (see below).
+This will import the **OpenSourceActions** module and run the **Build** adapter. On completion, the script returns with an exit code (0 for success or a non-zero error code). You can include optional flags like `-WorkingDirectory` to change directory before execution, or `-DryRun` to simulate the action (see below). For details on these and other dispatcher flags, see [Common Parameters](common-parameters.md).
 4. **Confirm Results:** After running, check the console output and exit code. The unified dispatcher prints informative logs (at INFO level by default) and any errors encountered. For GitHub Actions, a non-zero exit code will mark the step as failed, surfacing any error messages thrown by the adapter or underlying script.
 
 ## Need help?

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ nav:
     - Overview: index.md
     - Architecture: architecture.md
   - Quickstart: quickstart.md
+  - Common Parameters: common-parameters.md
   - Troubleshooting: troubleshooting.md
   - Unified Dispatcher: UnifiedDispatcher.md
   - Adapter Authoring: adapter-authoring.md


### PR DESCRIPTION
## Summary
- document dispatcher flags and environment variables in `common-parameters.md`
- link common parameters doc from index, quickstart, and unified dispatcher
- expose page in `mkdocs.yml` navigation

## Testing
- `npm test`
- ⚠️ `pwsh ./scripts/lint-docs.ps1` *(missing: pwsh; attempted `apt-get install -y powershell` but package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bd3938e5c8329a7312bc82e622fc4