### PR TITLE
Gracefully handle unescaped Windows paths

### DIFF
--- a/actions/Invoke-OSAction.ps1
+++ b/actions/Invoke-OSAction.ps1
@@ -99,7 +99,7 @@ try {
       # attempt to escape all single backslashes and parse again. This allows
       # callers to provide paths like C:\repo without manually double-escaping
       # each separator.
-      $escapedJson = $ArgsJson -replace '\', '\\'
+        $escapedJson = $ArgsJson.Replace('\', '\\')
       try {
         $argsHash = ConvertFrom-Json -InputObject $escapedJson -AsHashtable -ErrorAction Stop
         Write-Warning 'ArgsJson contained unescaped backslashes. They were automatically escaped.'

--- a/actions/Invoke-OSAction.ps1
+++ b/actions/Invoke-OSAction.ps1
@@ -91,8 +91,23 @@ try {
   # Parse ArgsJson → case-insensitive hashtable
   $argsHash = @{}
   if ($ArgsJson -and $ArgsJson.Trim()) {
-    try { $argsHash = ConvertFrom-Json -InputObject $ArgsJson -AsHashtable -ErrorAction Stop }
-    catch { throw "ArgsJson is not valid JSON: $($_.Exception.Message)" }
+    try {
+      $argsHash = ConvertFrom-Json -InputObject $ArgsJson -AsHashtable -ErrorAction Stop
+    }
+    catch {
+      # If parsing fails (commonly due to unescaped Windows backslashes),
+      # attempt to escape all single backslashes and parse again. This allows
+      # callers to provide paths like C:\repo without manually double-escaping
+      # each separator.
+      $escapedJson = $ArgsJson -replace '\', '\\'
+      try {
+        $argsHash = ConvertFrom-Json -InputObject $escapedJson -AsHashtable -ErrorAction Stop
+        Write-Warning 'ArgsJson contained unescaped backslashes. They were automatically escaped.'
+      }
+      catch {
+        throw "ArgsJson is not valid JSON: $($_.Exception.Message)"
+      }
+    }
   }
   if ($DryRun)   { $argsHash['DryRun']   = $true }
   if ($LogLevel) { $argsHash['LogLevel'] = $LogLevel }

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -32,6 +32,14 @@ Describe 'Unified Dispatcher — discovery and validation' {
   }
 }
 
+Describe 'ArgsJson path handling' {
+  It 'handles Windows paths without manual escaping' {
+    $json = '{ "RelativePath": "C:\path\foo" }'
+    & $global:dispatcher -ActionName set-development-mode -ArgsJson $json -DryRun *> $null
+    $LASTEXITCODE | Should -Be 0
+  }
+}
+
 Describe 'Unified Dispatcher — DryRun behavior for all actions' {
   $script:argsJson = (
     @{ MinimumSupportedLVVersion = '2021'


### PR DESCRIPTION
## Summary
- escape unescaped backslashes in ArgsJson before parsing to avoid JSON errors
- cover ArgsJson Windows path handling with a new Pester test

## Testing
- `npm test`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -CI -Path ./tests/pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d77febc748329aa6b2b19ac214e0e