### PR TITLE
fix docs action template placeholder

### DIFF
--- a/docs/actions/_template.md
+++ b/docs/actions/_template.md
@@ -1,4 +1,4 @@
-# \<action-name>
+# `<action-name>`
 
 ## Purpose
 
@@ -46,4 +46,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName <action-name> -ArgsJson '{
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/<action-name>/](../../scripts/<action-name>/)
+Source: [scripts/`<action-name>`/](../../scripts/<action-name>/) <!-- markdown-link-check-disable-line -->


### PR DESCRIPTION
## Summary
- fix action template heading to avoid markdownlint MD033
- disable link checking for placeholder source link

## Testing
- `npx --yes markdownlint-cli README.md docs/**/*.md`
- `npx --yes markdown-link-check -c .markdown-link-check.json docs/actions/_template.md`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d0e69c380832995b7b530a4d3fdcd