### PR TITLE
chore: move composite action to repository root

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ PowerShell-based actions for LabVIEW build and test tasks exposed through a sing
 
 ```yaml
 - name: Run tests
-  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: run-unit-tests
     args_json: '{ "MinimumSupportedLVVersion": "2021", "SupportedBitness": "64" }'

--- a/action.yml
+++ b/action.yml
@@ -51,8 +51,8 @@ ${{ inputs.args_json }}
           $params['DryRun'] = $true
         }
 
-        # Locate the dispatcher script relative to this action folder.
-        $script = Join-Path $env:GITHUB_ACTION_PATH '..' 'Invoke-OSAction.ps1'
+        # Locate the dispatcher script relative to this repository root.
+        $script = Join-Path $env:GITHUB_ACTION_PATH 'actions' 'Invoke-OSAction.ps1'
 
         & $script @params
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }


### PR DESCRIPTION
## Summary
- relocate `action.yml` to repository root
- update script reference for new location
- refresh README usage example for root action path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ce62191c4832999db27b32aa8dacb