### PR TITLE
Use JSZip to create action-docs artifact and fail on errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "glob": "^10.3.10",
-    "xml2js": "^0.6.2"
+    "xml2js": "^0.6.2",
+    "jszip": "^3.10.1"
   },
   "devDependencies": {
     "@types/xml2js": "^0.4.14",

--- a/scripts/generate-ci-summary.test.js
+++ b/scripts/generate-ci-summary.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'fs/promises';
 import { fileURLToPath } from 'url';
 import path from 'path';
-import { loadRequirementMapping, findRequirementId, parseJUnitFile, renderActionDoc } from './generate-ci-summary.ts';
+import { loadRequirementMapping, findRequirementId, parseJUnitFile, renderActionDoc, main } from './generate-ci-summary.ts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -44,4 +44,24 @@ test('renderActionDoc fills template placeholders', async () => {
   assert.ok(md.includes('**Opt** (`number`): optional param'));
   assert.ok(md.includes('pwsh -File actions/Invoke-OSAction.ps1 -ActionName demo-action'));
   assert.ok(md.includes('action_name: demo-action'));
+});
+
+test('main writes artifacts to artifacts directory', async () => {
+  const cwd = process.cwd();
+  try {
+    process.chdir(path.resolve(__dirname, '..'));
+    const junitXml = `<?xml version="1.0" encoding="UTF-8"?>\n<testsuite name="Sample" tests="1">\n  <testcase name="Dispatcher.Tests"/>\n</testsuite>`;
+    const junitPath = path.join(__dirname, 'ci-junit.xml');
+    await fs.writeFile(junitPath, junitXml);
+    process.env.TEST_RESULTS_GLOBS = junitPath;
+    await fs.rm('artifacts', { recursive: true, force: true });
+    await main();
+    await fs.access(path.join('artifacts', 'traceability.json'));
+    await fs.access(path.join('artifacts', 'action-docs.zip'));
+    await fs.unlink(junitPath);
+  } finally {
+    delete process.env.TEST_RESULTS_GLOBS;
+    await fs.rm(path.join(process.cwd(), 'artifacts'), { recursive: true, force: true });
+    process.chdir(cwd);
+  }
 });

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -5,6 +5,7 @@ import { glob } from 'glob';
 import { parseStringPromise } from 'xml2js';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import JSZip from 'jszip';
 
 const execFileAsync = promisify(execFile);
 
@@ -85,7 +86,7 @@ async function appendSummary(results: SuiteResult[]): Promise<void> {
   await fs.appendFile(summaryPath, md);
 }
 
-async function writeTraceability(results: SuiteResult[], mapping: Record<string, string>): Promise<void> {
+export async function writeTraceability(results: SuiteResult[], mapping: Record<string, string>): Promise<void> {
   const trace: Record<string, unknown> = {};
   for (const r of results) {
     const req = findRequirementId(r.name, mapping);
@@ -161,7 +162,29 @@ export function renderActionDoc(template: string, info: ActionInfo): string {
   return md;
 }
 
-async function generateActionDocs(): Promise<void> {
+async function zipDirectory(sourceDir: string, outPath: string): Promise<void> {
+  const zip = new JSZip();
+  const root = zip.folder(path.basename(sourceDir));
+  if (!root) throw new Error('Unable to create zip folder');
+  async function addDir(dir: string, folder: JSZip): Promise<void> {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        const sub = folder.folder(entry.name);
+        if (sub) await addDir(full, sub);
+      } else if (entry.isFile()) {
+        const data = await fs.readFile(full);
+        folder.file(entry.name, data);
+      }
+    }
+  }
+  await addDir(sourceDir, root);
+  const content = await zip.generateAsync({ type: 'nodebuffer' });
+  await fs.writeFile(outPath, content);
+}
+
+export async function generateActionDocs(): Promise<void> {
   const scripts = await glob('scripts/*/*.ps1');
   if (scripts.length === 0) return;
   const template = await fs.readFile(path.join('doc-templates', 'action-doc-template.md'), 'utf8');
@@ -177,13 +200,13 @@ async function generateActionDocs(): Promise<void> {
     }
   }
   try {
-    await execFileAsync('zip', ['-r', 'action-docs.zip', 'action-docs'], { cwd: 'artifacts' });
+    await zipDirectory(outDir, path.join('artifacts', 'action-docs.zip'));
   } catch (err: any) {
-    console.warn(`Failed to zip action docs: ${err.message}`);
+    throw new Error(`Failed to zip action docs: ${err.message}`);
   }
 }
 
-async function main() {
+export async function main() {
   const patternsEnv = process.env.TEST_RESULTS_GLOBS;
   if (!patternsEnv) {
     console.warn('TEST_RESULTS_GLOBS not set');
@@ -209,10 +232,18 @@ async function main() {
 
   const mappingFile = process.env.REQ_MAPPING_FILE ?? 'requirements.json';
   const mapping = await loadRequirementMapping(path.resolve(mappingFile));
-  await writeTraceability(results, mapping);
-  await generateActionDocs();
+  let artifactError = false;
+  try {
+    await writeTraceability(results, mapping);
+    await generateActionDocs();
+    await fs.access(path.join('artifacts', 'traceability.json'));
+    await fs.access(path.join('artifacts', 'action-docs.zip'));
+  } catch (err: any) {
+    console.error(`Artifact generation failed: ${err.message}`);
+    artifactError = true;
+  }
 
-  if (results.some((r) => r.failures > 0)) {
+  if (results.some((r) => r.failures > 0) || artifactError) {
     process.exitCode = 1;
   }
 }


### PR DESCRIPTION
## Summary
- zip action docs with JSZip instead of system `zip`
- fail CI summary script when traceability or docs artifacts are missing
- test that `generate-ci-summary` writes required artifacts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689eadd8ee608329a56945b651688b52