### PR TITLE
ci: install deps before node tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+      - run: npm install
       - run: npm run test:ci
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
## Summary
- install npm dependencies before running node tests in CI

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689eabcba2c08329ac74392ea7729293