### PR TITLE
docs: add action call reference to docs home

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@ Unifies LabVIEW CI/CD scripts behind a single PowerShell dispatcher. Use `Invoke
 
 - [Architecture](architecture.md)
 - [Quickstart](quickstart.md)
+- [Action Call Reference](action-call-reference.md)
 - [Common Parameters](common-parameters.md)
 - [Adapter Authoring Guide](adapter-authoring.md)
 - [Versioning Policy](versioning.md)


### PR DESCRIPTION
## Summary
- add link to Action Call Reference in Get Started list

## Testing
- `pwsh scripts/lint-docs.ps1`

------
https://chatgpt.com/codex/tasks/task_e_689d476e4e008329b2465e0dce764882