### PR TITLE
docs: link action docs to sources

### DIFF
--- a/docs/actions/_template.md
+++ b/docs/actions/_template.md
@@ -43,3 +43,5 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName <action-name> -ArgsJson '{
 - non‑zero – failure
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
+
+Source: [scripts/<action-name>/](../../scripts/<action-name>/)

--- a/docs/actions/add-token-to-labview.md
+++ b/docs/actions/add-token-to-labview.md
@@ -49,3 +49,5 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName add-token-to-labview -ArgsJso
 - non‑zero – g-cli error adding token
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
+
+Source: [scripts/add-token-to-labview/](../../scripts/add-token-to-labview/)

--- a/docs/actions/apply-vipc.md
+++ b/docs/actions/apply-vipc.md
@@ -55,3 +55,5 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName apply-vipc -ArgsJson '{
 - `1` – error applying VIPC or invalid input
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
+
+Source: [scripts/apply-vipc/](../../scripts/apply-vipc/)

--- a/docs/actions/build-lvlibp.md
+++ b/docs/actions/build-lvlibp.md
@@ -70,3 +70,5 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -ArgsJson '{
 - `1` – build failed or g-cli error
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
+
+Source: [scripts/build-lvlibp/](../../scripts/build-lvlibp/)

--- a/docs/actions/build-vi-package.md
+++ b/docs/actions/build-vi-package.md
@@ -73,3 +73,5 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-vi-package -ArgsJson '{
 - non‑zero – g-cli or build error
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
+
+Source: [scripts/build-vi-package/](../../scripts/build-vi-package/)

--- a/docs/actions/build.md
+++ b/docs/actions/build.md
@@ -67,3 +67,5 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build -ArgsJson '{
 - non‑zero – build script or g-cli error
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
+
+Source: [scripts/build/](../../scripts/build/)

--- a/docs/actions/close-labview.md
+++ b/docs/actions/close-labview.md
@@ -46,3 +46,5 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName close-labview -ArgsJson '{
 - non‑zero – g-cli error closing LabVIEW
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
+
+Source: [scripts/close-labview/](../../scripts/close-labview/)

--- a/docs/actions/generate-release-notes.md
+++ b/docs/actions/generate-release-notes.md
@@ -43,3 +43,5 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName generate-release-notes -ArgsJ
 - non‑zero – git error generating notes
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
+
+Source: [scripts/generate-release-notes/](../../scripts/generate-release-notes/)

--- a/docs/actions/missing-in-project.md
+++ b/docs/actions/missing-in-project.md
@@ -50,3 +50,5 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName missing-in-project -ArgsJson 
 - `2` – missing files found
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
+
+Source: [scripts/missing-in-project/](../../scripts/missing-in-project/)

--- a/docs/actions/modify-vipb-display-info.md
+++ b/docs/actions/modify-vipb-display-info.md
@@ -73,3 +73,5 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName modify-vipb-display-info -Arg
 - non‑zero – g-cli or build error
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
+
+Source: [scripts/modify-vipb-display-info/](../../scripts/modify-vipb-display-info/)

--- a/docs/actions/prepare-labview-source.md
+++ b/docs/actions/prepare-labview-source.md
@@ -55,3 +55,5 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName prepare-labview-source -ArgsJ
 - non‑zero – g-cli error preparing source
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
+
+Source: [scripts/prepare-labview-source/](../../scripts/prepare-labview-source/)

--- a/docs/actions/rename-file.md
+++ b/docs/actions/rename-file.md
@@ -46,3 +46,5 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName rename-file -ArgsJson '{
 - non‑zero – file not found or rename failed
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
+
+Source: [scripts/rename-file/](../../scripts/rename-file/)

--- a/docs/actions/restore-setup-lv-source.md
+++ b/docs/actions/restore-setup-lv-source.md
@@ -55,3 +55,5 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName restore-setup-lv-source -Args
 - non‑zero – g-cli error restoring setup
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
+
+Source: [scripts/restore-setup-lv-source/](../../scripts/restore-setup-lv-source/)

--- a/docs/actions/revert-development-mode.md
+++ b/docs/actions/revert-development-mode.md
@@ -43,3 +43,5 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName revert-development-mode -Args
 - non‑zero – script or g-cli error
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
+
+Source: [scripts/revert-development-mode/](../../scripts/revert-development-mode/)

--- a/docs/actions/run-unit-tests.md
+++ b/docs/actions/run-unit-tests.md
@@ -47,3 +47,5 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{
 - `3` – g-cli or test run error
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
+
+Source: [scripts/run-unit-tests/](../../scripts/run-unit-tests/)

--- a/docs/actions/set-development-mode.md
+++ b/docs/actions/set-development-mode.md
@@ -43,3 +43,5 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName set-development-mode -ArgsJso
 - non‑zero – script or g-cli error
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
+
+Source: [scripts/set-development-mode/](../../scripts/set-development-mode/)


### PR DESCRIPTION
## Summary
- add Source links in every action doc to corresponding scripts directory

## Testing
- `npm test`
- `pwsh -NoLogo -Command "Invoke-Pester -Path tests/pester"` *(fails: command not found, attempted to install `powershell` but package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bdd6402cc832994b4318699698f8d