### PR TITLE
Fix dry-run dispatcher tests to pass ArgsJson parameter

### DIFF
--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -33,11 +33,7 @@ Describe 'Unified Dispatcher — discovery and validation' {
 }
 
 Describe 'Unified Dispatcher — DryRun behavior for all actions' {
-  $actions = pwsh -NoProfile -File $global:dispatcher -ListActions |
-    Where-Object { $_ -match '^\s+- ' } |
-    ForEach-Object { @{ Action = $_.Trim().Substring(2) } }
-
-  $argsJson = (
+  $script:argsJson = (
     @{ MinimumSupportedLVVersion = '2021'
        VIP_LVVersion             = '2021'
        SupportedBitness          = '64'
@@ -65,15 +61,19 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions' {
        ExtraParam                = 'extra'
     } | ConvertTo-Json -Compress )
 
+  $actions = pwsh -NoProfile -File $global:dispatcher -ListActions |
+    Where-Object { $_ -match '^\s+- ' } |
+    ForEach-Object { @{ Action = $_.Trim().Substring(2); ArgsJson = $script:argsJson } }
+
   It "describes <Action>" -ForEach $actions {
-    param($Action)
+    param($Action, $ArgsJson)
     pwsh -NoProfile -File $global:dispatcher -Describe $Action *> $null
     $LASTEXITCODE | Should -Be 0
   }
 
   It "dry-runs <Action> and warns on unknown args" -ForEach $actions {
-    param($Action)
-    $out = pwsh -NoProfile -File $global:dispatcher -ActionName $Action -ArgsJson $argsJson -DryRun | Out-String
+    param($Action, $ArgsJson)
+    $out = & $global:dispatcher -ActionName $Action -ArgsJson $ArgsJson -DryRun *>&1 | Out-String
     $LASTEXITCODE | Should -Be 0
     $out | Should -Match 'Ignored unknown parameters'
   }


### PR DESCRIPTION
## Summary
- ensure `Dispatcher.Tests` uses per-action ArgsJson test data
- invoke dispatcher with call operator and capture warning output for dry-run tests

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -CI -Path ./tests/pester"`

------
https://chatgpt.com/codex/tasks/task_e_689d19b493b4832997d71bf4b74e2370