### PR TITLE
feat: make RelativePath mandatory

### DIFF
--- a/scripts/set-development-mode/Set_Development_Mode.ps1
+++ b/scripts/set-development-mode/Set_Development_Mode.ps1
@@ -14,6 +14,7 @@
 #>
 
 param(
+    [Parameter(Mandatory = $true)]
     [string]$RelativePath
 )
 

--- a/tests/pester/Dispatcher.InvalidPaths.Tests.ps1
+++ b/tests/pester/Dispatcher.InvalidPaths.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'Invalid RelativePath handling' {
     It 'fails when RelativePath is missing' {
         $out = pwsh -NonInteractive -NoProfile -File $global:dispatcher -ActionName set-development-mode -ArgsJson '{}' *>&1 | Out-String
         $LASTEXITCODE | Should -Not -Be 0
-        $out | Should -Match 'Missing an argument for parameter'
+        $out | Should -Match 'missing mandatory'
         $out | Should -Match 'RelativePath'
     }
 }


### PR DESCRIPTION
## Summary
- enforce mandatory RelativePath in Set_Development_Mode script
- adjust tests for updated missing parameter error message

## Testing
- `npm test` *(fails: ERR_UNSUPPORTED_DIR_IMPORT)*
- `node --loader ts-node/esm --test scripts/generate-ci-summary.test.js`
- `pwsh -NoProfile -Command "Invoke-Pester -CI -Path tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_689ed38f629c83299f49d5e80f1da601