### PR TITLE
chore: accumulate markdown link check exit codes

### DIFF
--- a/scripts/lint-docs.ps1
+++ b/scripts/lint-docs.ps1
@@ -18,16 +18,21 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 Write-Host 'Running markdown-link-check...'
+# Initialize accumulator for markdown-link-check
+$exitCode = 0
+
 # Check links in README
 npx --yes markdown-link-check -q -c .markdown-link-check.json README.md
 if ($LASTEXITCODE -ne 0) {
-    exit $LASTEXITCODE
+    $exitCode = $LASTEXITCODE
 }
 
 # Check links in docs
 Get-ChildItem -Path 'docs' -Recurse -Filter '*.md' | ForEach-Object {
     npx --yes markdown-link-check -q -c .markdown-link-check.json $_.FullName
     if ($LASTEXITCODE -ne 0) {
-        exit $LASTEXITCODE
+        $exitCode = $LASTEXITCODE
     }
 }
+
+exit $exitCode


### PR DESCRIPTION
## Summary
- accumulate markdown-link-check exit codes in scripts/lint-docs.ps1
- exit with aggregated code so dead links cause non-zero code after processing all docs

## Testing
- `pwsh scripts/lint-docs.ps1` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689d2b16e0a48329a3f5fbe0dd8bd782