### PR TITLE
fix: resolve repo root in dispatcher tests

### DIFF
--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -5,7 +5,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$repoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
 $dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
 
 Describe 'Unified Dispatcher — discovery and validation' {


### PR DESCRIPTION
## Summary
- resolve tests' repository root using `PSScriptRoot`

## Testing
- `pwsh -Command "Install-Module Pester -Force -Scope CurrentUser; Invoke-Pester -CI -Path tests/pester"` *(fails: InvalidOperation: The expression after '&' in a pipeline element produced an object that was not valid)*


------
https://chatgpt.com/codex/tasks/task_e_689cbb9882c48329808001347a1e374a