### PR TITLE
Fail docs lint on dead links

### DIFF
--- a/scripts/lint-docs.ps1
+++ b/scripts/lint-docs.ps1
@@ -18,20 +18,32 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 Write-Host 'Running markdown-link-check...'
-# Initialize accumulator for markdown-link-check
-$exitCode = 0
+function Invoke-LinkCheck {
+    param([string]$FilePath)
 
-# Check links in README
-npx --yes markdown-link-check -q -c .markdown-link-check.json README.md
-if ($LASTEXITCODE -ne 0) {
-    $exitCode = $LASTEXITCODE
+    $output = npx --yes markdown-link-check -q -c .markdown-link-check.json $FilePath 2>&1
+    $output | Write-Output
+
+    if ($output -match 'ERROR: \d+ dead links found') {
+        Write-Error "Dead links found in $FilePath"
+        return 1
+    }
+    if ($LASTEXITCODE -ne 0) {
+        return $LASTEXITCODE
+    }
+
+    return 0
 }
 
-# Check links in docs
+$exitCode = 0
+
+if (Invoke-LinkCheck README.md) {
+    $exitCode = 1
+}
+
 Get-ChildItem -Path 'docs' -Recurse -Filter '*.md' | ForEach-Object {
-    npx --yes markdown-link-check -q -c .markdown-link-check.json $_.FullName
-    if ($LASTEXITCODE -ne 0) {
-        $exitCode = $LASTEXITCODE
+    if (Invoke-LinkCheck $_.FullName) {
+        $exitCode = 1
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure markdown-link-check errors cause docs lint to fail

## Testing
- `pwsh scripts/lint-docs.ps1` *(fails: command not found: pwsh)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*
- `npx --yes markdown-link-check -q -c .markdown-link-check.json /tmp/broken.md`

------
https://chatgpt.com/codex/tasks/task_e_689d2d0908148329abf9b5e308a52765