### PR TITLE
Add Pester tests to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  pester-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Pester
+        shell: pwsh
+        run: Install-Module Pester -Force -Scope CurrentUser
+      - name: Run Pester tests
+        shell: pwsh
+        run: Invoke-Pester -CI -Path tests/pester


### PR DESCRIPTION
## Summary
- run Pester tests when a release is published
- install Pester and fail release if tests fail

## Testing
- `npm test`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -CI -Path tests/pester"` *(fails: command not found: pwsh)*

------
https://chatgpt.com/codex/tasks/task_e_689cb8bb26d8832989c440704530c329