### PR TITLE
refactor: update missing-in-project action usage

### DIFF
--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -50,11 +50,15 @@ jobs:
 
       - name: Missing in Project Check
         if: ${{ github.event.inputs.test_action == 'missing-in-project' }}
-        uses: LabVIEW-Community-CI-CD/open-source-actions/missing-in-project@v1
+        uses: LabVIEW-Community-CI-CD/open-source-actions@v1
         with:
-          lv-ver: 2021
-          arch: 64
-          project-file: lv_icon_editor.lvproj
+          action_name: missing-in-project
+          args_json: >
+            {
+              "LVVersion": "2021",
+              "Arch": "64",
+              "ProjectFile": "lv_icon_editor.lvproj"
+            }
 
       - name: Run Unit Tests
         if: ${{ github.event.inputs.test_action == 'run-unit-tests' }}

--- a/.github/workflows/test-harness.yml
+++ b/.github/workflows/test-harness.yml
@@ -35,18 +35,26 @@ jobs:
 
       - name: Apply VIPC Dependencies
         if: ${{ github.event.inputs.test_action == 'apply-vipc' }}
-        uses: LabVIEW-Community-CI-CD/open-source-actions/apply-vipc@v1
+        uses: LabVIEW-Community-CI-CD/open-source-actions@v1
         with:
-          minimum_supported_lv_version: 2021
-          vip_lv_version: 2021
-          supported_bitness: 64
-          relative_path: ${{ github.workspace }}
+          action_name: apply-vipc
+          args_json: >
+            {
+              "minimum_supported_lv_version": 2021,
+              "vip_lv_version": 2021,
+              "supported_bitness": 64,
+              "relative_path": "${{ github.workspace }}"
+            }
 
       - name: Compute Version
         if: ${{ github.event.inputs.test_action == 'compute-version' }}
-        uses: LabVIEW-Community-CI-CD/open-source-actions/compute-version@v1
+        uses: LabVIEW-Community-CI-CD/open-source-actions@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          action_name: compute-version
+          args_json: >
+            {
+              "github_token": "${{ secrets.GITHUB_TOKEN }}"
+            }
 
       - name: Missing in Project Check
         if: ${{ github.event.inputs.test_action == 'missing-in-project' }}
@@ -62,71 +70,98 @@ jobs:
 
       - name: Run Unit Tests
         if: ${{ github.event.inputs.test_action == 'run-unit-tests' }}
-        uses: LabVIEW-Community-CI-CD/open-source-actions/run-unit-tests@v1
+        uses: LabVIEW-Community-CI-CD/open-source-actions@v1
         with:
-          minimum_supported_lv_version: 2021
-          supported_bitness: 64
+          action_name: run-unit-tests
+          args_json: >
+            {
+              "minimum_supported_lv_version": 2021,
+              "supported_bitness": 64
+            }
 
       - name: Build Packed Library (PPL)
         if: ${{ github.event.inputs.test_action == 'build-lvlibp' }}
-        uses: LabVIEW-Community-CI-CD/open-source-actions/build-lvlibp@v1
+        uses: LabVIEW-Community-CI-CD/open-source-actions@v1
         with:
-          minimum_supported_lv_version: 2021
-          supported_bitness: 64
-          relative_path: ${{ github.workspace }}
-          major: 1
-          minor: 0
-          patch: 0
-          build: 0
-          commit: ${{ github.sha }}
+          action_name: build-lvlibp
+          args_json: >
+            {
+              "minimum_supported_lv_version": 2021,
+              "supported_bitness": 64,
+              "relative_path": "${{ github.workspace }}",
+              "major": 1,
+              "minor": 0,
+              "patch": 0,
+              "build": 0,
+              "commit": "${{ github.sha }}"
+            }
 
       - name: Close LabVIEW
         if: ${{ github.event.inputs.test_action == 'close-labview' }}
-        uses: LabVIEW-Community-CI-CD/open-source-actions/close-labview@v1
+        uses: LabVIEW-Community-CI-CD/open-source-actions@v1
         with:
-          minimum_supported_lv_version: 2021
-          supported_bitness: 64
+          action_name: close-labview
+          args_json: >
+            {
+              "minimum_supported_lv_version": 2021,
+              "supported_bitness": 64
+            }
 
       - name: Rename File
         if: ${{ github.event.inputs.test_action == 'rename-file' }}
-        uses: LabVIEW-Community-CI-CD/open-source-actions/rename-file@v1
+        uses: LabVIEW-Community-CI-CD/open-source-actions@v1
         with:
-          current_filename: dummy.txt
-          new_filename: dummy-renamed.txt
+          action_name: rename-file
+          args_json: >
+            {
+              "current_filename": "dummy.txt",
+              "new_filename": "dummy-renamed.txt"
+            }
 
       - name: Generate Release Notes
         if: ${{ github.event.inputs.test_action == 'generate-release-notes' }}
-        uses: LabVIEW-Community-CI-CD/open-source-actions/generate-release-notes@v1
+        uses: LabVIEW-Community-CI-CD/open-source-actions@v1
+        with:
+          action_name: generate-release-notes
+          args_json: '{}'
         # (no inputs required; uses default output path)
 
       - name: Modify VIPB Display Info
         if: ${{ github.event.inputs.test_action == 'modify-vipb-display-info' }}
-        uses: LabVIEW-Community-CI-CD/open-source-actions/modify-vipb-display-info@v1
+        uses: LabVIEW-Community-CI-CD/open-source-actions@v1
         with:
-          supported_bitness: 64
-          relative_path: ${{ github.workspace }}
-          vipb_path: Tooling/deployment/NI Icon editor.vipb
-          minimum_supported_lv_version: 2023
-          # labview_minor_revision omitted (defaults to 3 for LV2023 SP1)
-          major: 1
-          minor: 0
-          patch: 0
-          build: 0
-          commit: ${{ github.sha }}
-          release_notes_file: ${{ github.workspace }}/Tooling/deployment/release_notes.md
-          display_information_json: '{}'
+          action_name: modify-vipb-display-info
+          args_json: >
+            {
+              "supported_bitness": 64,
+              "relative_path": "${{ github.workspace }}",
+              "vipb_path": "Tooling/deployment/NI Icon editor.vipb",
+              "minimum_supported_lv_version": 2023,
+              "major": 1,
+              "minor": 0,
+              "patch": 0,
+              "build": 0,
+              "commit": "${{ github.sha }}",
+              "release_notes_file": "${{ github.workspace }}/Tooling/deployment/release_notes.md",
+              "display_information_json": "{}"
+            }
+        # labview_minor_revision omitted (defaults to 3 for LV2023 SP1)
 
       - name: Build VI Package
         if: ${{ github.event.inputs.test_action == 'build-vi-package' }}
-        uses: LabVIEW-Community-CI-CD/open-source-actions/build-vi-package@v1
+        uses: LabVIEW-Community-CI-CD/open-source-actions@v1
         with:
-          supported_bitness: 64
-          minimum_supported_lv_version: 2023
-          # labview_minor_revision omitted (defaults to 3)
-          major: 1
-          minor: 0
-          patch: 0
-          build: 0
-          commit: ${{ github.sha }}
-          release_notes_file: ${{ github.workspace }}/Tooling/deployment/release_notes.md
-          display_information_json: '{}'
+          action_name: build-vi-package
+          args_json: >
+            {
+              "supported_bitness": 64,
+              "minimum_supported_lv_version": 2023,
+              "major": 1,
+              "minor": 0,
+              "patch": 0,
+              "build": 0,
+              "commit": "${{ github.sha }}",
+              "release_notes_file": "${{ github.workspace }}/Tooling/deployment/release_notes.md",
+              "display_information_json": "{}"
+            }
+        # labview_minor_revision omitted (defaults to 3)


### PR DESCRIPTION
## Summary
- use generic open-source-actions entry point for missing-in-project

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d6e360b548329b4fd18c3cca6bb82