### PR TITLE
Use ArgsJson helper in dispatcher tests

### DIFF
--- a/tests/pester/Dispatcher.DryRun.Tests.ps1
+++ b/tests/pester/Dispatcher.DryRun.Tests.ps1
@@ -7,13 +7,12 @@ $ErrorActionPreference = 'Stop'
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
 $global:dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
+Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
 
 Describe 'Unified Dispatcher — DryRun behavior for all actions' {
-  $script:argsJson = (
-    @{ MinimumSupportedLVVersion = '2021'
+  $script:args = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
+  $extra = @{
        VIP_LVVersion             = '2021'
-       SupportedBitness          = '64'
-       RelativePath              = '.'
        VIPCPath                  = 'dummy.vipc'
        LabVIEW_Project           = 'My.lvproj'
        Build_Spec                = 'MyBuild'
@@ -35,8 +34,9 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions' {
        NewFilename               = 'new.txt'
        ReleaseNotesFile          = 'notes.md'
        ExtraParam                = 'extra'
-    } | ConvertTo-Json -Compress )
-
+    }
+  foreach ($kvp in $extra.GetEnumerator()) { $script:args | Add-Member -NotePropertyName $kvp.Key -NotePropertyValue $kvp.Value }
+  $script:argsJson = $script:args | ConvertTo-Json -Compress
   $actions = pwsh -NoProfile -File $global:dispatcher -ListActions |
     Where-Object { $_ -match '^\s+- ' } |
     ForEach-Object { @{ Action = $_.Trim().Substring(2); ArgsJson = $script:argsJson } }
@@ -44,14 +44,14 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions' {
   It "describes <Action>" -ForEach $actions {
     param($Action, $ArgsJson)
     Write-Host "Testing $Action with ArgsJson $ArgsJson"
-    pwsh -NoProfile -File $global:dispatcher -Describe $Action *> $null
+    pwsh -NoProfile -File $global:dispatcher -Describe $Action -ArgsJson $ArgsJson *> $null
     $LASTEXITCODE | Should -Be 0
   }
 
   It "prints description before dry-run <Action>" -ForEach $actions {
     param($Action, $ArgsJson)
     Write-Host "Testing $Action with ArgsJson $ArgsJson"
-    $describeOut = & $global:dispatcher -Describe $Action 6>&1 | Out-String
+    $describeOut = & $global:dispatcher -Describe $Action -ArgsJson $ArgsJson 6>&1 | Out-String
     & $global:dispatcher -ActionName $Action -ArgsJson $ArgsJson -DryRun *> $null
     $LASTEXITCODE | Should -Be 0
     $describeOut | Should -Match "$Action parameters:"

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -7,18 +7,21 @@ $ErrorActionPreference = 'Stop'
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
 $global:dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
+Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
+
 
 Describe 'Unified Dispatcher — discovery and validation' {
   It 'lists available actions' {
-    $out = pwsh -NoProfile -File $global:dispatcher -ListActions | Out-String
+    $json = Get-LabVIEWIconEditorArgsJson
+    $out = pwsh -NoProfile -File $global:dispatcher -ListActions -ArgsJson $json | Out-String
     $out | Should -Match 'apply-vipc'
     $out | Should -Match 'build-lvlibp'
     $out | Should -Match 'missing-in-project'
     $out | Should -Match 'run-unit-tests'
   }
-
   It 'describes a known action (build-lvlibp)' {
-    $out = pwsh -NoProfile -File $global:dispatcher -Describe build-lvlibp | Out-String
+    $json = Get-LabVIEWIconEditorArgsJson
+    $out = pwsh -NoProfile -File $global:dispatcher -Describe build-lvlibp -ArgsJson $json | Out-String
     $out | Should -Match 'Major'
     $out | Should -Match 'Minor'
     $out | Should -Match 'Patch'
@@ -27,15 +30,13 @@ Describe 'Unified Dispatcher — discovery and validation' {
   }
 
   It 'fails gracefully on unknown action' {
-    pwsh -NoProfile -File $global:dispatcher -ActionName no-such-action -ArgsJson '{}' *>$null
+    $json = Get-LabVIEWIconEditorArgsJson
+    pwsh -NoProfile -File $global:dispatcher -ActionName no-such-action -ArgsJson $json *>$null
     $LASTEXITCODE | Should -Be 1
   }
 }
 
 Describe 'ArgsJson path handling' {
-  BeforeAll {
-    Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
-  }
   It 'handles Windows paths without manual escaping' {
     $json = Get-LabVIEWIconEditorArgsJson
     & $global:dispatcher -ActionName set-development-mode -ArgsJson $json -DryRun *> $null
@@ -59,13 +60,21 @@ Describe 'Filter-Args helper' {
 
   Describe 'close-labview parameter aliases' {
     It 'accepts camelCase args' {
-      $json = '{ "MinimumSupportedLVVersion": "2021", "SupportedBitness": "64" }'
+      $base = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
+      $json = @{
+        MinimumSupportedLVVersion = $base.MinimumSupportedLVVersion
+        SupportedBitness = $base.SupportedBitness
+      } | ConvertTo-Json -Compress
       & $global:dispatcher -ActionName close-labview -ArgsJson $json -DryRun *> $null
       $LASTEXITCODE | Should -Be 0
     }
 
     It 'accepts snake_case args without warnings' {
-      $json = '{ "minimum_supported_lv_version": "2021", "supported_bitness": "64" }'
+      $base = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
+      $json = @{
+        minimum_supported_lv_version = $base.MinimumSupportedLVVersion
+        supported_bitness = $base.SupportedBitness
+      } | ConvertTo-Json -Compress
       $out = & $global:dispatcher -ActionName close-labview -ArgsJson $json -DryRun *>&1 | Out-String
       $LASTEXITCODE | Should -Be 0
       $out | Should -Not -Match 'Ignored unknown parameters'


### PR DESCRIPTION
## Summary
- import ArgsJson helper in dispatcher tests
- build dispatcher args from Get-LabVIEWIconEditorArgsJson
- feed dispatcher calls with generated ArgsJson

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -CI -Path ./tests/pester"`

------
https://chatgpt.com/codex/tasks/task_e_689e49c253148329a80939f0024929ce