### PR TITLE
chore(ci): run pester tests on linux and windows

### DIFF
--- a/.github/branch_protection_rules.yml
+++ b/.github/branch_protection_rules.yml
@@ -1,0 +1,10 @@
+actions:
+  required_status_checks:
+    - docs-lint
+    - node-tests
+    - dispatcher-tests (ubuntu-latest)
+    - dispatcher-tests (windows-latest)
+    - dispatcher-dryrun-tests (ubuntu-latest)
+    - dispatcher-dryrun-tests (windows-latest)
+    - scriptpath-tests (ubuntu-latest)
+    - scriptpath-tests (windows-latest)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,31 +37,46 @@ jobs:
 
   dispatcher-tests:
     name: dispatcher-tests
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Run dispatcher tests
         shell: pwsh
-        run: Invoke-Pester -CI -Path tests/pester/Dispatcher.Tests.ps1
+        run: |
+          $testPath = Join-Path -Path 'tests/pester' -ChildPath 'Dispatcher.Tests.ps1'
+          Invoke-Pester -CI -Path $testPath
 
   dispatcher-dryrun-tests:
     name: dispatcher-dryrun-tests
     needs: dispatcher-tests
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Run dispatcher dry-run tests
         shell: pwsh
-        run: Invoke-Pester -CI -Path tests/pester/Dispatcher.DryRun.Tests.ps1
+        run: |
+          $testPath = Join-Path -Path 'tests/pester' -ChildPath 'Dispatcher.DryRun.Tests.ps1'
+          Invoke-Pester -CI -Path $testPath
 
   scriptpath-tests:
     name: scriptpath-tests
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Run scriptpath tests
         shell: pwsh
-        run: Invoke-Pester -CI -Path tests/pester/ScriptPath.Tests.ps1
+        run: |
+          $testPath = Join-Path -Path 'tests/pester' -ChildPath 'ScriptPath.Tests.ps1'
+          Invoke-Pester -CI -Path $testPath
 
   deploy-docs:
     if: github.ref == 'refs/heads/actions'


### PR DESCRIPTION
## Summary
- run dispatcher, dry-run, and scriptpath Pester suites on Ubuntu and Windows using a matrix
- list each job variant in branch protection rules

## Testing
- `npm test`
- `pwsh -NoLogo -Command "Write-Host hi"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689e40abbbc483299a53d52f1c0c98ac