### PR TITLE
feat: summarize junit test results

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,12 @@
     "test": "node --loader ts-node/esm --test scripts",
     "test:ci": "mkdir -p test-results && node --loader ts-node/esm --test --test-reporter=junit --test-reporter-destination test-results/node-junit.xml"
   },
+  "dependencies": {
+    "glob": "^10.3.10",
+    "xml2js": "^0.6.2"
+  },
   "devDependencies": {
+    "@types/xml2js": "^0.4.14",
     "ts-node": "^10.9.1",
     "typescript": "^5.4.0"
   }

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env ts-node
 import { promises as fs } from 'fs';
 import path from 'path';
+import { glob } from 'glob';
+import { parseStringPromise } from 'xml2js';
 
 /**
  * Load requirement mappings from a JSON file. Returns empty object when file
@@ -29,21 +31,98 @@ export function findRequirementId(testName: string, mapping: Record<string, stri
   return undefined;
 }
 
-async function main() {
-  const mappingFile = process.env.REQ_MAPPING_FILE ?? 'requirements.json';
-  const mapping = await loadRequirementMapping(path.resolve(mappingFile));
+interface SuiteResult {
+  name: string;
+  tests: number;
+  failures: number;
+  passed: number;
+}
 
-  const testName = process.argv[2];
-  if (!testName) {
-    console.log('No test name provided');
+async function parseJUnitFile(file: string): Promise<SuiteResult[]> {
+  const xml = await fs.readFile(file, 'utf8');
+  const data = await parseStringPromise(xml);
+  const suites: any[] = [];
+  if (data.testsuite) {
+    suites.push(data.testsuite);
+  } else if (data.testsuites && Array.isArray(data.testsuites.testsuite)) {
+    suites.push(...data.testsuites.testsuite);
+  } else if (data.testsuites && data.testsuites.testsuite) {
+    suites.push(data.testsuites.testsuite);
+  } else if (data.testsuites && data.testsuites.testcase) {
+    const cases = Array.isArray(data.testsuites.testcase)
+      ? data.testsuites.testcase
+      : [data.testsuites.testcase];
+    const failures = cases.filter((c: any) => c.failure || c.error).length;
+    suites.push({
+      $: {
+        name: path.basename(file),
+        tests: String(cases.length),
+        failures: String(failures),
+      },
+    });
+  }
+  return suites.map((suite) => {
+    const attrs = suite.$ || {};
+    const tests = parseInt(attrs.tests ?? '0', 10);
+    const failures = parseInt(attrs.failures ?? '0', 10) + parseInt(attrs.errors ?? '0', 10);
+    const skipped = parseInt(attrs.skipped ?? attrs.disabled ?? '0', 10);
+    const passed = tests - failures - skipped;
+    return { name: attrs.name ?? path.basename(file), tests, failures, passed } as SuiteResult;
+  });
+}
+
+async function appendSummary(results: SuiteResult[]): Promise<void> {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+  let md = '| Test Suite | Passed | Failed |\n| --- | --- | --- |\n';
+  for (const r of results) {
+    md += `| ${r.name} | ${r.passed} | ${r.failures} |\n`;
+  }
+  await fs.appendFile(summaryPath, md);
+}
+
+async function writeTraceability(results: SuiteResult[], mapping: Record<string, string>): Promise<void> {
+  const trace: Record<string, unknown> = {};
+  for (const r of results) {
+    const req = findRequirementId(r.name, mapping);
+    if (req) {
+      trace[req] = { test: r.name, passed: r.failures === 0, failed: r.failures, passedTests: r.passed, total: r.tests };
+    }
+  }
+  await fs.mkdir('artifacts', { recursive: true });
+  await fs.writeFile(path.join('artifacts', 'traceability.json'), JSON.stringify(trace, null, 2));
+}
+
+async function main() {
+  const patternsEnv = process.env.TEST_RESULTS_GLOBS;
+  if (!patternsEnv) {
+    console.warn('TEST_RESULTS_GLOBS not set');
     return;
   }
 
-  const req = findRequirementId(testName, mapping);
-  if (req) {
-    console.log(`${testName} maps to requirement ${req}`);
-  } else {
-    console.log(`No requirement mapping found for ${testName}`);
+  const patterns = patternsEnv.split(/\r?\n|[ ,]+/).filter(Boolean);
+  const files = new Set<string>();
+  for (const pattern of patterns) {
+    const matches = await glob(pattern);
+    for (const m of matches) {
+      files.add(m);
+    }
+  }
+
+  const results: SuiteResult[] = [];
+  for (const file of files) {
+    const suites = await parseJUnitFile(file);
+    results.push(...suites);
+  }
+
+  await appendSummary(results);
+
+  const mappingFile = process.env.REQ_MAPPING_FILE ?? 'requirements.json';
+  const mapping = await loadRequirementMapping(path.resolve(mappingFile));
+  await writeTraceability(results, mapping);
+
+  if (results.some((r) => r.failures > 0)) {
+    process.exitCode = 1;
   }
 }
 


### PR DESCRIPTION
## Summary
- collect and parse JUnit XML files to derive pass/fail counts
- record test results in step summary and traceability artifact
- support flat JUnit reports in addition to testsuites

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ea53d66f08329a2d18443cc8fbc8b