### PR TITLE
Use version comparison for Pester installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,10 @@ jobs:
       - name: Install Pester
         shell: pwsh
         run: |
-          if (-not (Get-Module -ListAvailable -Name Pester -MinimumVersion 5.0.0)) {
+          if (-not (Get-Module -ListAvailable -Name Pester |
+                    Where-Object { $_.Version -ge [Version]'5.0.0' })) {
             Remove-Module Pester -ErrorAction SilentlyContinue
-            Install-Module Pester -MinimumVersion 5.0.0 -Force -Scope CurrentUser -SkipPublisherCheck
+            Install-Module -Name Pester -MinimumVersion 5.0.0 -Scope CurrentUser -Force -SkipPublisherCheck
           }
       - name: Run Pester with JUnit output
         shell: pwsh
@@ -93,9 +94,10 @@ jobs:
       - name: Install Pester
         shell: pwsh
         run: |
-          if (-not (Get-Module -ListAvailable -Name Pester -MinimumVersion 5.0.0)) {
+          if (-not (Get-Module -ListAvailable -Name Pester |
+                    Where-Object { $_.Version -ge [Version]'5.0.0' })) {
             Remove-Module Pester -ErrorAction SilentlyContinue
-            Install-Module Pester -MinimumVersion 5.0.0 -Force -Scope CurrentUser -SkipPublisherCheck
+            Install-Module -Name Pester -MinimumVersion 5.0.0 -Scope CurrentUser -Force -SkipPublisherCheck
           }
       - name: Run dispatcher dry-run tests
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,10 @@ jobs:
       - name: Install Pester
         shell: pwsh
         run: |
-          if (-not (Get-Module -ListAvailable -Name Pester -MinimumVersion 5.0.0)) {
+          if (-not (Get-Module -ListAvailable -Name Pester |
+                    Where-Object { $_.Version -ge [Version]'5.0.0' })) {
             Remove-Module Pester -ErrorAction SilentlyContinue
-            Install-Module Pester -MinimumVersion 5.0.0 -Force -Scope CurrentUser -SkipPublisherCheck
+            Install-Module -Name Pester -MinimumVersion 5.0.0 -Scope CurrentUser -Force -SkipPublisherCheck
           }
 
       - name: Run Pester tests


### PR DESCRIPTION
## Summary
- ensure Pester 5+ is installed by comparing module version instead of using unsupported -MinimumVersion

## Testing
- `npm test`
- `pwsh -NoProfile -Command "Invoke-Pester -CI -Path tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_689ed73b02d88329ace20d10ff94c816