### PR TITLE
Fail CI when dispatcher tests fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,10 @@ jobs:
           path: artifacts/evidence/**
           if-no-files-found: ignore
 
+      - name: Verify required jobs
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1
+
   deploy-docs:
     needs: report
     if: github.ref == 'refs/heads/actions' && needs.report.result == 'success'


### PR DESCRIPTION
## Summary
- ensure `dispatcher-tests` result impacts CI by failing `report` when dependent jobs fail

## Testing
- `npm test`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path './tests/pester'"` *(fails: Invalid RelativePath handling)*

------
https://chatgpt.com/codex/tasks/task_e_689ed07fbd148329a9246afbfb21de8e