### PR TITLE
docs: add Windows Pester test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,20 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for general gu
 pip install mkdocs mkdocs-material
 mkdocs serve
 ```
+
+## Running Pester tests locally on Windows
+
+1. Open a PowerShell 7 terminal.
+2. Install the Pester module if it's not already installed:
+
+   ```powershell
+   Install-Module Pester -Scope CurrentUser -Force
+   ```
+
+3. From the repository root, run the test suite:
+
+   ```powershell
+   Invoke-Pester -CI -Path tests/pester
+   ```
+
+These tests exercise the dispatcher and do not require LabVIEW or g-cli.


### PR DESCRIPTION
## Summary
- document how to run Pester tests locally on Windows

## Testing
- `pwsh -NoLogo scripts/lint-docs.ps1` (fails: dead link in docs/actions/_template.md)
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path tests/pester"` (fails: expected output not found)


------
https://chatgpt.com/codex/tasks/task_e_689cd4b7fa608329b06935a13bda40bc