### PR TITLE
Lint doc templates in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,13 @@ jobs:
           filters: |
             docs:
               - 'docs/**'
+              - 'doc-templates/**'
               - 'README.md'
-      - if: steps.changes.outputs.docs == 'true'
+      - if: ${{ steps.changes.outputs.docs == 'true' }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - if: steps.changes.outputs.docs == 'true'
+      - if: ${{ steps.changes.outputs.docs == 'true' }}
         name: Lint documentation
         shell: pwsh
         run: scripts/lint-docs.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
             docs:
               - 'docs/**'
               - 'doc-templates/**'
+              - 'scripts/**'
               - 'README.md'
       - if: ${{ steps.changes.outputs.docs == 'true' }}
         uses: actions/setup-node@v4

--- a/doc-templates/action-doc-template.md
+++ b/doc-templates/action-doc-template.md
@@ -6,7 +6,7 @@ Briefly describe the action's goal.
 
 ## Parameters
 
-Common parameters are described in [Common parameters](../common-parameters.md).
+Common parameters are described in [Common parameters](../docs/common-parameters.md).
 
 ### Required
 
@@ -44,6 +44,6 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName <action-name> -ArgsJson '{
 - `0` – success
 - non‑zero – failure
 
-For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
+For troubleshooting tips, see the [troubleshooting guide](../docs/troubleshooting.md).
 
 Source: [scripts/`<action-name>`/](../../scripts/<action-name>/) <!-- markdown-link-check-disable-line -->

--- a/scripts/lint-docs.ps1
+++ b/scripts/lint-docs.ps1
@@ -12,7 +12,7 @@ $ErrorActionPreference = 'Stop'
 
 Write-Host 'Running markdownlint...'
 # Lint README and documentation Markdown files
-npx --yes markdownlint-cli README.md docs/**/*.md
+npx --yes markdownlint-cli README.md docs/**/*.md doc-templates/**/*.md
 if ($LASTEXITCODE -ne 0) {
     exit $LASTEXITCODE
 }
@@ -41,7 +41,7 @@ if (Invoke-LinkCheck README.md) {
     $exitCode = 1
 }
 
-Get-ChildItem -Path 'docs' -Recurse -Filter '*.md' | ForEach-Object {
+Get-ChildItem -Path 'docs','doc-templates' -Recurse -Filter '*.md' | ForEach-Object {
     if (Invoke-LinkCheck $_.FullName) {
         $exitCode = 1
     }


### PR DESCRIPTION
## Summary
- ensure doc-template markdown changes trigger docs lint
- expand lint script to scan doc templates and fix template links

## Testing
- `pwsh scripts/lint-docs.ps1`

------
https://chatgpt.com/codex/tasks/task_e_689f45845ca883298836a5d77c436977