### PR TITLE
docs: standardize project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Unified LabVIEW Action
+# Open Source LabVIEW Actions
 
-Unified LabVIEW Action is a composite GitHub Action that dispatches LabVIEW CI/CD tasks via PowerShell. See the [documentation site](https://open-source-actions.github.io/open-source-actions/) for setup and action reference. The [quickstart](docs/quickstart.md) shows a full example and [Unified Dispatcher](docs/UnifiedDispatcher.md) describes how the dispatcher works. For an overview of the project's architecture, see [docs/architecture.md](docs/architecture.md).
+Open Source LabVIEW Actions is a composite GitHub Action that dispatches LabVIEW CI/CD tasks via PowerShell. See the [documentation site](https://open-source-actions.github.io/open-source-actions/) for setup and action reference. The [quickstart](docs/quickstart.md) shows a full example and [Unified Dispatcher](docs/UnifiedDispatcher.md) describes how the dispatcher works. For an overview of the project's architecture, see [docs/architecture.md](docs/architecture.md).
 
 To inspect the action's source and full schema, see [action.yml](action.yml).
 

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Unified LabVIEW Action'
+name: 'Open Source LabVIEW Actions'
 description: 'Composite action to dispatch LabVIEW CI/CD tasks through a unified PowerShell interface.'
 inputs:
   action_name:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-The Open Source Actions project exposes multiple LabVIEW CI/CD steps through a single dispatcher and a set of adapter scripts.
+The Open Source LabVIEW Actions project exposes multiple LabVIEW CI/CD steps through a single dispatcher and a set of adapter scripts.
 
 ## Dispatcher
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Open Source LabVIEW Actions
 
-Unifies LabVIEW CI/CD scripts behind a single PowerShell dispatcher. Use `Invoke-OSAction.ps1` to call actions by name with JSON arguments. The dispatcher exposes discovery commands (`-ListActions` and `-Describe`) and preserves each action's exit codes. It runs on Windows or Linux runners with LabVIEW and g-cli available, and supports `-DryRun` for safe previews.
+Open Source LabVIEW Actions unifies LabVIEW CI/CD scripts behind a single PowerShell dispatcher. Use `Invoke-OSAction.ps1` to call actions by name with JSON arguments. The dispatcher exposes discovery commands (`-ListActions` and `-Describe`) and preserves each action's exit codes. It runs on Windows or Linux runners with LabVIEW and g-cli available, and supports `-DryRun` for safe previews.
 
 ## Get Started
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Open Source Actions
+site_name: Open Source LabVIEW Actions
 site_url: https://open-source-actions.github.io/open-source-actions/
 docs_dir: docs
 nav:


### PR DESCRIPTION
## Summary
- adopt "Open Source LabVIEW Actions" as the canonical project name
- update documentation and action metadata to use the new name
- align MkDocs configuration with the canonical name

## Testing
- `pwsh scripts/lint-docs.ps1`

------
https://chatgpt.com/codex/tasks/task_e_689d4a0ae7008329b7482cad4ae0423d