### PR TITLE
Document requirement mappings for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Open Source LabVIEW Actions
 
 Open Source LabVIEW Actions is a composite GitHub Action that dispatches LabVIEW CI/CD tasks via PowerShell. See the [documentation site](https://open-source-actions.github.io/open-source-actions/) for setup and action reference. The [quickstart](docs/quickstart.md) shows a full example and [Unified Dispatcher](docs/UnifiedDispatcher.md) describes how the dispatcher works. For an overview of the project's architecture, see [docs/architecture.md](docs/architecture.md).
+For a mapping of high-level requirements to the tests that verify them, see [docs/requirements.md](docs/requirements.md).
 
 To inspect the action's source and full schema, see [action.yml](action.yml).
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,18 @@
+# Requirements
+
+This project tracks high‑level requirements and maps each one to the Pester test
+files that verify it. The authoritative mapping is stored in
+[`requirements.json`](../requirements.json); the table below provides a human‑readable
+summary for quick reference.
+
+| ID | Description | Tests |
+|----|-------------|-------|
+| REQ-001 | Dispatcher discovers available actions, describes them, and validates arguments. | `tests/pester/Dispatcher.Tests.ps1` |
+| REQ-002 | Dispatcher dry‑run mode prints descriptions and warns on unknown arguments without executing actions. | `tests/pester/Dispatcher.DryRun.Tests.ps1` |
+| REQ-003 | Actions correctly resolve and pass RelativePath arguments without warnings. | `tests/pester/RelativePath.Actions.Tests.ps1` |
+| REQ-004 | Every action script exists at the expected path. | `tests/pester/ScriptPath.Tests.ps1` |
+| REQ-005 | Dispatcher fails when RelativePath is missing or invalid. | `tests/pester/Dispatcher.InvalidPaths.Tests.ps1` |
+
+Each test file is annotated with its corresponding requirement ID to maintain
+traceability between requirements and test coverage.
+

--- a/tests/pester/Dispatcher.DryRun.Tests.ps1
+++ b/tests/pester/Dispatcher.DryRun.Tests.ps1
@@ -1,6 +1,7 @@
 #requires -Version 7.0
 # Pester v5+ tests that do NOT require LabVIEW/g-cli.
 # Run:  Invoke-Pester -CI -Path ./tests/pester
+# Requirement: REQ-002 - Dispatcher dry-run mode prints descriptions and warns on unknown arguments without executing actions.
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'

--- a/tests/pester/Dispatcher.InvalidPaths.Tests.ps1
+++ b/tests/pester/Dispatcher.InvalidPaths.Tests.ps1
@@ -1,5 +1,6 @@
 #requires -Version 7.0
 # Pester v5+ tests verifying dispatcher handling of invalid RelativePath
+# Requirement: REQ-005 - Dispatcher fails when RelativePath is missing or invalid.
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -1,6 +1,7 @@
 #requires -Version 7.0
 # Pester v5+ tests that do NOT require LabVIEW/g-cli.
 # Run:  Invoke-Pester -CI -Path ./tests/pester
+# Requirement: REQ-001 - Dispatcher discovers available actions, describes them, and validates arguments.
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'

--- a/tests/pester/RelativePath.Actions.Tests.ps1
+++ b/tests/pester/RelativePath.Actions.Tests.ps1
@@ -1,5 +1,6 @@
 #requires -Version 7.0
 # Pester v5+ tests verifying RelativePath-consuming actions
+# Requirement: REQ-003 - Actions correctly resolve and pass RelativePath arguments without warnings.
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'

--- a/tests/pester/ScriptPath.Tests.ps1
+++ b/tests/pester/ScriptPath.Tests.ps1
@@ -1,5 +1,6 @@
 #requires -Version 7.0
 # Verify that each action script exists in the expected location.
+# Requirement: REQ-004 - Every action script exists at the expected path.
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'


### PR DESCRIPTION
## Summary
- annotate each Pester test with its requirement ID
- add a requirements overview mapping tests to requirements
- reference requirements doc from README

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -CI -Path ./tests/pester"`

------
https://chatgpt.com/codex/tasks/task_e_689ee1e3dd48832999c13cdd9b4f928c