### PR TITLE
fix: clean docs lint

### DIFF
--- a/docs/actions/add-token-to-labview.md
+++ b/docs/actions/add-token-to-labview.md
@@ -50,4 +50,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName add-token-to-labview -ArgsJso
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/add-token-to-labview/](https://github.com/open-source-actions/open-source-actions/tree/actions/scripts/add-token-to-labview/)
+Source: [scripts/add-token-to-labview/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/add-token-to-labview/)

--- a/docs/actions/apply-vipc.md
+++ b/docs/actions/apply-vipc.md
@@ -56,4 +56,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName apply-vipc -ArgsJson '{
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/apply-vipc/](https://github.com/open-source-actions/open-source-actions/tree/actions/scripts/apply-vipc/)
+Source: [scripts/apply-vipc/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/apply-vipc/)

--- a/docs/actions/build-lvlibp.md
+++ b/docs/actions/build-lvlibp.md
@@ -71,4 +71,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -ArgsJson '{
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/build-lvlibp/](https://github.com/open-source-actions/open-source-actions/tree/actions/scripts/build-lvlibp/)
+Source: [scripts/build-lvlibp/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/build-lvlibp/)

--- a/docs/actions/build-vi-package.md
+++ b/docs/actions/build-vi-package.md
@@ -74,4 +74,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-vi-package -ArgsJson '{
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/build-vi-package/](https://github.com/open-source-actions/open-source-actions/tree/actions/scripts/build-vi-package/)
+Source: [scripts/build-vi-package/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/build-vi-package/)

--- a/docs/actions/build.md
+++ b/docs/actions/build.md
@@ -68,4 +68,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build -ArgsJson '{
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/build/](https://github.com/open-source-actions/open-source-actions/tree/actions/scripts/build/)
+Source: [scripts/build/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/build/)

--- a/docs/actions/close-labview.md
+++ b/docs/actions/close-labview.md
@@ -47,4 +47,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName close-labview -ArgsJson '{
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/close-labview/](https://github.com/open-source-actions/open-source-actions/tree/actions/scripts/close-labview/)
+Source: [scripts/close-labview/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/close-labview/)

--- a/docs/actions/generate-release-notes.md
+++ b/docs/actions/generate-release-notes.md
@@ -44,4 +44,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName generate-release-notes -ArgsJ
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/generate-release-notes/](https://github.com/open-source-actions/open-source-actions/tree/actions/scripts/generate-release-notes/)
+Source: [scripts/generate-release-notes/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/generate-release-notes/)

--- a/docs/actions/missing-in-project.md
+++ b/docs/actions/missing-in-project.md
@@ -51,4 +51,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName missing-in-project -ArgsJson 
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/missing-in-project/](https://github.com/open-source-actions/open-source-actions/tree/actions/scripts/missing-in-project/)
+Source: [scripts/missing-in-project/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/missing-in-project/)

--- a/docs/actions/modify-vipb-display-info.md
+++ b/docs/actions/modify-vipb-display-info.md
@@ -74,4 +74,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName modify-vipb-display-info -Arg
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/modify-vipb-display-info/](https://github.com/open-source-actions/open-source-actions/tree/actions/scripts/modify-vipb-display-info/)
+Source: [scripts/modify-vipb-display-info/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/modify-vipb-display-info/)

--- a/docs/actions/prepare-labview-source.md
+++ b/docs/actions/prepare-labview-source.md
@@ -56,4 +56,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName prepare-labview-source -ArgsJ
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/prepare-labview-source/](https://github.com/open-source-actions/open-source-actions/tree/actions/scripts/prepare-labview-source/)
+Source: [scripts/prepare-labview-source/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/prepare-labview-source/)

--- a/docs/actions/rename-file.md
+++ b/docs/actions/rename-file.md
@@ -47,4 +47,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName rename-file -ArgsJson '{
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/rename-file/](https://github.com/open-source-actions/open-source-actions/tree/actions/scripts/rename-file/)
+Source: [scripts/rename-file/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/rename-file/)

--- a/docs/actions/restore-setup-lv-source.md
+++ b/docs/actions/restore-setup-lv-source.md
@@ -56,4 +56,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName restore-setup-lv-source -Args
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/restore-setup-lv-source/](https://github.com/open-source-actions/open-source-actions/tree/actions/scripts/restore-setup-lv-source/)
+Source: [scripts/restore-setup-lv-source/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/restore-setup-lv-source/)

--- a/docs/actions/revert-development-mode.md
+++ b/docs/actions/revert-development-mode.md
@@ -44,4 +44,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName revert-development-mode -Args
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/revert-development-mode/](https://github.com/open-source-actions/open-source-actions/tree/actions/scripts/revert-development-mode/)
+Source: [scripts/revert-development-mode/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/revert-development-mode/)

--- a/docs/actions/run-unit-tests.md
+++ b/docs/actions/run-unit-tests.md
@@ -48,4 +48,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/run-unit-tests/](https://github.com/open-source-actions/open-source-actions/tree/actions/scripts/run-unit-tests/)
+Source: [scripts/run-unit-tests/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/run-unit-tests/)

--- a/docs/actions/set-development-mode.md
+++ b/docs/actions/set-development-mode.md
@@ -44,4 +44,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName set-development-mode -ArgsJso
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/set-development-mode/](https://github.com/open-source-actions/open-source-actions/tree/actions/scripts/set-development-mode/)
+Source: [scripts/set-development-mode/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/set-development-mode/)

--- a/docs/adapter-authoring.md
+++ b/docs/adapter-authoring.md
@@ -5,12 +5,14 @@
 This guide explains the structure of the unified dispatcher and how to extend it with new adapters and scripts.
 
 ## Architecture Recap
+
 - **Dispatcher Script (`Invoke-OSAction.ps1`)**: Entry point that parses inputs and dispatches to an adapter based on `-ActionName`.
 - **PowerShell Module (`OpenSourceActions.psm1`)**: Houses all adapter functions and shared logic.
 - **Underlying Scripts**: Implement the actual functionality and live under `actions/<action-name>/`.
 - **Composite Action (`abstract-action/action.yml`)**: Wraps the dispatcher for GitHub workflows.
 
 ## Naming Conventions
+
 - **Action Name**: Lowercase with hyphens, e.g., `"my-new-action"`.
 - **Script Filename**: Place your PowerShell script in `actions/<action-name>/` with a clear name.
 - **Adapter Function Name**: Use `Invoke<PascalCase>` (e.g., `InvokeMyNewAction`).
@@ -23,6 +25,7 @@ actions/
 ```
 
 ## Adapter Function Template
+
 Add your function to `OpenSourceActions.psm1`:
 
 ```powershell
@@ -55,6 +58,7 @@ function InvokeMyNewAction {
 ```
 
 ## Registry Update (`Invoke-OSAction.ps1`)
+
 Map the action name to the adapter function:
 
 ```powershell
@@ -67,24 +71,30 @@ $registry = @{
 ```
 
 ## Logging and Verbosity
+
 Use `Write-Information` for normal logs and `Write-Verbose` for debug details. Respect the `-LogLevel` parameter set by the dispatcher.
 
 ## DryRun Considerations
+
 If `-DryRun` is specified, log what would happen and return 0 instead of calling the underlying script.
 
 ## Testing Your Adapter
+
 - Add Pester tests in `tests/pester/`.
 - Mock underlying script calls and verify mandatory parameter enforcement.
 - Run `pwsh -File tests/pester/Dispatcher.Tests.ps1` before submitting.
 
 ## Module Version and Documentation
+
 - Bump the module version in `OpenSourceActions.psd1` if appropriate.
 - Document the new action under `docs/actions/`. Start from `_template.md` and include sections: Purpose, Parameters (Required/Optional), CLI example, GitHub Action example, and Return Codes. Update central lists.
 
 ## Logging and Error Handling Guidelines
+
 - Avoid `Write-Host`.
 - Throw on failure instead of using `Exit`.
 - Clean up any temporary state your adapter creates.
 
 ## Following these Steps
+
 By adhering to these conventions, your new action will be discoverable, consistent, and easier to maintain. Happy coding!

--- a/docs/common-parameters.md
+++ b/docs/common-parameters.md
@@ -5,41 +5,51 @@ Calls to `actions/Invoke-OSAction.ps1` share a core set of flags and environment
 ## Command-line flags
 
 ### `-LogLevel`
+
 Controls logging verbosity. Allowed values: `ERROR`, `WARN`, `INFO` (default), `DEBUG`.
 
 Example:
+
 ```powershell
 pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{}' -LogLevel DEBUG
 ```
 
 ### `-DryRun`
+
 Prints the adapter invocation without executing it.
 
 Example:
+
 ```powershell
 pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{}' -DryRun
 ```
 
 ### `WorkingDirectory`
+
 Runs the adapter after changing to the specified directory using `-WorkingDirectory`.
 
 Example:
+
 ```powershell
 pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{}' -WorkingDirectory src
 ```
 
 ### `-ListActions`
+
 Lists available actions then exits.
 
 Example:
+
 ```powershell
 pwsh ./actions/Invoke-OSAction.ps1 -ListActions
 ```
 
 ### `-Describe`
+
 Shows the parameters for a specific action then exits.
 
 Example:
+
 ```powershell
 pwsh ./actions/Invoke-OSAction.ps1 -Describe run-unit-tests
 ```
@@ -47,17 +57,21 @@ pwsh ./actions/Invoke-OSAction.ps1 -Describe run-unit-tests
 ## Environment variables
 
 ### `gcliPath`
+
 Optional path to the NI g-cli executable. When provided in `args_json`, the dispatcher prepends it to `PATH`. Default: assumes `g-cli` is already on `PATH`.
 
 Example:
+
 ```powershell
 pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{"gcliPath":"/opt/gcli/bin"}'
 ```
 
 ### `PSModulePath`
+
 PowerShell uses this variable to locate modules. The dispatcher honors the value inherited from the environment. Override it before invoking the dispatcher to load custom modules.
 
 Example:
+
 ```powershell
 $env:PSModulePath = "$PWD/modules"
 pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{}'

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,57 +1,69 @@
 # Troubleshooting
 
 ## Setup issues
+
 - Ensure NI LabVIEW and g-cli are installed and accessible.
 - Verify PowerShell 7+ (`pwsh`) is available on the PATH.
 - Confirm the working directory and file paths are correct.
 
 ## Missing dependencies
+
 - Check that required packages and toolkits are installed.
 - Install any missing modules or scripts referenced by the action.
 - Review action parameters for typos that could hide dependencies.
 
 ## Interpreting exit codes
+
 - `0` indicates success; any non-zero code signals a failure.
 - Consult each action's documentation for specific return codes.
 - Use verbose logs to pinpoint the cause of unexpected codes.
 
 ## Missing g-cli or LabVIEW
+
 **Symptom:** Actions fail immediately because g-cli or LabVIEW is absent or misconfigured.
 
 **Example error output**
+
 ```text
 ❌  g-cli executable not found in PATH.
 Invoke-OSAction.ps1 : g-cli: command not found
 ```
 
 **Resolution**
+
 1. Install NI LabVIEW and g-cli.
 2. If g-cli isn't on `PATH`, provide its location via [`gcliPath`](common-parameters.md#gclipath).
 3. Verify the path uses proper separators and escaping.
 
 ## 32- vs 64-bit mismatches
+
 **Symptom:** g-cli cannot find the requested LabVIEW architecture.
 
 **Example error output**
+
 ```text
 Unsupported VIP_LVVersion or SupportedBitness for VIP_LVVersion_A.
 g-cli: could not locate LabVIEW 2021 (64-bit)
 ```
 
 **Resolution**
+
 1. Ensure the installed LabVIEW bitness matches the `SupportedBitness` argument.
 2. Confirm action configuration (e.g., [`run-unit-tests`](actions/run-unit-tests.md)) specifies the correct `SupportedBitness`.
 3. Use a g-cli build that matches the target architecture.
 
 ## Permission or working-directory errors
+
 **Symptom:** Files or directories cannot be accessed.
 
 **Example error output**
+
 ```text
 Invoke-OSAction.ps1 : Cannot find path 'C:\\repo\\project' because it does not exist.
 Access to the path '/opt/labview/Tooling' is denied.
 ```
 
 **Resolution**
+
 1. Verify the working directory is correct or set [`-WorkingDirectory`](common-parameters.md#workingdirectory).
 2. Ensure the runner has permission to read/write the necessary paths.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -3,12 +3,15 @@
 The **OpenSourceActions** module and composite action follow [Semantic Versioning](https://semver.org/) in the format **MAJOR.MINOR.PATCH**. The version is stored in `OpenSourceActions.psd1` and mirrored in repository tags.
 
 ## MAJOR version
+
 Used for incompatible changes such as removing or renaming actions, changing required inputs, or altering behavior in a way that breaks existing workflows.
 
 ## MINOR version
+
 Introduces backwards-compatible features: new adapters, optional parameters, or enhancements that do not require workflow changes.
 
 ## PATCH version
+
 Reserved for backwards-compatible bug fixes and internal improvements.
 
 ## Updating Version in `OpenSourceActions.psd1`
@@ -18,21 +21,25 @@ ModuleVersion = '1.2.3'
 ```
 
 After updating the manifest:
+
 1. Document the change in release notes.
 2. Tag the repository with the new version.
 
 ## Maintaining Compatibility
+
 - Preserve existing parameters where possible.
 - Deprecate before removing features.
 - Use `DryRun` and clear error messages to aid migrations.
 
 ## Examples of Changes and Their Impact
+
 - Adding a new action adapter → **MINOR** bump.
 - Requiring a previously optional parameter → **MAJOR** bump.
 - Fixing a parsing bug without interface changes → **PATCH** bump.
 - Renaming an action (`set-development-mode` → `enter-dev-mode`) → **MAJOR** bump.
 
 ## Communication
+
 Release notes, README badges, and migration guides help users understand the impact of version changes and how to update their workflows.
 
 Significant documentation revisions are tracked in [CHANGELOG.md](CHANGELOG.md). When you add or modify major documentation sections, append a dated entry or associated release version to keep the changelog current.


### PR DESCRIPTION
## Summary
- ensure markdown headings, lists, and code fences have surrounding blank lines
- update action docs to link to correct GitHub repository

## Testing
- `npx --yes markdownlint-cli README.md docs/**/*.md`
- `bash -lc 'shopt -s globstar; for file in README.md docs/**/*.md; do echo "Checking $file"; npx --yes markdown-link-check -q -c .markdown-link-check.json "$file" || exit 1; done'`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d316a32988329954b96cb11ac494a