### PR TITLE
chore: warn when report artifacts missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         with:
           name: traceability
           path: artifacts/traceability.*
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: Upload action-docs
         if: always()
@@ -151,7 +151,7 @@ jobs:
         with:
           name: action-docs
           path: artifacts/action-docs.zip
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: Upload evidence (optional)
         if: always()


### PR DESCRIPTION
## Summary
- avoid failing CI report job when traceability or action-docs artifacts are absent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689eb010b4e48329b83f4471f901b054