### PR TITLE
feat: support CI requirement mappings

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "test": "node --test scripts",
-    "test:ci": "mkdir -p test-results && node --test --test-reporter=junit --test-reporter-destination test-results/node-junit.xml"
+    "test": "node --loader ts-node/esm --test scripts",
+    "test:ci": "mkdir -p test-results && node --loader ts-node/esm --test --test-reporter=junit --test-reporter-destination test-results/node-junit.xml"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.4.0"
   }
 }

--- a/requirements.json
+++ b/requirements.json
@@ -1,0 +1,6 @@
+{
+  "REQ-001": "Dispatcher.Tests",
+  "REQ-002": "Dispatcher.DryRun.Tests",
+  "REQ-003": "RelativePath.Actions.Tests",
+  "REQ-004": "ScriptPath.Tests"
+}

--- a/scripts/generate-ci-summary.test.js
+++ b/scripts/generate-ci-summary.test.js
@@ -1,6 +1,16 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import { loadRequirementMapping, findRequirementId } from './generate-ci-summary.ts';
 
-test('sample addition', () => {
-  assert.equal(1 + 1, 2);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const mappingPath = path.resolve(__dirname, '../requirements.json');
+
+test('loadRequirementMapping reads file and findRequirementId works', async () => {
+  const mapping = await loadRequirementMapping(mappingPath);
+  assert.equal(findRequirementId('Dispatcher.Tests', mapping), 'REQ-001');
+  assert.equal(findRequirementId('Unknown.Tests', mapping), undefined);
 });

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -1,1 +1,53 @@
 #!/usr/bin/env ts-node
+import { promises as fs } from 'fs';
+import path from 'path';
+
+/**
+ * Load requirement mappings from a JSON file. Returns empty object when file
+ * cannot be parsed or does not exist.
+ */
+export async function loadRequirementMapping(mappingPath: string): Promise<Record<string, string>> {
+  try {
+    const contents = await fs.readFile(mappingPath, 'utf8');
+    return JSON.parse(contents) as Record<string, string>;
+  } catch (err: any) {
+    console.warn(`Unable to read requirement mapping file at ${mappingPath}: ${err.message}`);
+    return {};
+  }
+}
+
+/**
+ * Find the requirement identifier for a given test name. Returns undefined if
+ * the test name is not present in the mapping.
+ */
+export function findRequirementId(testName: string, mapping: Record<string, string>): string | undefined {
+  for (const [id, name] of Object.entries(mapping)) {
+    if (name === testName) {
+      return id;
+    }
+  }
+  return undefined;
+}
+
+async function main() {
+  const mappingFile = process.env.REQ_MAPPING_FILE ?? 'requirements.json';
+  const mapping = await loadRequirementMapping(path.resolve(mappingFile));
+
+  const testName = process.argv[2];
+  if (!testName) {
+    console.log('No test name provided');
+    return;
+  }
+
+  const req = findRequirementId(testName, mapping);
+  if (req) {
+    console.log(`${testName} maps to requirement ${req}`);
+  } else {
+    console.log(`No requirement mapping found for ${testName}`);
+  }
+}
+
+// Only run main when executed directly (not when imported for tests)
+if (process.argv[1] && process.argv[1].endsWith('generate-ci-summary.ts')) {
+  main();
+}


### PR DESCRIPTION
## Summary
- add requirements.json to map requirement IDs to tests
- teach generate-ci-summary.ts to read mapping and handle missing entries
- update node tests to cover requirement mapping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ea36e10cc8329a9e2fcb1db8f0e4a