### PR TITLE
Fix broken documentation cross-references

### DIFF
--- a/docs/UnifiedDispatcher.md
+++ b/docs/UnifiedDispatcher.md
@@ -61,5 +61,4 @@ jobs:
 - **MAJOR**: breaking parameter/type changes, removing or renaming actions.
 - **MINOR**: adding new adapter actions or optional parameters.
 - **PATCH**: backwards‑compatible fixes and docs.
-
-For the current module version, refer to [`actions/OpenSourceActions.psd1`](../actions/OpenSourceActions.psd1).
+For the current module version, refer to `actions/OpenSourceActions.psd1`.

--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -4,7 +4,7 @@ To keep documentation consistent and easy to review, please follow these rules w
 
 ## Action documentation
 
-When adding a new action, copy [`doc-templates/action-doc-template.md`](../doc-templates/action-doc-template.md) to `docs/actions/<action-name>.md` and complete each section: Purpose, Parameters, CLI example, GitHub Action example, and Return Codes.
+When adding a new action, copy `doc-templates/action-doc-template.md` to `docs/actions/<action-name>.md` and complete each section: Purpose, Parameters, CLI example, GitHub Action example, and Return Codes.
 
 ## Markdown linting
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -65,5 +65,5 @@ Access to the path '/opt/labview/Tooling' is denied.
 
 **Resolution**
 
-1. Verify the working directory is correct or set [`-WorkingDirectory`](common-parameters.md#workingdirectory).
+1. Verify the working directory is correct or set [`-WorkingDirectory`](common-parameters.md#-workingdirectory).
 2. Ensure the runner has permission to read/write the necessary paths.


### PR DESCRIPTION
## Summary
- Remove invalid link to module manifest in Unified Dispatcher doc
- Mention action doc template without relative link outside docs
- Correct Troubleshooting reference to `-WorkingDirectory` anchor

## Testing
- `mkdocs build --strict`

------
https://chatgpt.com/codex/tasks/task_e_689d5268fa508329b97e7bc14df37d7a