### PR TITLE
Add visibility for script path checks

### DIFF
--- a/tests/pester/ScriptPath.Tests.ps1
+++ b/tests/pester/ScriptPath.Tests.ps1
@@ -25,6 +25,7 @@ $cases = foreach ($name in $actionNames) {
 Describe 'Action script paths' {
     It 'has script for <Name>' -TestCases $cases {
         param($Name, $Path)
+        Write-Host "Checking $Path"
         Test-Path $Path | Should -BeTrue
     }
 }


### PR DESCRIPTION
## Summary
- log each script path being validated in ScriptPath.Tests

## Testing
- `pwsh -NoLogo -NoProfile -File scripts/run-pester-tests/RunPesterTests.ps1` *(fails: The property 'Describe' cannot be found on this object)*

------
https://chatgpt.com/codex/tasks/task_e_689e2ff068b08329b21122bc222e4135