### PR TITLE
Add Pester tests to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release Tests
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  pester-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Pester
+        shell: pwsh
+        run: Install-Module Pester -Force -Scope CurrentUser
+
+      - name: Run Pester tests
+        shell: pwsh
+        run: Invoke-Pester -CI -Path tests/pester


### PR DESCRIPTION
## Summary
- run Pester test suite on release using pwsh

## Testing
- `npm test`
- `pwsh -Command "Install-Module Pester -Force -Scope CurrentUser; Invoke-Pester -CI -Path tests/pester"` *(fails: Expected regular expression 'apply-vipc' to match 'InvalidOperation: The expression after '&' in a pipeline element produced an object that was not valid. It must result in a command name, a script block, or a CommandInfo object.', but it did not match.)*

------
https://chatgpt.com/codex/tasks/task_e_689cb8bb26d8832989c440704530c329