### PR TITLE
fix: run generate summary script with esm loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
           REQ_MAPPING_FILE: "requirements.json"
           DISPATCHER_SCRIPT: "actions/Invoke-OSAction.ps1"
           EVIDENCE_DIR: "test-screenshots"
-        run: npx ts-node scripts/generate-ci-summary.ts
+        run: node --loader ts-node/esm scripts/generate-ci-summary.ts
 
       - name: Upload traceability
         if: always()

--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -4,7 +4,7 @@ To keep documentation consistent and easy to review, please follow these rules w
 
 ## Action documentation
 
-Documentation for PowerShell actions is generated automatically. During CI the script `scripts/generate-ci-summary.ts` reads the help metadata from each action and fills in `doc-templates/action-doc-template.md`. The rendered Markdown files are zipped into `artifacts/action-docs.zip`. Run `node scripts/generate-ci-summary.ts` locally to preview the generated docs.
+Documentation for PowerShell actions is generated automatically. During CI the script `scripts/generate-ci-summary.ts` reads the help metadata from each action and fills in `doc-templates/action-doc-template.md`. The rendered Markdown files are zipped into `artifacts/action-docs.zip`. Run `node --loader ts-node/esm scripts/generate-ci-summary.ts` locally to preview the generated docs.
 
 ## Markdown linting
 


### PR DESCRIPTION
## Summary
- run `generate-ci-summary.ts` using Node's ts-node ESM loader in CI
- document how to invoke `generate-ci-summary.ts` locally with the loader

## Testing
- `npm test`
- `node --loader ts-node/esm scripts/generate-ci-summary.ts`


------
https://chatgpt.com/codex/tasks/task_e_689ede68f948832982a7818e9b657d34