### PR TITLE
Install Pester before dispatcher dry-run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: Install Pester
+        shell: pwsh
+        run: Install-Module Pester -MinimumVersion 5.0.0 -Force -Scope CurrentUser -SkipPublisherCheck
       - name: Run dispatcher dry-run tests
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary
- ensure dispatcher dry-run tests install Pester 5

## Testing
- `npm test`
- `pwsh -NoLogo -Command "Install-Module Pester -MinimumVersion 5.0.0 -Force -Scope CurrentUser -SkipPublisherCheck; Invoke-Pester -CI -Path 'tests/pester/Dispatcher.DryRun.Tests.ps1'"`


------
https://chatgpt.com/codex/tasks/task_e_689ec122be508329b379dab0878c0373