### PR TITLE
ci: ensure Pester 5 installed for dispatcher tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install Pester (if needed)
+      - name: Install Pester
         shell: pwsh
-        run: |
-          if (-not (Get-Module -ListAvailable -Name Pester)) {
-            Install-Module Pester -Force -Scope CurrentUser -SkipPublisherCheck
-          }
+        run: Install-Module Pester -MinimumVersion 5.0.0 -Force -Scope CurrentUser -SkipPublisherCheck
       - name: Run Pester with JUnit output
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary
- Install or update Pester to version 5+ for dispatcher tests
- Keep JUnit output so pester-results/pester-junit.xml is always generated

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689eac93e9f08329a277308ae564d7d2