### PR TITLE
docs: document markdown and link linting

### DIFF
--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -8,7 +8,7 @@ When adding a new action, copy `docs/actions/_template.md` to `docs/actions/<act
 
 ## Markdown linting
 
-- Run a Markdown linter such as [`markdownlint`](https://github.com/DavidAnson/markdownlint) before submitting changes.
+- Run `pwsh scripts/lint-docs.ps1` to lint Markdown and check links before submitting changes.
 - Keep one `#`-level heading at the top of each file and increment heading levels sequentially; do not skip levels.
 
 ## Heading levels


### PR DESCRIPTION
## Summary
- recommend running `pwsh scripts/lint-docs.ps1` to lint markdown and verify links

## Testing
- `pwsh scripts/lint-docs.ps1`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bdbd71fa883298df75c4f4e83838d