### PR TITLE
Deploy docs after successful report job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,8 @@ jobs:
           if-no-files-found: ignore
 
   deploy-docs:
-    if: github.ref == 'refs/heads/actions'
+    needs: report
+    if: github.ref == 'refs/heads/actions' && needs.report.result == 'success'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary
- ensure `deploy-docs` job depends on `report`
- gate docs deployment on report job success

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ecf4a5b608329b2e83e7270c3f87d