### PR TITLE
Summarize action parameter descriptions

### DIFF
--- a/actions/Invoke-OSAction.ps1
+++ b/actions/Invoke-OSAction.ps1
@@ -54,9 +54,19 @@ function Show-Description([string]$Name) {
   if (-not $Registry.Contains($key)) { throw "Unknown action '$Name'" }
   $funcName = $Registry[$key]
   $cmd = Get-Command $funcName -ErrorAction Stop
-  Write-Host "$key parameters:"
+
+  $consoleLines = @("$key parameters:")
+  $summaryLines = @("### $key parameters")
   foreach ($p in $cmd.Parameters.Values) {
-    Write-Host " - $($p.Name): $($p.ParameterType.Name)"
+    $consoleLines += " - $($p.Name): $($p.ParameterType.Name)"
+    $summaryLines += "- ``$($p.Name)``: ``$($p.ParameterType.Name)``"
+  }
+
+  $consoleLines | ForEach-Object { Write-Host $_ }
+
+  if ($env:GITHUB_STEP_SUMMARY) {
+    $summary = ($summaryLines -join [Environment]::NewLine) + [Environment]::NewLine
+    Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $summary
   }
 }
 

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -79,6 +79,14 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions' {
     $LASTEXITCODE | Should -Be 0
   }
 
+  It "prints description before dry-run <Action>" -ForEach $actions {
+    param($Action, $ArgsJson)
+    $describeOut = & $global:dispatcher -Describe $Action 6>&1 | Out-String
+    & $global:dispatcher -ActionName $Action -ArgsJson $ArgsJson -DryRun *> $null
+    $LASTEXITCODE | Should -Be 0
+    $describeOut | Should -Match "$Action parameters:"
+  }
+
   It "dry-runs <Action> and warns on unknown args" -ForEach $actions {
     param($Action, $ArgsJson)
     $out = & $global:dispatcher -ActionName $Action -ArgsJson $ArgsJson -DryRun *>&1 | Out-String


### PR DESCRIPTION
## Summary
- collect Show-Description output lines
- append formatted parameter list to `GITHUB_STEP_SUMMARY`

## Testing
- `npm test`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester tests/pester"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689e1fc6876c8329920e976435416b8f