### PR TITLE
Exit on npx failure in lint-docs

### DIFF
--- a/scripts/lint-docs.ps1
+++ b/scripts/lint-docs.ps1
@@ -13,12 +13,21 @@ $ErrorActionPreference = 'Stop'
 Write-Host 'Running markdownlint...'
 # Lint README and documentation Markdown files
 npx --yes markdownlint-cli README.md docs/**/*.md
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
 
 Write-Host 'Running markdown-link-check...'
 # Check links in README
 npx --yes markdown-link-check -q -c .markdown-link-check.json README.md
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
 
 # Check links in docs
 Get-ChildItem -Path 'docs' -Recurse -Filter '*.md' | ForEach-Object {
     npx --yes markdown-link-check -q -c .markdown-link-check.json $_.FullName
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
 }


### PR DESCRIPTION
## Summary
- halt `lint-docs.ps1` when markdownlint or markdown-link-check fail
- propagate non-zero exit codes for README and docs link validation

## Testing
- `npm test`
- `pwsh -Command "Invoke-Pester tests/pester"` *(fails: Expected 0, but got 1)*
- `pwsh -File scripts/lint-docs.ps1` *(fails: docs/actions/_template.md:49:18 MD033/no-inline-html Inline HTML [Element: action-name])*

------
https://chatgpt.com/codex/tasks/task_e_689d0cc788b08329992ffeb6e30ba0af