### PR TITLE
Use relative script links in action docs

### DIFF
--- a/docs/actions/add-token-to-labview.md
+++ b/docs/actions/add-token-to-labview.md
@@ -50,4 +50,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName add-token-to-labview -ArgsJso
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/add-token-to-labview/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/add-token-to-labview/)
+Source: [scripts/add-token-to-labview/](../../scripts/add-token-to-labview/)

--- a/docs/actions/apply-vipc.md
+++ b/docs/actions/apply-vipc.md
@@ -56,4 +56,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName apply-vipc -ArgsJson '{
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/apply-vipc/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/apply-vipc/)
+Source: [scripts/apply-vipc/](../../scripts/apply-vipc/)

--- a/docs/actions/build-lvlibp.md
+++ b/docs/actions/build-lvlibp.md
@@ -71,4 +71,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -ArgsJson '{
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/build-lvlibp/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/build-lvlibp/)
+Source: [scripts/build-lvlibp/](../../scripts/build-lvlibp/)

--- a/docs/actions/build-vi-package.md
+++ b/docs/actions/build-vi-package.md
@@ -74,4 +74,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-vi-package -ArgsJson '{
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/build-vi-package/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/build-vi-package/)
+Source: [scripts/build-vi-package/](../../scripts/build-vi-package/)

--- a/docs/actions/build.md
+++ b/docs/actions/build.md
@@ -68,4 +68,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build -ArgsJson '{
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/build/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/build/)
+Source: [scripts/build/](../../scripts/build/)

--- a/docs/actions/close-labview.md
+++ b/docs/actions/close-labview.md
@@ -47,4 +47,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName close-labview -ArgsJson '{
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/close-labview/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/close-labview/)
+Source: [scripts/close-labview/](../../scripts/close-labview/)

--- a/docs/actions/generate-release-notes.md
+++ b/docs/actions/generate-release-notes.md
@@ -44,4 +44,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName generate-release-notes -ArgsJ
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/generate-release-notes/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/generate-release-notes/)
+Source: [scripts/generate-release-notes/](../../scripts/generate-release-notes/)

--- a/docs/actions/missing-in-project.md
+++ b/docs/actions/missing-in-project.md
@@ -51,4 +51,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName missing-in-project -ArgsJson 
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/missing-in-project/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/missing-in-project/)
+Source: [scripts/missing-in-project/](../../scripts/missing-in-project/)

--- a/docs/actions/modify-vipb-display-info.md
+++ b/docs/actions/modify-vipb-display-info.md
@@ -74,4 +74,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName modify-vipb-display-info -Arg
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/modify-vipb-display-info/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/modify-vipb-display-info/)
+Source: [scripts/modify-vipb-display-info/](../../scripts/modify-vipb-display-info/)

--- a/docs/actions/prepare-labview-source.md
+++ b/docs/actions/prepare-labview-source.md
@@ -56,4 +56,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName prepare-labview-source -ArgsJ
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/prepare-labview-source/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/prepare-labview-source/)
+Source: [scripts/prepare-labview-source/](../../scripts/prepare-labview-source/)

--- a/docs/actions/rename-file.md
+++ b/docs/actions/rename-file.md
@@ -47,4 +47,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName rename-file -ArgsJson '{
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/rename-file/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/rename-file/)
+Source: [scripts/rename-file/](../../scripts/rename-file/)

--- a/docs/actions/restore-setup-lv-source.md
+++ b/docs/actions/restore-setup-lv-source.md
@@ -56,4 +56,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName restore-setup-lv-source -Args
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/restore-setup-lv-source/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/restore-setup-lv-source/)
+Source: [scripts/restore-setup-lv-source/](../../scripts/restore-setup-lv-source/)

--- a/docs/actions/revert-development-mode.md
+++ b/docs/actions/revert-development-mode.md
@@ -44,4 +44,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName revert-development-mode -Args
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/revert-development-mode/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/revert-development-mode/)
+Source: [scripts/revert-development-mode/](../../scripts/revert-development-mode/)

--- a/docs/actions/run-unit-tests.md
+++ b/docs/actions/run-unit-tests.md
@@ -48,4 +48,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/run-unit-tests/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/run-unit-tests/)
+Source: [scripts/run-unit-tests/](../../scripts/run-unit-tests/)

--- a/docs/actions/set-development-mode.md
+++ b/docs/actions/set-development-mode.md
@@ -44,4 +44,4 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName set-development-mode -ArgsJso
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
 
-Source: [scripts/set-development-mode/](https://github.com/LabVIEW-Community-CI-CD/open-source-actions/tree/actions/scripts/set-development-mode/)
+Source: [scripts/set-development-mode/](../../scripts/set-development-mode/)


### PR DESCRIPTION
## Summary
- use relative paths for action script source links

## Testing
- `pwsh scripts/lint-docs.ps1` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_689d4428f5ac8329b9e5c0ba69c16684