### PR TITLE
feat: add node tests and workflow

### DIFF
--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -1,0 +1,16 @@
+name: Node Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,12 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run Node tests
+        run: npm test
+
       - name: Install PowerShell 7
         shell: bash
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 # Contributing
 
-Contributions of all kinds are welcome. Before submitting pull requests, consider running any available tests and linters.
+Contributions of all kinds are welcome. Before submitting pull requests, run the JavaScript tests and any available linters.
+
+```bash
+npm test
+```
 
 For documentation updates, follow the [documentation contribution guidelines](docs/contributing-docs.md). Run `pwsh scripts/lint-docs.ps1` to lint Markdown files and verify links before submitting a pull request.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,15 @@ pwsh actions/Invoke-OSAction.ps1 -Describe run-unit-tests
 
 ## Contributing
 
-Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for general guidelines and [docs/contributing-docs.md](docs/contributing-docs.md) for documentation rules. To preview docs locally:
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for general guidelines and [docs/contributing-docs.md](docs/contributing-docs.md) for documentation rules.
+
+Run the JavaScript tests with:
+
+```bash
+npm test
+```
+
+To preview docs locally:
 
 ```bash
 pip install mkdocs mkdocs-material

--- a/docs/actions/_template.md
+++ b/docs/actions/_template.md
@@ -1,4 +1,4 @@
-# \<action-name>
+# `<action-name>`
 
 ## Purpose
 
@@ -46,4 +46,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName <action-name> -ArgsJson '{
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/<action-name>/](../../scripts/<action-name>/)
+Source: [scripts/`<action-name>`/](../../scripts/<action-name>/) <!-- markdown-link-check-disable-line -->

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "open-source-actions",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "license": "MIT",
   "scripts": {
-    "test": "echo \"No JS tests configured\" && exit 0"
+    "test": "node --test scripts/**/*.test.js"
   }
 }

--- a/scripts/auto-issue-branch/utils.js
+++ b/scripts/auto-issue-branch/utils.js
@@ -1,0 +1,6 @@
+export function buildIssueBranchName(issueNumber) {
+  if (typeof issueNumber !== 'number') {
+    throw new TypeError('issueNumber must be a number');
+  }
+  return `issue/${issueNumber}`;
+}

--- a/scripts/auto-issue-branch/utils.test.js
+++ b/scripts/auto-issue-branch/utils.test.js
@@ -1,0 +1,13 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildIssueBranchName } from './utils.js';
+
+test('buildIssueBranchName formats branch name', () => {
+  assert.equal(buildIssueBranchName(123), 'issue/123');
+});
+
+test('buildIssueBranchName rejects non-numeric input', () => {
+  assert.throws(() => buildIssueBranchName('abc'), {
+    name: 'TypeError'
+  });
+});

--- a/scripts/lint-docs.ps1
+++ b/scripts/lint-docs.ps1
@@ -13,12 +13,21 @@ $ErrorActionPreference = 'Stop'
 Write-Host 'Running markdownlint...'
 # Lint README and documentation Markdown files
 npx --yes markdownlint-cli README.md docs/**/*.md
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
 
 Write-Host 'Running markdown-link-check...'
 # Check links in README
 npx --yes markdown-link-check -q -c .markdown-link-check.json README.md
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
 
 # Check links in docs
 Get-ChildItem -Path 'docs' -Recurse -Filter '*.md' | ForEach-Object {
     npx --yes markdown-link-check -q -c .markdown-link-check.json $_.FullName
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
 }


### PR DESCRIPTION
## Summary
- run Node tests via `npm test`
- document how to run JavaScript tests
- execute Node tests in CI and release workflows

## Testing
- `npm test`
- `pwsh scripts/lint-docs.ps1` *(fails: MD033/no-inline-html; dead link in docs/actions/_template.md)*

------
https://chatgpt.com/codex/tasks/task_e_689d07749ba88329ab60f1c5b8a0d792