### PR TITLE
Map missing-in-project action to script

### DIFF
--- a/tests/pester/ScriptPath.Tests.ps1
+++ b/tests/pester/ScriptPath.Tests.ps1
@@ -12,13 +12,19 @@ $actionNames = pwsh -NoProfile -File $dispatcher -ListActions |
     Where-Object { $_ -match '^\s+- ' } |
     ForEach-Object { $_.Trim().Substring(2) }
 
+$scriptMap = @{ 'missing-in-project' = 'Invoke-MissingInProjectCLI.ps1' }
+
 $cases = foreach ($name in $actionNames) {
     $dir = Join-Path $scriptRoot $name
-    $scriptFile = Get-ChildItem -Path $dir -Filter '*.ps1' -File | Select-Object -First 1
-    if ($null -eq $scriptFile) {
-        @{ Name = $name; Path = Join-Path $dir "$name.ps1" }
+    if ($scriptMap.ContainsKey($name)) {
+        @{ Name = $name; Path = Join-Path $dir $scriptMap[$name] }
     } else {
-        @{ Name = $name; Path = $scriptFile.FullName }
+        $scriptFile = Get-ChildItem -Path $dir -Filter '*.ps1' -File | Select-Object -First 1
+        if ($null -eq $scriptFile) {
+            @{ Name = $name; Path = Join-Path $dir "$name.ps1" }
+        } else {
+            @{ Name = $name; Path = $scriptFile.FullName }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- explicitly map `missing-in-project` to `Invoke-MissingInProjectCLI.ps1` in script path tests

## Testing
- `npm test`
- `pwsh -NoProfile scripts/run-pester-tests/RunPesterTests.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ebde280788329873e253ac9400f94