### PR TITLE
docs: add Pester testing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,15 +81,23 @@ Get details about a specific action:
 pwsh actions/Invoke-OSAction.ps1 -Describe run-unit-tests
 ```
 
-## Contributing
-
-Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for general guidelines and [docs/contributing-docs.md](docs/contributing-docs.md) for documentation rules.
+## Testing
 
 Run the JavaScript tests with:
 
 ```bash
 npm test
 ```
+
+Pester tests cover the dispatcher and helper modules. See [docs/testing-pester.md](docs/testing-pester.md) for guidelines on using the canonical argument helper and adding new tests. Run them with:
+
+```powershell
+Invoke-Pester -CI -Path ./tests/pester
+```
+
+## Contributing
+
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for general guidelines and [docs/contributing-docs.md](docs/contributing-docs.md) for documentation rules.
 
 To preview docs locally:
 

--- a/docs/testing-pester.md
+++ b/docs/testing-pester.md
@@ -1,0 +1,40 @@
+# Pester Testing
+
+## Canonical argument helper
+
+Pester tests share a small helper module, `tests/pester/Helper/ArgsJson.psm1`, which exposes `Get-LabVIEWIconEditorArgsJson`. The function returns a canonical set of dispatcher arguments so every test starts from the same baseline. Using the helper avoids repeating boilerplate and keeps tests resilient to environment differences.
+
+## labview-icon-editor reference project
+
+The helper points at the **labview-icon-editor** project. This open-source repository is tiny, exercises common LabVIEW project layouts and does not require NI components to execute in dry-run mode. Using it as the reference project gives all tests a consistent, real-world example without adding heavy dependencies.
+
+## Adding new tests
+
+1. Create a `*.Tests.ps1` file under `tests/pester` or one of its subfolders.
+2. Import the helper module:
+   ```powershell
+   Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
+   ```
+3. Use `Get-LabVIEWIconEditorArgsJson` to obtain the canonical JSON for dispatcher calls.
+4. Include both positive and negative path tests where practical.
+5. Run the suite with `Invoke-Pester -CI -Path ./tests/pester` before submitting a pull request.
+
+### Positive path example
+
+```powershell
+It 'describes a known action' {
+  $json = Get-LabVIEWIconEditorArgsJson
+  $out = pwsh -NoProfile -File $global:dispatcher -Describe build-lvlibp -ArgsJson $json | Out-String
+  $out | Should -Match 'Major'
+}
+```
+
+### Negative path example
+
+```powershell
+It 'fails on unknown action' {
+  $json = Get-LabVIEWIconEditorArgsJson
+  pwsh -NoProfile -File $global:dispatcher -ActionName no-such-action -ArgsJson $json *>$null
+  $LASTEXITCODE | Should -Be 1
+}
+```


### PR DESCRIPTION
## Summary
- document canonical args helper and reference project for PowerShell Pester tests
- link new Pester testing guide from README

## Testing
- `npm test`
- `pwsh scripts/lint-docs.ps1` *(fails: command not found)*
- `pwsh scripts/run-pester-tests` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689e6a4bb7448329b2f102b431983b6e