### PR TITLE
Map alias parameters to canonical names

### DIFF
--- a/actions/Invoke-OSAction.ps1
+++ b/actions/Invoke-OSAction.ps1
@@ -62,15 +62,26 @@ function Show-Description([string]$Name) {
 
 function Filter-Args([hashtable]$InputArgs, [string]$FuncName, [string]$ActionNameForWarn, [switch]$ReturnUnknownParams) {
   $cmd = Get-Command $FuncName -ErrorAction Stop
-  $paramNames = @()
+
+  # Map each alias to its canonical parameter name for the target function
+  $aliasMap = @{}
   foreach ($p in $cmd.Parameters.Values) {
-    $paramNames += $p.Name
-    if ($p.Aliases) { $paramNames += $p.Aliases }
+    foreach ($a in $p.Aliases) { $aliasMap[$a] = $p.Name }
   }
+
   $unknown = @()
   $filtered = @{}
   foreach ($k in @($InputArgs.Keys)) {
-    if ($paramNames -contains $k) { $filtered[$k] = $InputArgs[$k] } else { $unknown += $k }
+    if ($cmd.Parameters.ContainsKey($k)) {
+      $filtered[$k] = $InputArgs[$k]
+    }
+    elseif ($aliasMap.ContainsKey($k)) {
+      $canonical = $aliasMap[$k]
+      if (-not $filtered.ContainsKey($canonical)) { $filtered[$canonical] = $InputArgs[$k] }
+    }
+    else {
+      $unknown += $k
+    }
   }
   $msg = $null
   if ($unknown.Count) {

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -100,16 +100,18 @@ Describe 'Filter-Args helper' {
   }
 }
 
-Describe 'close-labview parameter aliases' {
-  It 'accepts camelCase args' {
-    $json = '{ "MinimumSupportedLVVersion": "2021", "SupportedBitness": "64" }'
-    & $global:dispatcher -ActionName close-labview -ArgsJson $json -DryRun *> $null
-    $LASTEXITCODE | Should -Be 0
-  }
+  Describe 'close-labview parameter aliases' {
+    It 'accepts camelCase args' {
+      $json = '{ "MinimumSupportedLVVersion": "2021", "SupportedBitness": "64" }'
+      & $global:dispatcher -ActionName close-labview -ArgsJson $json -DryRun *> $null
+      $LASTEXITCODE | Should -Be 0
+    }
 
-  It 'accepts snake_case args' {
-    $json = '{ "minimum_supported_lv_version": "2021", "supported_bitness": "64" }'
-    & $global:dispatcher -ActionName close-labview -ArgsJson $json -DryRun *> $null
-    $LASTEXITCODE | Should -Be 0
+    It 'accepts snake_case args without warnings' {
+      $json = '{ "minimum_supported_lv_version": "2021", "supported_bitness": "64" }'
+      $out = & $global:dispatcher -ActionName close-labview -ArgsJson $json -DryRun *>&1 | Out-String
+      $LASTEXITCODE | Should -Be 0
+      $out | Should -Not -Match 'Ignored unknown parameters'
+      $out | Should -Not -Match 'Missing an argument'
+    }
   }
-}


### PR DESCRIPTION
## Summary
- Map parameter aliases to their canonical names when filtering dispatcher args
- Test that Close-LabVIEW accepts snake_case parameters without warnings

## Testing
- `npm test`
- `pwsh -NoProfile -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_689d89206ecc832982613c8bd6cefb9a