### PR TITLE
fix: indent args_json block

### DIFF
--- a/actions/abstract-action/action.yml
+++ b/actions/abstract-action/action.yml
@@ -34,8 +34,8 @@ runs:
 
         # Capture JSON exactly as provided by the caller, without quoting/escaping issues.
         $json = @'
-${{ inputs.args_json }}
-'@
+        ${{ inputs.args_json }}
+        '@
 
         # Build parameters via hashtable splatting to avoid fragile CLI string quoting.
         $params = @{


### PR DESCRIPTION
## Summary
- indent `args_json` here-string lines in abstract-action

## Testing
- `npm test`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -CI -Path ./tests/pester"` *(fails: expected regex 'apply-vipc' to match output)*

------
https://chatgpt.com/codex/tasks/task_e_689bfed8f9b08329b161250c3744fd37