### PR TITLE
Only install Pester when needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Pester
         shell: pwsh
-        run: Install-Module Pester -MinimumVersion 5.0.0 -Force -Scope CurrentUser -SkipPublisherCheck
+        run: |
+          if (-not (Get-Module -ListAvailable -Name Pester -MinimumVersion 5.0.0)) {
+            Remove-Module Pester -ErrorAction SilentlyContinue
+            Install-Module Pester -MinimumVersion 5.0.0 -Force -Scope CurrentUser -SkipPublisherCheck
+          }
       - name: Run Pester with JUnit output
         shell: pwsh
         run: |
@@ -88,7 +92,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Pester
         shell: pwsh
-        run: Install-Module Pester -MinimumVersion 5.0.0 -Force -Scope CurrentUser -SkipPublisherCheck
+        run: |
+          if (-not (Get-Module -ListAvailable -Name Pester -MinimumVersion 5.0.0)) {
+            Remove-Module Pester -ErrorAction SilentlyContinue
+            Install-Module Pester -MinimumVersion 5.0.0 -Force -Scope CurrentUser -SkipPublisherCheck
+          }
       - name: Run dispatcher dry-run tests
         shell: pwsh
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,11 @@ jobs:
 
       - name: Install Pester
         shell: pwsh
-        run: Install-Module Pester -Force -Scope CurrentUser
+        run: |
+          if (-not (Get-Module -ListAvailable -Name Pester -MinimumVersion 5.0.0)) {
+            Remove-Module Pester -ErrorAction SilentlyContinue
+            Install-Module Pester -MinimumVersion 5.0.0 -Force -Scope CurrentUser -SkipPublisherCheck
+          }
 
       - name: Run Pester tests
         shell: pwsh


### PR DESCRIPTION
## Summary
- Avoid redundant Pester installs in CI and release workflows by checking for existing module

## Testing
- `npm test`
- `pwsh -File /tmp/install-pester.ps1`

------
https://chatgpt.com/codex/tasks/task_e_689ec3d84ae48329b8ca20d969d41d9b