### PR TITLE
Add Pester test workflow

### DIFF
--- a/.github/workflows/pester-tests.yml
+++ b/.github/workflows/pester-tests.yml
@@ -1,0 +1,14 @@
+name: Pester Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pester-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Pester tests
+        shell: pwsh
+        run: Invoke-Pester -CI -Path ./tests/pester

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -33,11 +33,7 @@ Describe 'Unified Dispatcher — discovery and validation' {
 }
 
 Describe 'Unified Dispatcher — DryRun behavior for all actions' {
-  $actions = pwsh -NoProfile -File $global:dispatcher -ListActions |
-    Where-Object { $_ -match '^\s+- ' } |
-    ForEach-Object { @{ Action = $_.Trim().Substring(2) } }
-
-  $argsJson = (
+  $script:argsJson = (
     @{ MinimumSupportedLVVersion = '2021'
        VIP_LVVersion             = '2021'
        SupportedBitness          = '64'
@@ -65,15 +61,19 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions' {
        ExtraParam                = 'extra'
     } | ConvertTo-Json -Compress )
 
+  $actions = pwsh -NoProfile -File $global:dispatcher -ListActions |
+    Where-Object { $_ -match '^\s+- ' } |
+    ForEach-Object { @{ Action = $_.Trim().Substring(2); ArgsJson = $script:argsJson } }
+
   It "describes <Action>" -ForEach $actions {
-    param($Action)
+    param($Action, $ArgsJson)
     pwsh -NoProfile -File $global:dispatcher -Describe $Action *> $null
     $LASTEXITCODE | Should -Be 0
   }
 
   It "dry-runs <Action> and warns on unknown args" -ForEach $actions {
-    param($Action)
-    $out = pwsh -NoProfile -File $global:dispatcher -ActionName $Action -ArgsJson $argsJson -DryRun | Out-String
+    param($Action, $ArgsJson)
+    $out = & $global:dispatcher -ActionName $Action -ArgsJson $ArgsJson -DryRun *>&1 | Out-String
     $LASTEXITCODE | Should -Be 0
     $out | Should -Match 'Ignored unknown parameters'
   }

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -35,7 +35,7 @@ Describe 'Unified Dispatcher — discovery and validation' {
 Describe 'Unified Dispatcher — DryRun behavior for all actions' {
   $actions = pwsh -NoProfile -File $global:dispatcher -ListActions |
     Where-Object { $_ -match '^\s+- ' } |
-    ForEach-Object { $_.Trim().Substring(2) }
+    ForEach-Object { @{ Action = $_.Trim().Substring(2) } }
 
   $argsJson = (
     @{ MinimumSupportedLVVersion = '2021'
@@ -55,7 +55,7 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions' {
        Patch                     = 0
        Build                     = 1
        Commit                    = 'deadbeef'
-       DisplayInformationJSON    = '{}' 
+       DisplayInformationJSON    = '{}'
        OutputPath                = 'out.txt'
        CompanyName               = 'Company'
        AuthorName                = 'Author'
@@ -65,18 +65,17 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions' {
        ExtraParam                = 'extra'
     } | ConvertTo-Json -Compress )
 
-  foreach ($name in $actions) {
-    $action = $name
-    It "describes $action" {
-      pwsh -NoProfile -File $global:dispatcher -Describe $action *>$null
-      $LASTEXITCODE | Should -Be 0
-    }
+  It "describes <Action>" -ForEach $actions {
+    param($Action)
+    pwsh -NoProfile -File $global:dispatcher -Describe $Action *> $null
+    $LASTEXITCODE | Should -Be 0
+  }
 
-    It "dry-runs $action and warns on unknown args" {
-      $out = pwsh -NoProfile -File $global:dispatcher -ActionName $action -ArgsJson $argsJson -DryRun | Out-String
-      $LASTEXITCODE | Should -Be 0
-      $out | Should -Match 'Ignored unknown parameters'
-    }
+  It "dry-runs <Action> and warns on unknown args" -ForEach $actions {
+    param($Action)
+    $out = pwsh -NoProfile -File $global:dispatcher -ActionName $Action -ArgsJson $argsJson -DryRun | Out-String
+    $LASTEXITCODE | Should -Be 0
+    $out | Should -Match 'Ignored unknown parameters'
   }
 }
 


### PR DESCRIPTION
## Summary
- add CI workflow to run Pester tests on pushes and pull requests

## Testing
- `pwsh -NoLogo -NoProfile -Command 'Invoke-Pester -CI -Path ./tests/pester'` *(fails: `Tests Passed: 19, Failed: 30`)*

------
https://chatgpt.com/codex/tasks/task_e_689d12ad949483299c63056c9d3b9d2e