### PR TITLE
Split Pester tests into separate jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,23 @@ jobs:
           node-version: '20'
       - run: npm test
 
-  pester-tests:
+  dispatcher-tests:
+    name: dispatcher-tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run Pester tests
+      - name: Run dispatcher tests
         shell: pwsh
-        run: Invoke-Pester -CI -Path ./tests/pester
+        run: Invoke-Pester -CI -Path tests/pester/Dispatcher.Tests.ps1
+
+  scriptpath-tests:
+    name: scriptpath-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run scriptpath tests
+        shell: pwsh
+        run: Invoke-Pester -CI -Path tests/pester/ScriptPath.Tests.ps1
 
   deploy-docs:
     if: github.ref == 'refs/heads/actions'


### PR DESCRIPTION
## Summary
- run dispatcher Pester tests in dedicated CI job
- run script path Pester tests in separate job

## Testing
- `npm test`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path tests/pester/Dispatcher.Tests.ps1"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_689e3cc26f308329bc54972e64565995