### PR TITLE
feat: add snake_case aliases for close-labview parameters

### DIFF
--- a/actions/Invoke-OSAction.ps1
+++ b/actions/Invoke-OSAction.ps1
@@ -61,7 +61,12 @@ function Show-Description([string]$Name) {
 }
 
 function Filter-Args([hashtable]$InputArgs, [string]$FuncName, [string]$ActionNameForWarn, [switch]$ReturnUnknownParams) {
-  $paramNames = (Get-Command $FuncName -ErrorAction Stop).Parameters.Keys
+  $cmd = Get-Command $FuncName -ErrorAction Stop
+  $paramNames = @()
+  foreach ($p in $cmd.Parameters.Values) {
+    $paramNames += $p.Name
+    if ($p.Aliases) { $paramNames += $p.Aliases }
+  }
   $unknown = @()
   $filtered = @{}
   foreach ($k in @($InputArgs.Keys)) {

--- a/actions/OpenSourceActions.psm1
+++ b/actions/OpenSourceActions.psm1
@@ -194,8 +194,8 @@ function InvokeBuildLvlibp {
 function InvokeCloseLabVIEW {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)] [string] $MinimumSupportedLVVersion,
-        [Parameter(Mandatory)] [string] $SupportedBitness,
+        [Parameter(Mandatory)][Alias('minimum_supported_lv_version')] [string] $MinimumSupportedLVVersion,
+        [Parameter(Mandatory)][Alias('supported_bitness')]          [string] $SupportedBitness,
         [Parameter()] [string] $LogLevel = 'INFO',
         [Parameter()] [switch] $DryRun,
         [Parameter()] [string] $gcliPath

--- a/docs/actions/close-labview.md
+++ b/docs/actions/close-labview.md
@@ -10,8 +10,8 @@ Common parameters are described in [Common parameters](../common-parameters.md).
 
 ### Required
 
-- **MinimumSupportedLVVersion** (`string`): LabVIEW version to close.
-- **SupportedBitness** (`string`): "32" or "64" bitness of LabVIEW.
+- **MinimumSupportedLVVersion** (`string`, alias `minimum_supported_lv_version`): LabVIEW version to close.
+- **SupportedBitness** (`string`, alias `supported_bitness`): "32" or "64" bitness of LabVIEW.
 
 ### Optional
 
@@ -21,8 +21,8 @@ None.
 
 ```powershell
 pwsh -File actions/Invoke-OSAction.ps1 -ActionName close-labview -ArgsJson '{
-  "MinimumSupportedLVVersion": "2021",
-  "SupportedBitness": "64"
+  "minimum_supported_lv_version": "2021",
+  "supported_bitness": "64"
 }'
 ```
 

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -99,3 +99,17 @@ Describe 'Filter-Args helper' {
     $result.PSObject.Properties.Name | Should -Contain 'UnknownParams'
   }
 }
+
+Describe 'close-labview parameter aliases' {
+  It 'accepts camelCase args' {
+    $json = '{ "MinimumSupportedLVVersion": "2021", "SupportedBitness": "64" }'
+    & $global:dispatcher -ActionName close-labview -ArgsJson $json -DryRun *> $null
+    $LASTEXITCODE | Should -Be 0
+  }
+
+  It 'accepts snake_case args' {
+    $json = '{ "minimum_supported_lv_version": "2021", "supported_bitness": "64" }'
+    & $global:dispatcher -ActionName close-labview -ArgsJson $json -DryRun *> $null
+    $LASTEXITCODE | Should -Be 0
+  }
+}


### PR DESCRIPTION
## Summary
- allow close-labview action parameters to be passed in snake_case
- detect parameter aliases in dispatcher
- document and test camelCase and snake_case usage

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -CI -Path ./tests/pester"` *(fails: pwsh: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d84f1a9548329affa9d10c5d2f0ee