### PR TITLE
Fix CI traceability artifact paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,9 @@ jobs:
 
       - name: Generate Summary & Artifacts
         env:
-          TEST_RESULTS_GLOBS: "downloaded/**/*.xml;**/junit*.xml"
+          TEST_RESULTS_GLOBS: |
+            downloaded/**/*.xml
+            **/junit*.xml
           REQ_MAPPING_FILE: "requirements.json"
           DISPATCHER_SCRIPT: "actions/Invoke-OSAction.ps1"
           EVIDENCE_DIR: "test-screenshots"
@@ -154,7 +156,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: traceability
-          path: artifacts/traceability.*
+          path: |
+            artifacts/traceability.json
+            artifacts/traceability.md
           if-no-files-found: warn
 
       - name: Upload action-docs
@@ -165,7 +169,7 @@ jobs:
           path: artifacts/action-docs.zip
           if-no-files-found: warn
 
-      - name: Upload evidence (optional)
+      - name: Upload evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- allow multiple test result globs without semicolons
- upload traceability markdown and evidence artifacts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ecc6faef48329988c1693559f6bec