### PR TITLE
Run docs lint on PRs and deploy on push

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,15 +1,26 @@
-name: Deploy Docs
+name: Docs
 
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * 0'
+  pull_request:
+    branches: [actions]
+  push:
+    branches: [actions]
 
 jobs:
+  lint-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-mkdocs
+      - run: mkdocs build --strict
+
   deploy-docs:
+    if: github.event_name == 'push'
+    needs: lint-docs
     runs-on: ubuntu-latest
     environment:
       name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
     permissions:
       contents: read
       pages: write
@@ -18,24 +29,11 @@ jobs:
       group: pages
       cancel-in-progress: true
     steps:
-      - name: Log deploy conditions
-        run: 'echo "branch: ${{ github.ref }}"'
       - uses: actions/checkout@v4
-        if: github.ref == 'refs/heads/actions'
       - uses: ./actions/setup-mkdocs
-        if: github.ref == 'refs/heads/actions'
       - run: mkdocs build --strict
-        if: github.ref == 'refs/heads/actions'
-      - uses: actions/upload-artifact@v4
-        if: github.ref == 'refs/heads/actions'
-        with:
-          name: docs-site
-          path: site
-          if-no-files-found: error
       - uses: actions/upload-pages-artifact@v3
-        if: github.ref == 'refs/heads/actions'
         with:
           path: site
       - id: deploy
         uses: actions/deploy-pages@v4
-        if: github.ref == 'refs/heads/actions'


### PR DESCRIPTION
## Summary
- run `mkdocs build --strict` on pull requests
- deploy docs to GitHub Pages only after merge to `actions`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f512ebd3c8329b6d43a8edcdee035