### PR TITLE
docs: prefix WorkingDirectory heading with dash

### DIFF
--- a/docs/common-parameters.md
+++ b/docs/common-parameters.md
@@ -24,7 +24,7 @@ Example:
 pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{}' -DryRun
 ```
 
-### `WorkingDirectory`
+### `-WorkingDirectory`
 
 Runs the adapter after changing to the specified directory using `-WorkingDirectory`.
 


### PR DESCRIPTION
## Summary
- prefix the `WorkingDirectory` section heading with `-WorkingDirectory`

## Testing
- `pwsh scripts/lint-docs.ps1`


------
https://chatgpt.com/codex/tasks/task_e_689d455ed70c8329918a971613924b59