### PR TITLE
test: use Pester ForEach for dispatcher actions

### DIFF
--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -35,7 +35,7 @@ Describe 'Unified Dispatcher — discovery and validation' {
 Describe 'Unified Dispatcher — DryRun behavior for all actions' {
   $actions = pwsh -NoProfile -File $global:dispatcher -ListActions |
     Where-Object { $_ -match '^\s+- ' } |
-    ForEach-Object { $_.Trim().Substring(2) }
+    ForEach-Object { @{ Action = $_.Trim().Substring(2) } }
 
   $argsJson = (
     @{ MinimumSupportedLVVersion = '2021'
@@ -55,7 +55,7 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions' {
        Patch                     = 0
        Build                     = 1
        Commit                    = 'deadbeef'
-       DisplayInformationJSON    = '{}' 
+       DisplayInformationJSON    = '{}'
        OutputPath                = 'out.txt'
        CompanyName               = 'Company'
        AuthorName                = 'Author'
@@ -65,18 +65,17 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions' {
        ExtraParam                = 'extra'
     } | ConvertTo-Json -Compress )
 
-  foreach ($name in $actions) {
-    $action = $name
-    It "describes $action" {
-      pwsh -NoProfile -File $global:dispatcher -Describe $action *>$null
-      $LASTEXITCODE | Should -Be 0
-    }
+  It "describes <Action>" -ForEach $actions {
+    param($Action)
+    pwsh -NoProfile -File $global:dispatcher -Describe $Action *> $null
+    $LASTEXITCODE | Should -Be 0
+  }
 
-    It "dry-runs $action and warns on unknown args" {
-      $out = pwsh -NoProfile -File $global:dispatcher -ActionName $action -ArgsJson $argsJson -DryRun | Out-String
-      $LASTEXITCODE | Should -Be 0
-      $out | Should -Match 'Ignored unknown parameters'
-    }
+  It "dry-runs <Action> and warns on unknown args" -ForEach $actions {
+    param($Action)
+    $out = pwsh -NoProfile -File $global:dispatcher -ActionName $Action -ArgsJson $argsJson -DryRun | Out-String
+    $LASTEXITCODE | Should -Be 0
+    $out | Should -Match 'Ignored unknown parameters'
   }
 }
 


### PR DESCRIPTION
## Summary
- refactor dispatcher dry-run tests to use Pester's `-ForEach` for each action
- ensure `$Action` parameter is bound in each `It` block

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -CI -Path ./tests/pester"` *(fails: Expected 0, but got 1)*

------
https://chatgpt.com/codex/tasks/task_e_689d1621dc448329879db80d84ed6541