### PR TITLE
Rethrow errors in Set_Development_Mode script

### DIFF
--- a/scripts/set-development-mode/Set_Development_Mode.ps1
+++ b/scripts/set-development-mode/Set_Development_Mode.ps1
@@ -26,8 +26,7 @@ function Execute-Script {
     try {
         Invoke-Expression $ScriptCommand -ErrorAction Stop
     } catch {
-        Write-Error "Error occurred while executing: $ScriptCommand. Exiting."
-        exit 1
+        throw "Error occurred while executing: $ScriptCommand"
     }
 }
 # Sequential script execution with error handling


### PR DESCRIPTION
## Summary
- Propagate execution errors instead of exiting in `Execute-Script`
- Maintain outer error handler to log and exit on unexpected errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689eb51922d88329b12606703393c83f