### PR TITLE
fix: make docs build with strict

### DIFF
--- a/docs/requirements.json
+++ b/docs/requirements.json
@@ -1,0 +1,29 @@
+{
+  "requirements": [
+    {
+      "id": "REQ-001",
+      "description": "Dispatcher discovers available actions, describes them, and validates arguments.",
+      "tests": ["Dispatcher.Tests"]
+    },
+    {
+      "id": "REQ-002",
+      "description": "Dispatcher dry-run mode prints descriptions and warns on unknown arguments without executing actions.",
+      "tests": ["Dispatcher.DryRun.Tests"]
+    },
+    {
+      "id": "REQ-003",
+      "description": "Actions correctly resolve and pass RelativePath arguments without warnings.",
+      "tests": ["RelativePath.Actions.Tests"]
+    },
+    {
+      "id": "REQ-004",
+      "description": "Every action script exists at the expected path.",
+      "tests": ["ScriptPath.Tests"]
+    },
+    {
+      "id": "REQ-005",
+      "description": "Dispatcher fails when RelativePath is missing or invalid.",
+      "tests": ["Dispatcher.InvalidPaths.Tests"]
+    }
+  ]
+}

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2,7 +2,7 @@
 
 This project tracks high‑level requirements and maps each one to the Pester test
 files that verify it. The authoritative mapping is stored in
-[`requirements.json`](../requirements.json); the table below provides a human‑readable
+[`requirements.json`](requirements.json); the table below provides a human‑readable
 summary for quick reference.
 
 | ID | Description | Tests |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,8 @@ nav:
   - Versioning: versioning.md
   - Changelog: CHANGELOG.md
   - Contributing: contributing-docs.md
+  - Requirements: requirements.md
+  - Testing with Pester: testing-pester.md
   - Actions:
     - Add Token to LabVIEW: actions/add-token-to-labview.md
     - Apply VIPC: actions/apply-vipc.md


### PR DESCRIPTION
## Summary
- reference `requirements.json` from inside the docs tree
- surface requirements and testing docs in navigation

## Testing
- `mkdocs build --strict`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f4cf22d54832995e30d759197f98f