### PR TITLE
Expose unknown parameter warnings

### DIFF
--- a/actions/Invoke-OSAction.ps1
+++ b/actions/Invoke-OSAction.ps1
@@ -60,17 +60,20 @@ function Show-Description([string]$Name) {
   }
 }
 
-function Filter-Args([hashtable]$InputArgs, [string]$FuncName, [string]$ActionNameForWarn) {
+function Filter-Args([hashtable]$InputArgs, [string]$FuncName, [string]$ActionNameForWarn, [switch]$ReturnUnknownParams) {
   $paramNames = (Get-Command $FuncName -ErrorAction Stop).Parameters.Keys
   $unknown = @()
   $filtered = @{}
   foreach ($k in @($InputArgs.Keys)) {
     if ($paramNames -contains $k) { $filtered[$k] = $InputArgs[$k] } else { $unknown += $k }
   }
+  $msg = $null
   if ($unknown.Count) {
     $msg = "Ignored unknown parameters for '$ActionNameForWarn': $($unknown -join ', ')"
     Write-Warning $msg
-    Write-Output $msg
+  }
+  if ($ReturnUnknownParams) {
+    return [pscustomobject]@{ Args = $filtered; UnknownParams = $msg }
   }
   return $filtered
 }

--- a/docs/actions/_template.md
+++ b/docs/actions/_template.md
@@ -16,6 +16,8 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 
 - **Param2** (`type`): Description.
 
+> **Unknown parameters:** Parameters not recognized by the dispatcher are ignored with a warning. The warning message can be retrieved from the returned object's `UnknownParams` field when requested.
+
 ## CLI example
 
 ```powershell

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -10,7 +10,7 @@ $global:dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
 
 Describe 'Unified Dispatcher — discovery and validation' {
   It 'lists available actions' {
-    $out = pwsh -NoProfile -File $global:dispatcher -ListActions
+    $out = pwsh -NoProfile -File $global:dispatcher -ListActions | Out-String
     $out | Should -Match 'apply-vipc'
     $out | Should -Match 'build-lvlibp'
     $out | Should -Match 'missing-in-project'
@@ -18,7 +18,7 @@ Describe 'Unified Dispatcher — discovery and validation' {
   }
 
   It 'describes a known action (build-lvlibp)' {
-    $out = pwsh -NoProfile -File $global:dispatcher -Describe build-lvlibp
+    $out = pwsh -NoProfile -File $global:dispatcher -Describe build-lvlibp | Out-String
     $out | Should -Match 'Major'
     $out | Should -Match 'Minor'
     $out | Should -Match 'Patch'
@@ -73,9 +73,22 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions' {
     }
 
     It "dry-runs $action and warns on unknown args" {
-      $out = pwsh -NoProfile -File $global:dispatcher -ActionName $action -ArgsJson $argsJson -DryRun
+      $out = pwsh -NoProfile -File $global:dispatcher -ActionName $action -ArgsJson $argsJson -DryRun | Out-String
       $LASTEXITCODE | Should -Be 0
       $out | Should -Match 'Ignored unknown parameters'
     }
+  }
+}
+
+Describe 'Filter-Args helper' {
+  It 'returns UnknownParams when requested' {
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($global:dispatcher, [ref]$null, [ref]$null)
+    $funcAst = $ast.Find({ param($a) $a -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $a.Name -eq 'Filter-Args' }, $true)
+    Invoke-Expression $funcAst.Extent.Text
+
+    function Dummy { param([string]$Known) }
+    $args = @{ Known = 'value'; Extra = 'x' }
+    $result = Filter-Args -InputArgs $args -FuncName 'Dummy' -ActionNameForWarn 'dummy' -ReturnUnknownParams
+    $result.PSObject.Properties.Name | Should -Contain 'UnknownParams'
   }
 }


### PR DESCRIPTION
## Summary
- Allow dispatcher helper `Filter-Args` to optionally return ignored parameter warnings via `UnknownParams`
- Document how unknown parameters are surfaced in dispatcher docs template
- Test helper to ensure `UnknownParams` field is present when requested

## Testing
- `pwsh -NoProfile -Command "Import-Module Pester; Invoke-Pester -CI -Path ./tests/pester"` *(failed: Expected 0, but got 1)*

------
https://chatgpt.com/codex/tasks/task_e_689cfba602408329b11de8765bfbd98f