### PR TITLE
Ensure release workflow installs PowerShell

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,14 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Install PowerShell 7
+        shell: bash
+        run: |
+          wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb
+          sudo dpkg -i packages-microsoft-prod.deb
+          sudo apt-get update
+          sudo apt-get install -y powershell
+
       - name: Install Pester
         shell: pwsh
         run: Install-Module Pester -Force -Scope CurrentUser


### PR DESCRIPTION
## Summary
- install PowerShell 7 in the release workflow before running Pester tests

## Testing
- `pwsh -NoProfile -c '$PSVersionTable.PSVersion'`
- `pwsh -NoProfile -c 'Invoke-Pester -CI -Path tests/pester'` *(fails: Expected regular expression 'apply-vipc' to match 'Available actions:'...)*


------
https://chatgpt.com/codex/tasks/task_e_689cf81282e48329adde95f4a7c5594a