### PR TITLE
Specify environment for docs deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
   deploy-docs:
     if: github.ref == 'refs/heads/actions'
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
     permissions:
       contents: read
       pages: write


### PR DESCRIPTION
## Summary
- set GitHub Pages environment for `deploy-docs` workflow job

## Testing
- `npm test`
- `pwsh -Command "Invoke-Pester -CI -Path ./tests/pester"` *(fails: command not found)*
- `git push` *(fails: No configured push destination)*

------
https://chatgpt.com/codex/tasks/task_e_689d5788f2e48329b955059d2f44362d