### PR TITLE
Export dispatcher functions

### DIFF
--- a/actions/OpenSourceActions.psd1
+++ b/actions/OpenSourceActions.psd1
@@ -9,7 +9,23 @@
   PowerShellVersion     = '7.0'
   CompatiblePSEditions  = @('Core')
 
-  FunctionsToExport = '*'
+  FunctionsToExport = @(
+    'InvokeAddTokenToLabVIEW'
+    'InvokeApplyVIPC'
+    'InvokeBuild'
+    'InvokeBuildLvlibp'
+    'InvokeBuildViPackage'
+    'InvokeCloseLabVIEW'
+    'InvokeGenerateReleaseNotes'
+    'InvokeMissingInProject'
+    'InvokeModifyVIPBDisplayInfo'
+    'InvokePrepareLabVIEWSource'
+    'InvokeRenameFile'
+    'InvokeRestoreSetupLVSource'
+    'InvokeRevertDevelopmentMode'
+    'InvokeRunUnitTests'
+    'InvokeSetDevelopmentMode'
+  )
 
   PrivateData = @{
     PSData = @{


### PR DESCRIPTION
## Summary
- export dispatcher `Invoke*` functions in module manifest

## Testing
- `pwsh -NoProfile -Command "Import-Module ./actions/OpenSourceActions.psd1; Get-Command -Module OpenSourceActions | Select-Object -ExpandProperty Name"`
- `npm test`
- `pwsh -NoProfile -Command "Invoke-Pester -Path tests/pester"` *(fails: Expected regular expression 'apply-vipc' to match ...; Expected 0, but got 64.)*


------
https://chatgpt.com/codex/tasks/task_e_689cecbeb2248329aae37241d67796ce