### PR TITLE
Improve error handling in AddTokenToLabVIEW

### DIFF
--- a/scripts/add-token-to-labview/AddTokenToLabVIEW.ps1
+++ b/scripts/add-token-to-labview/AddTokenToLabVIEW.ps1
@@ -42,7 +42,8 @@ try {
     if ($LASTEXITCODE -eq 0) {
         Write-Host "Create localhost.library path from ini file"
     }
+    exit $LASTEXITCODE
 } catch {
-    Write-Host ""
-    exit 0
+    Write-Error "Failed to add localhost.library path to INI file: $_"
+    exit 1
 }


### PR DESCRIPTION
## Summary
- surface failure details when adding library path tokens to LabVIEW INI
- propagate g-cli exit status so successful runs exit with 0

## Testing
- `npm test`
- `pwsh scripts/add-token-to-labview/AddTokenToLabVIEW.ps1 -MinimumSupportedLVVersion 2021 -SupportedBitness 64 -RelativePath .` *(fails without g-cli)*
- `pwsh scripts/add-token-to-labview/AddTokenToLabVIEW.ps1 -MinimumSupportedLVVersion 2021 -SupportedBitness 64 -RelativePath .` *(succeeds with dummy g-cli)*

------
https://chatgpt.com/codex/tasks/task_e_689eb8ae4e9c832993710a8625fce153