### PR TITLE
Fix Pester JUnit invocation in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,11 @@ jobs:
           Import-Module Pester -MinimumVersion 5.0.0
           $cfg = [PesterConfiguration]::Default
           $cfg.Run.Path = './tests/pester'
+          $cfg.Run.Exit = $true
           $cfg.TestResult.Enabled = $true
           $cfg.TestResult.OutputFormat = 'JUnitXml'
           $cfg.TestResult.OutputPath = (Join-Path $OutDir 'pester-junit.xml')
-          Invoke-Pester -Configuration $cfg -CI
+          Invoke-Pester -Configuration $cfg
       - name: Upload Pester JUnit
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- fix Invoke-Pester invocation with configuration-based exit
- add Run.Exit to ensure correct CI failure handling

## Testing
- `npm test`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`

------
https://chatgpt.com/codex/tasks/task_e_689ed972fc5c8329b1d58118a9e557f3