### PR TITLE
fix: exit non-zero on restore error

### DIFF
--- a/scripts/restore-setup-lv-source/RestoreSetupLVSource.ps1
+++ b/scripts/restore-setup-lv-source/RestoreSetupLVSource.ps1
@@ -45,10 +45,14 @@ try {
     Invoke-Expression $script
 
     # Check the exit code of the executed command
-    if ($LASTEXITCODE -eq 0) {
-        Write-Host "Unzip vi.lib/LabVIEW Icon API from LabVIEW $MinimumSupportedLVVersion ($SupportedBitness-bit) and remove localhost.library path from ini file"
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        Write-Error "g-cli exited with code $exitCode"
+        exit $exitCode
     }
+
+    Write-Host "Unzip vi.lib/LabVIEW Icon API from LabVIEW $MinimumSupportedLVVersion ($SupportedBitness-bit) and remove localhost.library path from ini file"
 } catch {
-    Write-Host ""
-    exit 0
+    Write-Error "Failed to restore LabVIEW source: $_"
+    exit 1
 }


### PR DESCRIPTION
## Summary
- update RestoreSetupLVSource.ps1 to surface errors and exit with non-zero status

## Testing
- `npm test`
- `pwsh -File scripts/restore-setup-lv-source/RestoreSetupLVSource.ps1 ...` *(fails: g-cli not found)*

------
https://chatgpt.com/codex/tasks/task_e_689eb75ea7008329a85e941559ec6c71