### PR TITLE
test: discover action script paths dynamically

### DIFF
--- a/tests/pester/ScriptPath.Tests.ps1
+++ b/tests/pester/ScriptPath.Tests.ps1
@@ -7,23 +7,20 @@ $ErrorActionPreference = 'Stop'
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
 $scriptRoot = Join-Path $repoRoot 'scripts'
 
-$cases = @(
-    @{ Name = 'add-token-to-labview';      Path = Join-Path $scriptRoot 'add-token-to-labview/AddTokenToLabVIEW.ps1' },
-    @{ Name = 'apply-vipc';               Path = Join-Path $scriptRoot 'apply-vipc/ApplyVIPC.ps1' },
-    @{ Name = 'build';                    Path = Join-Path $scriptRoot 'build/Build.ps1' },
-    @{ Name = 'build-lvlibp';             Path = Join-Path $scriptRoot 'build-lvlibp/Build_lvlibp.ps1' },
-    @{ Name = 'build-vi-package';         Path = Join-Path $scriptRoot 'build-vi-package/build_vip.ps1' },
-    @{ Name = 'close-labview';            Path = Join-Path $scriptRoot 'close-labview/Close_LabVIEW.ps1' },
-    @{ Name = 'generate-release-notes';   Path = Join-Path $scriptRoot 'generate-release-notes/GenerateReleaseNotes.ps1' },
-    @{ Name = 'missing-in-project';       Path = Join-Path $scriptRoot 'missing-in-project/Invoke-MissingInProjectCLI.ps1' },
-    @{ Name = 'modify-vipb-display-info'; Path = Join-Path $scriptRoot 'modify-vipb-display-info/ModifyVIPBDisplayInfo.ps1' },
-    @{ Name = 'prepare-labview-source';   Path = Join-Path $scriptRoot 'prepare-labview-source/Prepare_LabVIEW_source.ps1' },
-    @{ Name = 'rename-file';              Path = Join-Path $scriptRoot 'rename-file/Rename-file.ps1' },
-    @{ Name = 'restore-setup-lv-source';  Path = Join-Path $scriptRoot 'restore-setup-lv-source/RestoreSetupLVSource.ps1' },
-    @{ Name = 'revert-development-mode';  Path = Join-Path $scriptRoot 'revert-development-mode/RevertDevelopmentMode.ps1' },
-    @{ Name = 'run-unit-tests';           Path = Join-Path $scriptRoot 'run-unit-tests/RunUnitTests.ps1' },
-    @{ Name = 'set-development-mode';     Path = Join-Path $scriptRoot 'set-development-mode/Set_Development_Mode.ps1' }
-)
+$dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
+$actionNames = pwsh -NoProfile -File $dispatcher -ListActions |
+    Where-Object { $_ -match '^\s+- ' } |
+    ForEach-Object { $_.Trim().Substring(2) }
+
+$cases = foreach ($name in $actionNames) {
+    $dir = Join-Path $scriptRoot $name
+    $scriptFile = Get-ChildItem -Path $dir -Filter '*.ps1' -File | Select-Object -First 1
+    if ($null -eq $scriptFile) {
+        @{ Name = $name; Path = Join-Path $dir "$name.ps1" }
+    } else {
+        @{ Name = $name; Path = $scriptFile.FullName }
+    }
+}
 
 Describe 'Action script paths' {
     It 'has script for <Name>' -TestCases $cases {


### PR DESCRIPTION
## Summary
- auto-discover actions from registry to check script paths

## Testing
- `Invoke-Pester -CI -Path tests/pester/ScriptPath.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_689cf9fea2d083298e9d5c2a7f90750d