### PR TITLE
Add Node test CI script and workflow artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,15 +37,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - run: npm test
-      # Optional: if node tests can emit JUnit, include:
-      # - run: npm run test:ci
-      # - uses: actions/upload-artifact@v4
-      #   if: always()
-      #   with:
-      #     name: node-junit
-      #     path: test-results/**/*.xml
-      #     if-no-files-found: ignore
+      - run: npm run test:ci
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: node-junit
+          path: test-results/node-junit.xml
+          if-no-files-found: error
 
   dispatcher-tests:
     name: dispatcher-tests

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "test": "node --test scripts/**/*.test.js"
+    "test": "node --test scripts",
+    "test:ci": "mkdir -p test-results && node --test --test-reporter=junit --test-reporter-destination test-results/node-junit.xml"
   }
 }

--- a/scripts/generate-ci-summary.test.js
+++ b/scripts/generate-ci-summary.test.js
@@ -1,0 +1,6 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('sample addition', () => {
+  assert.equal(1 + 1, 2);
+});


### PR DESCRIPTION
## Summary
- add a `test:ci` script that emits JUnit XML
- include a minimal Node test under `scripts`
- run `npm run test:ci` in CI and upload the results

## Testing
- `npm test`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689ea1c320a88329a4f843a80684f4de