### PR TITLE
feat: add describe input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,11 @@ inputs:
     required: false
     default: false
     type: boolean
+  describe:
+    description: 'If true, print a description of the action before executing.'
+    required: false
+    default: false
+    type: boolean
 runs:
   using: 'composite'
   steps:
@@ -53,6 +58,14 @@ runs:
 
         # Locate the dispatcher script relative to this repository root.
         $script = Join-Path $env:GITHUB_ACTION_PATH 'actions' 'Invoke-OSAction.ps1'
+
+        if ('${{ inputs.describe }}' -eq 'true') {
+          try {
+            & $script -Describe '${{ inputs.action_name }}'
+          } catch {
+            Write-Host 'Describe command failed but continuing.'
+          }
+        }
 
         & $script @params
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }


### PR DESCRIPTION
## Summary
- add optional `describe` boolean input
- show action description via `Invoke-OSAction.ps1 -Describe` when enabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e1ddf7f248329b4fb4cc545243dc3