### PR TITLE
Import Pester before configuring dispatcher tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
         run: |
           $OutDir = Join-Path $env:GITHUB_WORKSPACE 'pester-results'
           New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+          Import-Module Pester -MinimumVersion 5.0.0
           $cfg = [PesterConfiguration]::Default
           $cfg.Run.Path = './tests/pester'
           $cfg.TestResult.Enabled = $true


### PR DESCRIPTION
## Summary
- Import Pester module in dispatcher-tests workflow before referencing PesterConfiguration

## Testing
- `npm test` *(fails to document some scripts: spawn pwsh ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_689eb2a18a9c8329b330e06fcf0f9193