### PR TITLE
docs: update action doc template path

### DIFF
--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -4,7 +4,7 @@ To keep documentation consistent and easy to review, please follow these rules w
 
 ## Action documentation
 
-When adding a new action, copy `docs/actions/_template.md` to `docs/actions/<action-name>.md` and complete each section: Purpose, Parameters, CLI example, GitHub Action example, and Return Codes.
+When adding a new action, copy [`doc-templates/action-doc-template.md`](../doc-templates/action-doc-template.md) to `docs/actions/<action-name>.md` and complete each section: Purpose, Parameters, CLI example, GitHub Action example, and Return Codes.
 
 ## Markdown linting
 


### PR DESCRIPTION
## Summary
- fix contribution guide to reference action doc template in `doc-templates`

## Testing
- `pwsh scripts/lint-docs.ps1`


------
https://chatgpt.com/codex/tasks/task_e_689d41be6c988329a6fa70a41a1f5e67