### PR TITLE
Add tests for JUnit parsing and template rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Run the JavaScript tests with:
 npm test
 ```
 
+For CI, `npm run test:ci` emits a JUnit XML report that `scripts/generate-ci-summary.ts` parses to build the step summary and requirement traceability files. The script also renders action documentation from the templates in `doc-templates/` and packages the generated Markdown into the build artifacts.
+
 Pester tests cover the dispatcher and helper modules. See [docs/testing-pester.md](docs/testing-pester.md) for guidelines on using the canonical argument helper and adding new tests. Run them with:
 
 ```powershell

--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -4,7 +4,7 @@ To keep documentation consistent and easy to review, please follow these rules w
 
 ## Action documentation
 
-When adding a new action, copy `doc-templates/action-doc-template.md` to `docs/actions/<action-name>.md` and complete each section: Purpose, Parameters, CLI example, GitHub Action example, and Return Codes.
+Documentation for PowerShell actions is generated automatically. During CI the script `scripts/generate-ci-summary.ts` reads the help metadata from each action and fills in `doc-templates/action-doc-template.md`. The rendered Markdown files are zipped into `artifacts/action-docs.zip`. Run `node scripts/generate-ci-summary.ts` locally to preview the generated docs.
 
 ## Markdown linting
 
@@ -49,3 +49,7 @@ You can use [MkDocs](https://www.mkdocs.org/) to preview documentation changes o
    ```
 
 MkDocs serves the site at <http://127.0.0.1:8000/> by default. The server automatically rebuilds when files change, so refresh the browser to see your latest edits.
+
+## JUnit integration
+
+The CI pipeline collects JUnit XML output from both Node and PowerShell tests. `scripts/generate-ci-summary.ts` parses these files to build the GitHub step summary and requirement traceability report. Use `npm run test:ci` to produce the Node JUnit report when verifying documentation updates.

--- a/scripts/generate-ci-summary.test.js
+++ b/scripts/generate-ci-summary.test.js
@@ -1,8 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'fs/promises';
 import { fileURLToPath } from 'url';
 import path from 'path';
-import { loadRequirementMapping, findRequirementId } from './generate-ci-summary.ts';
+import { loadRequirementMapping, findRequirementId, parseJUnitFile, renderActionDoc } from './generate-ci-summary.ts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -13,4 +14,34 @@ test('loadRequirementMapping reads file and findRequirementId works', async () =
   const mapping = await loadRequirementMapping(mappingPath);
   assert.equal(findRequirementId('Dispatcher.Tests', mapping), 'REQ-001');
   assert.equal(findRequirementId('Unknown.Tests', mapping), undefined);
+});
+
+test('parseJUnitFile parses simple JUnit XML', async () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<testsuite name="Sample" tests="3" failures="1">\n  <testcase name="a"/>\n  <testcase name="b"><failure/></testcase>\n  <testcase name="c"/>\n</testsuite>`;
+  const junitPath = path.join(__dirname, 'sample-junit.xml');
+  await fs.writeFile(junitPath, xml);
+  const suites = await parseJUnitFile(junitPath);
+  await fs.unlink(junitPath);
+  assert.equal(suites.length, 1);
+  assert.deepEqual(suites[0], { name: 'Sample', tests: 3, failures: 1, passed: 2 });
+});
+
+test('renderActionDoc fills template placeholders', async () => {
+  const templatePath = path.resolve(__dirname, '../doc-templates/action-doc-template.md');
+  const template = await fs.readFile(templatePath, 'utf8');
+  const info = {
+    name: 'demo-action',
+    synopsis: 'Demo synopsis',
+    description: '',
+    parameters: [
+      { name: 'Req', type: 'string', required: true, description: 'required param' },
+      { name: 'Opt', type: 'number', required: false, description: 'optional param' },
+    ],
+  };
+  const md = renderActionDoc(template, info);
+  assert.ok(md.includes('demo-action'));
+  assert.ok(md.includes('**Req** (`string`): required param'));
+  assert.ok(md.includes('**Opt** (`number`): optional param'));
+  assert.ok(md.includes('pwsh -File actions/Invoke-OSAction.ps1 -ActionName demo-action'));
+  assert.ok(md.includes('action_name: demo-action'));
 });

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -42,7 +42,7 @@ interface SuiteResult {
   passed: number;
 }
 
-async function parseJUnitFile(file: string): Promise<SuiteResult[]> {
+export async function parseJUnitFile(file: string): Promise<SuiteResult[]> {
   const xml = await fs.readFile(file, 'utf8');
   const data = await parseStringPromise(xml);
   const suites: any[] = [];
@@ -130,7 +130,7 @@ async function getActionInfo(scriptPath: string): Promise<ActionInfo> {
   return { name: path.basename(path.dirname(scriptPath)), synopsis, description, parameters };
 }
 
-function renderActionDoc(template: string, info: ActionInfo): string {
+export function renderActionDoc(template: string, info: ActionInfo): string {
   const required = info.parameters.filter((p) => p.required);
   const optional = info.parameters.filter((p) => !p.required);
   const reqLines = required.length ? required.map((p) => `- **${p.name}** (\`${p.type}\`): ${p.description}`).join('\n') : 'None.';


### PR DESCRIPTION
## Summary
- export internal helpers for testing
- add unit tests for JUnit parser and documentation renderer
- document JUnit XML integration and auto-generated docs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ea8f0b048832993212a61bef60126