### PR TITLE
Use literal Replace for ArgsJson backslashes

### DIFF
--- a/actions/Invoke-OSAction.ps1
+++ b/actions/Invoke-OSAction.ps1
@@ -99,7 +99,7 @@ try {
       # attempt to escape all single backslashes and parse again. This allows
       # callers to provide paths like C:\repo without manually double-escaping
       # each separator.
-      $escapedJson = $ArgsJson -replace '\', '\\'
+        $escapedJson = $ArgsJson.Replace('\', '\\')
       try {
         $argsHash = ConvertFrom-Json -InputObject $escapedJson -AsHashtable -ErrorAction Stop
         Write-Warning 'ArgsJson contained unescaped backslashes. They were automatically escaped.'


### PR DESCRIPTION
## Summary
- avoid regex replacement when escaping backslashes in `ArgsJson`

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_689d7b9906d0832980e6fd0f9b6dedde