### PR TITLE
ci: expand report job dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
   report:
     name: Generate TTM & Action Docs
     runs-on: ubuntu-latest
-    needs: [dispatcher-tests, node-tests]
+    needs: [docs-lint, dispatcher-tests, dispatcher-dryrun-tests, scriptpath-tests, node-tests]
     if: always()
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- ensure report job waits for docs-lint, dispatcher-dryrun-tests, and scriptpath-tests
- keep report job running unconditionally with `if: always()`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ece76b33483299277e1a10659d1d9