### PR TITLE
docs: reference common parameters in actions

### DIFF
--- a/docs/actions/_template.md
+++ b/docs/actions/_template.md
@@ -6,6 +6,8 @@ Briefly describe the action's goal.
 
 ## Parameters
 
+Common parameters are described in [Common parameters](../common-parameters.md).
+
 ### Required
 
 - **Param1** (`type`): Description.

--- a/docs/actions/add-token-to-labview.md
+++ b/docs/actions/add-token-to-labview.md
@@ -6,6 +6,8 @@ Add a custom library path token to the LabVIEW INI file so LabVIEW can locate pr
 
 ## Parameters
 
+Common parameters are described in [Common parameters](../common-parameters.md).
+
 ### Required
 
 - **MinimumSupportedLVVersion** (`string`): LabVIEW version used to run g-cli.

--- a/docs/actions/apply-vipc.md
+++ b/docs/actions/apply-vipc.md
@@ -6,6 +6,8 @@ Apply a VI Package Configuration (.vipc) file to a specific LabVIEW installation
 
 ## Parameters
 
+Common parameters are described in [Common parameters](../common-parameters.md).
+
 ### Required
 
 - **MinimumSupportedLVVersion** (`string`): LabVIEW version used to apply the VIPC.

--- a/docs/actions/build-lvlibp.md
+++ b/docs/actions/build-lvlibp.md
@@ -6,6 +6,8 @@ Build a LabVIEW project’s build specification into a Packed Project Library (.
 
 ## Parameters
 
+Common parameters are described in [Common parameters](../common-parameters.md).
+
 ### Required
 
 - **MinimumSupportedLVVersion** (`string`): LabVIEW version used for the build.

--- a/docs/actions/build-vi-package.md
+++ b/docs/actions/build-vi-package.md
@@ -6,6 +6,8 @@ Update VIPB display information and build a VI package using g-cli.
 
 ## Parameters
 
+Common parameters are described in [Common parameters](../common-parameters.md).
+
 ### Required
 
 - **MinimumSupportedLVVersion** (`string`): Minimum LabVIEW version supported by the package.

--- a/docs/actions/build.md
+++ b/docs/actions/build.md
@@ -6,6 +6,8 @@ Automate building the LabVIEW Icon Editor project, including cleaning, building 
 
 ## Parameters
 
+Common parameters are described in [Common parameters](../common-parameters.md).
+
 ### Required
 
 - **RelativePath** (`string`): Path to the repository root.

--- a/docs/actions/close-labview.md
+++ b/docs/actions/close-labview.md
@@ -6,6 +6,8 @@ Gracefully close a running LabVIEW instance via g-cli.
 
 ## Parameters
 
+Common parameters are described in [Common parameters](../common-parameters.md).
+
 ### Required
 
 - **MinimumSupportedLVVersion** (`string`): LabVIEW version to close.

--- a/docs/actions/generate-release-notes.md
+++ b/docs/actions/generate-release-notes.md
@@ -6,6 +6,8 @@ Generate release notes from the git history and write them to a markdown file.
 
 ## Parameters
 
+Common parameters are described in [Common parameters](../common-parameters.md).
+
 ### Required
 
 None.

--- a/docs/actions/missing-in-project.md
+++ b/docs/actions/missing-in-project.md
@@ -6,6 +6,8 @@ Check that all files in a LabVIEW project are present by scanning for items miss
 
 ## Parameters
 
+Common parameters are described in [Common parameters](../common-parameters.md).
+
 ### Required
 
 - **LVVersion** (`string`): LabVIEW version used to open the project.

--- a/docs/actions/modify-vipb-display-info.md
+++ b/docs/actions/modify-vipb-display-info.md
@@ -6,6 +6,8 @@ Update display information in a VIPB file and rebuild the VI package.
 
 ## Parameters
 
+Common parameters are described in [Common parameters](../common-parameters.md).
+
 ### Required
 
 - **SupportedBitness** (`string`): "32" or "64" bitness of LabVIEW.

--- a/docs/actions/prepare-labview-source.md
+++ b/docs/actions/prepare-labview-source.md
@@ -6,6 +6,8 @@ Run PrepareIESource.vi via g-cli to unzip components and configure LabVIEW for b
 
 ## Parameters
 
+Common parameters are described in [Common parameters](../common-parameters.md).
+
 ### Required
 
 - **MinimumSupportedLVVersion** (`string`): LabVIEW version used to run g-cli.

--- a/docs/actions/rename-file.md
+++ b/docs/actions/rename-file.md
@@ -6,6 +6,8 @@ Rename a file if it exists.
 
 ## Parameters
 
+Common parameters are described in [Common parameters](../common-parameters.md).
+
 ### Required
 
 - **CurrentFilename** (`string`): Full path to the file to rename.

--- a/docs/actions/restore-setup-lv-source.md
+++ b/docs/actions/restore-setup-lv-source.md
@@ -6,6 +6,8 @@ Restore the LabVIEW source setup by unzipping the LabVIEW Icon API and removing 
 
 ## Parameters
 
+Common parameters are described in [Common parameters](../common-parameters.md).
+
 ### Required
 
 - **MinimumSupportedLVVersion** (`string`): LabVIEW version used to run g-cli.

--- a/docs/actions/revert-development-mode.md
+++ b/docs/actions/revert-development-mode.md
@@ -6,6 +6,8 @@ Restore the repository from development mode by restoring packaged sources and c
 
 ## Parameters
 
+Common parameters are described in [Common parameters](../common-parameters.md).
+
 ### Required
 
 - **RelativePath** (`string`): Path to the repository root.

--- a/docs/actions/run-unit-tests.md
+++ b/docs/actions/run-unit-tests.md
@@ -6,6 +6,8 @@ Run LabVIEW unit tests via the LabVIEW Unit Test Framework CLI and report pass/f
 
 ## Parameters
 
+Common parameters are described in [Common parameters](../common-parameters.md).
+
 ### Required
 
 - **MinimumSupportedLVVersion** (`string`): LabVIEW version for the test run.

--- a/docs/actions/set-development-mode.md
+++ b/docs/actions/set-development-mode.md
@@ -6,6 +6,8 @@ Configure the repository for development mode by removing packed libraries, addi
 
 ## Parameters
 
+Common parameters are described in [Common parameters](../common-parameters.md).
+
 ### Required
 
 - **RelativePath** (`string`): Path to the repository root.


### PR DESCRIPTION
## Summary
- link action documentation to common parameter reference

## Testing
- `npm test`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_689bd4b0b00c832989310ce79e094078