### PR TITLE
test: cover all dispatcher actions with dry run

### DIFF
--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -6,11 +6,11 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
-$dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
+$global:dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
 
 Describe 'Unified Dispatcher — discovery and validation' {
   It 'lists available actions' {
-    $out = pwsh -NoProfile -File $dispatcher -ListActions
+    $out = pwsh -NoProfile -File $global:dispatcher -ListActions
     $out | Should -Match 'apply-vipc'
     $out | Should -Match 'build-lvlibp'
     $out | Should -Match 'missing-in-project'
@@ -18,7 +18,7 @@ Describe 'Unified Dispatcher — discovery and validation' {
   }
 
   It 'describes a known action (build-lvlibp)' {
-    $out = pwsh -NoProfile -File $dispatcher -Describe build-lvlibp
+    $out = pwsh -NoProfile -File $global:dispatcher -Describe build-lvlibp
     $out | Should -Match 'Major'
     $out | Should -Match 'Minor'
     $out | Should -Match 'Patch'
@@ -27,35 +27,55 @@ Describe 'Unified Dispatcher — discovery and validation' {
   }
 
   It 'fails gracefully on unknown action' {
-    pwsh -NoProfile -File $dispatcher -ActionName no-such-action -ArgsJson '{}' *>$null
+    pwsh -NoProfile -File $global:dispatcher -ActionName no-such-action -ArgsJson '{}' *>$null
     $LASTEXITCODE | Should -Be 1
   }
 }
 
-Describe 'Unified Dispatcher — DryRun behavior' {
-  It 'apply-vipc honors DryRun and returns 0' {
-    $json = '{"MinimumSupportedLVVersion":"2021","VIP_LVVersion":"2021","SupportedBitness":"64","RelativePath":".","VIPCPath":"dummy.vipc"}'
-    pwsh -NoProfile -File $dispatcher -ActionName apply-vipc -ArgsJson $json -DryRun *>$null
-    $LASTEXITCODE | Should -Be 0
-  }
+Describe 'Unified Dispatcher — DryRun behavior for all actions' {
+  $actions = pwsh -NoProfile -File $global:dispatcher -ListActions |
+    Where-Object { $_ -match '^\s+- ' } |
+    ForEach-Object { $_.Trim().Substring(2) }
 
-  It 'build-lvlibp honors DryRun and returns 0' {
-    $json = '{
-      "MinimumSupportedLVVersion":"2021",
-      "SupportedBitness":"64",
-      "RelativePath":".",
-      "LabVIEW_Project":"My.lvproj",
-      "Build_Spec":"MyBuild",
-      "Major":1,"Minor":0,"Patch":0,"Build":1,"Commit":"deadbeef"
-    }'
-    pwsh -NoProfile -File $dispatcher -ActionName build-lvlibp -ArgsJson $json -DryRun *>$null
-    $LASTEXITCODE | Should -Be 0
-  }
+  $argsJson = (
+    @{ MinimumSupportedLVVersion = '2021'
+       VIP_LVVersion             = '2021'
+       SupportedBitness          = '64'
+       RelativePath              = '.'
+       VIPCPath                  = 'dummy.vipc'
+       LabVIEW_Project           = 'My.lvproj'
+       Build_Spec                = 'MyBuild'
+       LabVIEWMinorRevision      = '2021'
+       VIPBPath                  = 'dummy.vipb'
+       LVVersion                 = '2021'
+       Arch                      = '64'
+       ProjectFile               = 'Project.lvproj'
+       Major                     = 1
+       Minor                     = 0
+       Patch                     = 0
+       Build                     = 1
+       Commit                    = 'deadbeef'
+       DisplayInformationJSON    = '{}' 
+       OutputPath                = 'out.txt'
+       CompanyName               = 'Company'
+       AuthorName                = 'Author'
+       CurrentFilename           = 'old.txt'
+       NewFilename               = 'new.txt'
+       ReleaseNotesFile          = 'notes.md'
+       ExtraParam                = 'extra'
+    } | ConvertTo-Json -Compress )
 
-  It 'filters unknown args without crashing' {
-    $json = '{"UnknownParam":123}'
-    $out = pwsh -NoProfile -File $dispatcher -ActionName build-lvlibp -ArgsJson $json -DryRun
-    $LASTEXITCODE | Should -Be 0
-    $out | Should -Match 'Ignored unknown parameters'
+  foreach ($name in $actions) {
+    $action = $name
+    It "describes $action" {
+      pwsh -NoProfile -File $global:dispatcher -Describe $action *>$null
+      $LASTEXITCODE | Should -Be 0
+    }
+
+    It "dry-runs $action and warns on unknown args" {
+      $out = pwsh -NoProfile -File $global:dispatcher -ActionName $action -ArgsJson $argsJson -DryRun
+      $LASTEXITCODE | Should -Be 0
+      $out | Should -Match 'Ignored unknown parameters'
+    }
   }
 }


### PR DESCRIPTION
## Summary
- run dispatcher `-Describe` for each registered action
- dry run every action with sample args and verify unknown parameter warning

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -CI -Path tests/pester"` *(fails: Expected 0, but got 1)*

------
https://chatgpt.com/codex/tasks/task_e_689ceed573d08329b9906da344f5e507