### PR TITLE
Fix ESM execution for CI summary script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
           REQ_MAPPING_FILE: "requirements.json"
           DISPATCHER_SCRIPT: "actions/Invoke-OSAction.ps1"
           EVIDENCE_DIR: "test-screenshots"
-        run: npx ts-node scripts/generate-ci-summary.ts
+        run: node --loader ts-node/esm scripts/generate-ci-summary.ts
 
       - name: Upload traceability
         if: always()

--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -4,7 +4,7 @@ To keep documentation consistent and easy to review, please follow these rules w
 
 ## Action documentation
 
-Documentation for PowerShell actions is generated automatically. During CI the script `scripts/generate-ci-summary.ts` reads the help metadata from each action and fills in `doc-templates/action-doc-template.md`. The rendered Markdown files are zipped into `artifacts/action-docs.zip`. Run `node scripts/generate-ci-summary.ts` locally to preview the generated docs.
+Documentation for PowerShell actions is generated automatically. During CI the script `scripts/generate-ci-summary.ts` reads the help metadata from each action and fills in `doc-templates/action-doc-template.md`. The rendered Markdown files are zipped into `artifacts/action-docs.zip`. Run `node --loader ts-node/esm scripts/generate-ci-summary.ts` locally to preview the generated docs.
 
 ## Markdown linting
 

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node
+#!/usr/bin/env -S node --loader ts-node/esm
 import { promises as fs } from 'fs';
 import path from 'path';
 import { glob } from 'glob';


### PR DESCRIPTION
## Summary
- run CI summary script with Node's ts-node ESM loader
- document the correct command for local generation
- update script shebang for direct execution

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ede68f948832982a7818e9b657d34