### PR TITLE
docs: fix dead link in dispatcher docs

### DIFF
--- a/docs/UnifiedDispatcher.md
+++ b/docs/UnifiedDispatcher.md
@@ -62,4 +62,4 @@ jobs:
 - **MINOR**: adding new adapter actions or optional parameters.
 - **PATCH**: backwards‑compatible fixes and docs.
 
-For the current module version, refer to [`actions/OpenSourceActions.psd1`](https://github.com/open-source-actions/open-source-actions/tree/actions/actions/OpenSourceActions.psd1).
+For the current module version, refer to [`actions/OpenSourceActions.psd1`](../actions/OpenSourceActions.psd1).


### PR DESCRIPTION
## Summary
- fix broken link for OpenSourceActions module in UnifiedDispatcher doc

## Testing
- `npm test`
- `npx --yes markdown-link-check -v -c .markdown-link-check.json docs/UnifiedDispatcher.md`


------
https://chatgpt.com/codex/tasks/task_e_689d2f136a388329aea85f51c20ce422