### PR TITLE
docs: add action call reference

### DIFF
--- a/doc-templates/action-doc-template.md
+++ b/doc-templates/action-doc-template.md
@@ -30,7 +30,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName <action-name> -ArgsJson '{
 
 ```yaml
 - name: <action description>
-  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: <action-name>
     args_json: >-

--- a/docs/UnifiedDispatcher.md
+++ b/docs/UnifiedDispatcher.md
@@ -4,7 +4,7 @@ This package adds a single, stable entrypoint to run LabVIEW CI/CD scripts.
 
 - **Entry script:** `actions/Invoke-OSAction.ps1`
 - **Module:** `actions/OpenSourceActions.psm1/.psd1`
-- **Composite Action:** `actions/abstract-action/action.yml`
+- **Composite Action:** `action.yml` (repository root)
 - **Adapters included:** See [docs/index.md](index.md#action-reference) for the authoritative list of adapters
 - **Discovery:** `-ListActions` and `-Describe <name>`
 - **Dry run:** `-DryRun` logs the exact call and skips execution
@@ -27,7 +27,7 @@ pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests `
 ## Composite Action usage
 
 ```yaml
-- uses: ./actions/abstract-action
+- uses: ./
   with:
     action_name: run-unit-tests
     args_json: >
@@ -45,7 +45,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: ./actions/abstract-action
+      - uses: ./
         with:
           action_name: run-unit-tests
           args_json: >

--- a/docs/action-call-reference.md
+++ b/docs/action-call-reference.md
@@ -7,7 +7,7 @@ Use the composite action to invoke any adapter by specifying its `action_name` a
 See [add-token-to-labview](actions/add-token-to-labview.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+- uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: add-token-to-labview
     args_json: >-
@@ -23,7 +23,7 @@ See [add-token-to-labview](actions/add-token-to-labview.md) for all parameters.
 See [apply-vipc](actions/apply-vipc.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+- uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: apply-vipc
     args_json: >-
@@ -41,7 +41,7 @@ See [apply-vipc](actions/apply-vipc.md) for all parameters.
 See [build](actions/build.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+- uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: build
     args_json: >-
@@ -63,7 +63,7 @@ See [build](actions/build.md) for all parameters.
 See [build-lvlibp](actions/build-lvlibp.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+- uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: build-lvlibp
     args_json: >-
@@ -86,7 +86,7 @@ See [build-lvlibp](actions/build-lvlibp.md) for all parameters.
 See [build-vi-package](actions/build-vi-package.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+- uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: build-vi-package
     args_json: >-
@@ -110,7 +110,7 @@ See [build-vi-package](actions/build-vi-package.md) for all parameters.
 See [close-labview](actions/close-labview.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+- uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: close-labview
     args_json: >-
@@ -125,7 +125,7 @@ See [close-labview](actions/close-labview.md) for all parameters.
 See [generate-release-notes](actions/generate-release-notes.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+- uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: generate-release-notes
     args_json: >-
@@ -139,7 +139,7 @@ See [generate-release-notes](actions/generate-release-notes.md) for all paramete
 See [missing-in-project](actions/missing-in-project.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+- uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: missing-in-project
     args_json: >-
@@ -155,7 +155,7 @@ See [missing-in-project](actions/missing-in-project.md) for all parameters.
 See [modify-vipb-display-info](actions/modify-vipb-display-info.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+- uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: modify-vipb-display-info
     args_json: >-
@@ -179,7 +179,7 @@ See [modify-vipb-display-info](actions/modify-vipb-display-info.md) for all para
 See [prepare-labview-source](actions/prepare-labview-source.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+- uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: prepare-labview-source
     args_json: >-
@@ -197,7 +197,7 @@ See [prepare-labview-source](actions/prepare-labview-source.md) for all paramete
 See [rename-file](actions/rename-file.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+- uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: rename-file
     args_json: >-
@@ -212,7 +212,7 @@ See [rename-file](actions/rename-file.md) for all parameters.
 See [restore-setup-lv-source](actions/restore-setup-lv-source.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+- uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: restore-setup-lv-source
     args_json: >-
@@ -230,7 +230,7 @@ See [restore-setup-lv-source](actions/restore-setup-lv-source.md) for all parame
 See [revert-development-mode](actions/revert-development-mode.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+- uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: revert-development-mode
     args_json: >-
@@ -244,7 +244,7 @@ See [revert-development-mode](actions/revert-development-mode.md) for all parame
 See [run-unit-tests](actions/run-unit-tests.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+- uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: run-unit-tests
     args_json: >-
@@ -259,7 +259,7 @@ See [run-unit-tests](actions/run-unit-tests.md) for all parameters.
 See [set-development-mode](actions/set-development-mode.md) for all parameters.
 
 ```yaml
-- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+- uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: set-development-mode
     args_json: >-

--- a/docs/action-call-reference.md
+++ b/docs/action-call-reference.md
@@ -1,0 +1,269 @@
+# Action Call Reference
+
+Use the composite action to invoke any adapter by specifying its `action_name` and JSON arguments. Each section below shows a sample GitHub Actions step for calling one of the available actions. Refer to the linked action documentation for parameter details and return codes.
+
+## add-token-to-labview
+
+See [add-token-to-labview](actions/add-token-to-labview.md) for all parameters.
+
+```yaml
+- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: add-token-to-labview
+    args_json: >-
+      {
+        "MinimumSupportedLVVersion": "2021",
+        "SupportedBitness": "64",
+        "RelativePath": "."
+      }
+```
+
+## apply-vipc
+
+See [apply-vipc](actions/apply-vipc.md) for all parameters.
+
+```yaml
+- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: apply-vipc
+    args_json: >-
+      {
+        "MinimumSupportedLVVersion": "2019",
+        "VIP_LVVersion": "2019",
+        "SupportedBitness": "64",
+        "RelativePath": ".",
+        "VIPCPath": "MyProject.vipc"
+      }
+```
+
+## build
+
+See [build](actions/build.md) for all parameters.
+
+```yaml
+- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: build
+    args_json: >-
+      {
+        "RelativePath": ".",
+        "Major": 1,
+        "Minor": 0,
+        "Patch": 0,
+        "Build": 1,
+        "Commit": "abcdef",
+        "LabVIEWMinorRevision": "3",
+        "CompanyName": "Acme Corp",
+        "AuthorName": "Jane Doe"
+      }
+```
+
+## build-lvlibp
+
+See [build-lvlibp](actions/build-lvlibp.md) for all parameters.
+
+```yaml
+- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: build-lvlibp
+    args_json: >-
+      {
+        "MinimumSupportedLVVersion": "2020",
+        "SupportedBitness": "64",
+        "RelativePath": ".",
+        "LabVIEW_Project": "Source/MyProject.lvproj",
+        "Build_Spec": "PackedLib Build",
+        "Major": 1,
+        "Minor": 0,
+        "Patch": 0,
+        "Build": 123,
+        "Commit": "abcdef"
+      }
+```
+
+## build-vi-package
+
+See [build-vi-package](actions/build-vi-package.md) for all parameters.
+
+```yaml
+- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: build-vi-package
+    args_json: >-
+      {
+        "MinimumSupportedLVVersion": "2023",
+        "SupportedBitness": "64",
+        "LabVIEWMinorRevision": "3",
+        "RelativePath": ".",
+        "VIPBPath": "Tooling/deployment/NI Icon editor.vipb",
+        "Major": 1,
+        "Minor": 0,
+        "Patch": 0,
+        "Build": 2,
+        "Commit": "abcdef",
+        "DisplayInformationJSON": "{\"Package Version\":{\"major\":1,\"minor\":0,\"patch\":0,\"build\":2}}"
+      }
+```
+
+## close-labview
+
+See [close-labview](actions/close-labview.md) for all parameters.
+
+```yaml
+- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: close-labview
+    args_json: >-
+      {
+        "MinimumSupportedLVVersion": "2021",
+        "SupportedBitness": "64"
+      }
+```
+
+## generate-release-notes
+
+See [generate-release-notes](actions/generate-release-notes.md) for all parameters.
+
+```yaml
+- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: generate-release-notes
+    args_json: >-
+      {
+        "OutputPath": "Tooling/deployment/release_notes.md"
+      }
+```
+
+## missing-in-project
+
+See [missing-in-project](actions/missing-in-project.md) for all parameters.
+
+```yaml
+- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: missing-in-project
+    args_json: >-
+      {
+        "LVVersion": "2020",
+        "Arch": "64",
+        "ProjectFile": "MyProject.lvproj"
+      }
+```
+
+## modify-vipb-display-info
+
+See [modify-vipb-display-info](actions/modify-vipb-display-info.md) for all parameters.
+
+```yaml
+- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: modify-vipb-display-info
+    args_json: >-
+      {
+        "SupportedBitness": "64",
+        "RelativePath": ".",
+        "VIPBPath": "Tooling/deployment/NI Icon editor.vipb",
+        "MinimumSupportedLVVersion": "2023",
+        "LabVIEWMinorRevision": "3",
+        "Major": 1,
+        "Minor": 0,
+        "Patch": 0,
+        "Build": 2,
+        "Commit": "abcdef",
+        "DisplayInformationJSON": "{\"Package Version\":{\"major\":1,\"minor\":0,\"patch\":0,\"build\":2}}"
+      }
+```
+
+## prepare-labview-source
+
+See [prepare-labview-source](actions/prepare-labview-source.md) for all parameters.
+
+```yaml
+- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: prepare-labview-source
+    args_json: >-
+      {
+        "MinimumSupportedLVVersion": "2021",
+        "SupportedBitness": "64",
+        "RelativePath": ".",
+        "LabVIEW_Project": "lv_icon_editor",
+        "Build_Spec": "Editor Packed Library"
+      }
+```
+
+## rename-file
+
+See [rename-file](actions/rename-file.md) for all parameters.
+
+```yaml
+- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: rename-file
+    args_json: >-
+      {
+        "CurrentFilename": "C:/path/lv_icon.lvlibp",
+        "NewFilename": "lv_icon_x64.lvlibp"
+      }
+```
+
+## restore-setup-lv-source
+
+See [restore-setup-lv-source](actions/restore-setup-lv-source.md) for all parameters.
+
+```yaml
+- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: restore-setup-lv-source
+    args_json: >-
+      {
+        "MinimumSupportedLVVersion": "2021",
+        "SupportedBitness": "64",
+        "RelativePath": ".",
+        "LabVIEW_Project": "lv_icon_editor",
+        "Build_Spec": "Editor Packed Library"
+      }
+```
+
+## revert-development-mode
+
+See [revert-development-mode](actions/revert-development-mode.md) for all parameters.
+
+```yaml
+- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: revert-development-mode
+    args_json: >-
+      {
+        "RelativePath": "."
+      }
+```
+
+## run-unit-tests
+
+See [run-unit-tests](actions/run-unit-tests.md) for all parameters.
+
+```yaml
+- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: run-unit-tests
+    args_json: >-
+      {
+        "MinimumSupportedLVVersion": "2020",
+        "SupportedBitness": "64"
+      }
+```
+
+## set-development-mode
+
+See [set-development-mode](actions/set-development-mode.md) for all parameters.
+
+```yaml
+- uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  with:
+    action_name: set-development-mode
+    args_json: >-
+      {
+        "RelativePath": "."
+      }
+```

--- a/docs/actions/add-token-to-labview.md
+++ b/docs/actions/add-token-to-labview.md
@@ -32,7 +32,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName add-token-to-labview -ArgsJso
 
 ```yaml
 - name: Add library token
-  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: add-token-to-labview
     args_json: >-

--- a/docs/actions/apply-vipc.md
+++ b/docs/actions/apply-vipc.md
@@ -36,7 +36,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName apply-vipc -ArgsJson '{
 
 ```yaml
 - name: Apply VIPC
-  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: apply-vipc
     args_json: >-

--- a/docs/actions/build-lvlibp.md
+++ b/docs/actions/build-lvlibp.md
@@ -46,7 +46,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -ArgsJson '{
 
 ```yaml
 - name: Build Packed Library
-  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: build-lvlibp
     args_json: >-

--- a/docs/actions/build-vi-package.md
+++ b/docs/actions/build-vi-package.md
@@ -48,7 +48,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-vi-package -ArgsJson '{
 
 ```yaml
 - name: Build VI Package
-  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: build-vi-package
     args_json: >-

--- a/docs/actions/build.md
+++ b/docs/actions/build.md
@@ -44,7 +44,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build -ArgsJson '{
 
 ```yaml
 - name: Build project
-  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: build
     args_json: >-

--- a/docs/actions/close-labview.md
+++ b/docs/actions/close-labview.md
@@ -30,7 +30,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName close-labview -ArgsJson '{
 
 ```yaml
 - name: Close LabVIEW
-  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: close-labview
     args_json: >-

--- a/docs/actions/generate-release-notes.md
+++ b/docs/actions/generate-release-notes.md
@@ -28,7 +28,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName generate-release-notes -ArgsJ
 
 ```yaml
 - name: Generate release notes
-  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: generate-release-notes
     args_json: >-

--- a/docs/actions/missing-in-project.md
+++ b/docs/actions/missing-in-project.md
@@ -32,7 +32,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName missing-in-project -ArgsJson 
 
 ```yaml
 - name: Check for Missing Project Items
-  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: missing-in-project
     args_json: >-

--- a/docs/actions/modify-vipb-display-info.md
+++ b/docs/actions/modify-vipb-display-info.md
@@ -48,7 +48,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName modify-vipb-display-info -Arg
 
 ```yaml
 - name: Modify VIPB display info
-  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: modify-vipb-display-info
     args_json: >-

--- a/docs/actions/prepare-labview-source.md
+++ b/docs/actions/prepare-labview-source.md
@@ -36,7 +36,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName prepare-labview-source -ArgsJ
 
 ```yaml
 - name: Prepare LabVIEW source
-  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: prepare-labview-source
     args_json: >-

--- a/docs/actions/rename-file.md
+++ b/docs/actions/rename-file.md
@@ -30,7 +30,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName rename-file -ArgsJson '{
 
 ```yaml
 - name: Rename file
-  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: rename-file
     args_json: >-

--- a/docs/actions/restore-setup-lv-source.md
+++ b/docs/actions/restore-setup-lv-source.md
@@ -36,7 +36,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName restore-setup-lv-source -Args
 
 ```yaml
 - name: Restore LabVIEW setup
-  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: restore-setup-lv-source
     args_json: >-

--- a/docs/actions/revert-development-mode.md
+++ b/docs/actions/revert-development-mode.md
@@ -28,7 +28,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName revert-development-mode -Args
 
 ```yaml
 - name: Revert development mode
-  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: revert-development-mode
     args_json: >-

--- a/docs/actions/run-unit-tests.md
+++ b/docs/actions/run-unit-tests.md
@@ -30,7 +30,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{
 
 ```yaml
 - name: Run LabVIEW Unit Tests
-  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: run-unit-tests
     args_json: >-

--- a/docs/actions/set-development-mode.md
+++ b/docs/actions/set-development-mode.md
@@ -28,7 +28,7 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName set-development-mode -ArgsJso
 
 ```yaml
 - name: Set development mode
-  uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+  uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: set-development-mode
     args_json: >-

--- a/docs/adapter-authoring.md
+++ b/docs/adapter-authoring.md
@@ -9,7 +9,7 @@ This guide explains the structure of the unified dispatcher and how to extend it
 - **Dispatcher Script (`Invoke-OSAction.ps1`)**: Entry point that parses inputs and dispatches to an adapter based on `-ActionName`.
 - **PowerShell Module (`OpenSourceActions.psm1`)**: Houses all adapter functions and shared logic.
 - **Underlying Scripts**: Implement the actual functionality and live under `actions/<action-name>/`.
-- **Composite Action (`abstract-action/action.yml`)**: Wraps the dispatcher for GitHub workflows.
+- **Composite Action (`action.yml`, repository root)**: Wraps the dispatcher for GitHub workflows.
 
 ## Naming Conventions
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,11 +12,12 @@ Each action lives in a `scripts/<action-name>` folder. These PowerShell scripts 
 
 ## Composite action layout
 
-Composite actions share a common template in `actions/abstract-action`. Each published action folder wraps the dispatcher, pointing to the relevant adapter script with parameters and metadata.
+The composite action is defined at the repository root in `action.yml` and wraps the dispatcher. Workflows call this single action and specify which adapter to invoke.
 
 ## Repository layout
 
-- `actions/` – dispatcher and composite action template
+- `actions/` – dispatcher scripts and PowerShell module
+- `action.yml` – composite action entry point
 - `docs/` – MkDocs documentation, including this page
 - `scripts/` – adapter scripts invoked by the dispatcher
 - `tests/` – Pester tests and other verification scripts

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build Packed Library (32-bit)
-        uses: LabVIEW-Community-CI-CD/open-source-actions/abstract-action@v1
+        uses: LabVIEW-Community-CI-CD/open-source-actions@v1
         with:
           action_name: build-lvlibp
           args_json: >

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ nav:
     - Overview: index.md
     - Architecture: architecture.md
   - Quickstart: quickstart.md
+  - Action Calls: action-call-reference.md
   - Common Parameters: common-parameters.md
   - Troubleshooting: troubleshooting.md
   - Unified Dispatcher: UnifiedDispatcher.md


### PR DESCRIPTION
## Summary
- document example invocations for all actions
- add new Action Calls page to MkDocs navigation

## Testing
- `npm test`
- `pwsh scripts/lint-docs.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d3c0c57008329941d3ec983d54051