### PR TITLE
test: add dispatcher path validation tests

### DIFF
--- a/tests/pester/Dispatcher.InvalidPaths.Tests.ps1
+++ b/tests/pester/Dispatcher.InvalidPaths.Tests.ps1
@@ -1,0 +1,25 @@
+#requires -Version 7.0
+# Pester v5+ tests verifying dispatcher handling of invalid RelativePath
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot   = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+$global:dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
+Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
+
+Describe 'Invalid RelativePath handling' {
+    It 'fails when RelativePath does not exist' {
+        $json = @{ RelativePath = 'NoSuchDir' } | ConvertTo-Json -Compress
+        $out = pwsh -NonInteractive -NoProfile -File $global:dispatcher -ActionName set-development-mode -ArgsJson $json *>&1 | Out-String
+        $LASTEXITCODE | Should -Not -Be 0
+        $out | Should -Match 'An unexpected error occurred during script execution'
+    }
+
+    It 'fails when RelativePath is missing' {
+        $out = pwsh -NonInteractive -NoProfile -File $global:dispatcher -ActionName set-development-mode -ArgsJson '{}' *>&1 | Out-String
+        $LASTEXITCODE | Should -Not -Be 0
+        $out | Should -Match 'missing mandatory'
+        $out | Should -Match 'RelativePath'
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for dispatcher invalid RelativePath cases

## Testing
- `Invoke-Pester -CI -Path './tests/pester/Dispatcher.InvalidPaths.Tests.ps1'`
- `Invoke-Pester -CI -Path './tests/pester'`


------
https://chatgpt.com/codex/tasks/task_e_689e61d2e5d08329848cb0cba4e165e9