### PR TITLE
test: verify dispatcher outputs description before dry-run

### DIFF
--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -79,6 +79,14 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions' {
     $LASTEXITCODE | Should -Be 0
   }
 
+  It "prints description before dry-run <Action>" -ForEach $actions {
+    param($Action, $ArgsJson)
+    $describeOut = & $global:dispatcher -Describe $Action 6>&1 | Out-String
+    & $global:dispatcher -ActionName $Action -ArgsJson $ArgsJson -DryRun *> $null
+    $LASTEXITCODE | Should -Be 0
+    $describeOut | Should -Match "$Action parameters:"
+  }
+
   It "dry-runs <Action> and warns on unknown args" -ForEach $actions {
     param($Action, $ArgsJson)
     $out = & $global:dispatcher -ActionName $Action -ArgsJson $ArgsJson -DryRun *>&1 | Out-String


### PR DESCRIPTION
## Summary
- test dispatcher description printed before executing dry-run for all actions

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_689e2231d9f4832988f63b00c1a12e19