### PR TITLE
feat: support yaml args

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ To inspect the action's source and full schema, see [action.yml](action.yml).
   uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: run-unit-tests
-    args_json: '{ "MinimumSupportedLVVersion": "2021", "SupportedBitness": "64" }'
+    args_yaml: |
+      MinimumSupportedLVVersion: '2021'
+      SupportedBitness: '64'
 ```
 
 This composite action wraps the dispatcher script [`actions/Invoke-OSAction.ps1`](actions/Invoke-OSAction.ps1). When the action runs it calls this script behind the scenes to execute the selected task.
@@ -28,7 +30,8 @@ This composite action wraps the dispatcher script [`actions/Invoke-OSAction.ps1`
 | Name | Required | Default | Description |
 | ---- | -------- | ------- | ----------- |
 | `action_name` | yes | – | Name of the action to execute (e.g. `run-unit-tests`). |
-| `args_json` | no | `{}` | JSON string of arguments for the selected action. Use to pass parameters to the action. |
+| `args_yaml` | no | _(none)_ | YAML string of arguments for the selected action. |
+| `args_json` | no | `{}` | **Legacy.** JSON string of arguments for the selected action. |
 | `working_directory` | no | _(none)_ | Directory where the action runs. Set when your project files are not at the repository root. |
 | `log_level` | no | `INFO` | Verbosity level (`ERROR`, `WARN`, `INFO`, `DEBUG`). Increase to `DEBUG` for troubleshooting. |
 | `dry_run` | no | `false` | Simulate the action without side effects. Helpful for verifying inputs. |
@@ -65,7 +68,11 @@ This action does not emit outputs. Check logs or uploaded artifacts for results.
 If you prefer or need to run tasks directly, call the dispatcher script yourself:
 
 ```powershell
-pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{ "MinimumSupportedLVVersion": "2021", "SupportedBitness": "64" }'
+$yaml = @'
+MinimumSupportedLVVersion: "2021"
+SupportedBitness: "64"
+'@
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsYaml (ConvertFrom-Yaml $yaml)
 ```
 
 ### Discovering actions

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,11 @@ inputs:
     required: false
     default: '{}'
     type: string
+  args_yaml:
+    description: 'YAML string of arguments for the selected action. Overrides args_json when set.'
+    required: false
+    default: ''
+    type: string
   working_directory:
     description: 'Working directory where the action will run.'
     required: false
@@ -37,16 +42,30 @@ runs:
       run: |
         $ErrorActionPreference = 'Stop'
 
-        # Capture JSON exactly as provided by the caller, without quoting/escaping issues.
-        $json = @'
-        ${{ inputs.args_json }}
+        # Prefer YAML args when provided; otherwise fall back to JSON.
+        $yaml = @'
+        ${{ inputs.args_yaml }}
         '@
 
-        # Build parameters via hashtable splatting to avoid fragile CLI string quoting.
         $params = @{
           ActionName = '${{ inputs.action_name }}'
-          ArgsJson   = $json
           LogLevel   = '${{ inputs.log_level }}'
+        }
+
+        if ($yaml.Trim()) {
+          try {
+            $params['ArgsYaml'] = ConvertFrom-Yaml -Yaml $yaml -ErrorAction Stop
+          }
+          catch {
+            throw "args_yaml is not valid YAML: $($_.Exception.Message)"
+          }
+        }
+        else {
+          # Capture JSON exactly as provided by the caller, without quoting/escaping issues.
+          $json = @'
+          ${{ inputs.args_json }}
+          '@
+          $params['ArgsJson'] = $json
         }
 
         if ('${{ inputs.working_directory }}' -ne '') {

--- a/actions/Invoke-OSAction.ps1
+++ b/actions/Invoke-OSAction.ps1
@@ -2,6 +2,7 @@
 param(
   [Parameter(Position=0)] [string] $ActionName,
   [Parameter()] [string] $ArgsJson = '{}',
+  [Parameter()] [hashtable] $ArgsYaml,
   [Parameter()] [string] $WorkingDirectory,
   [Parameter()] [ValidateSet('ERROR','WARN','INFO','DEBUG')] [string] $LogLevel = 'INFO',
   [switch] $DryRun,
@@ -135,6 +136,12 @@ try {
       }
     }
   }
+  if ($ArgsYaml) {
+    foreach ($k in $ArgsYaml.Keys) {
+      $argsHash[$k] = $ArgsYaml[$k]
+    }
+  }
+
   if ($DryRun)   { $argsHash['DryRun']   = $true }
   if ($LogLevel) { $argsHash['LogLevel'] = $LogLevel }
 

--- a/doc-templates/action-doc-template.md
+++ b/doc-templates/action-doc-template.md
@@ -21,9 +21,10 @@ Common parameters are described in [Common parameters](../docs/common-parameters
 ## CLI example
 
 ```powershell
-pwsh -File actions/Invoke-OSAction.ps1 -ActionName <action-name> -ArgsJson '{
-  "Param1": "value"
-}'
+$yaml = @'
+Param1: value
+'@
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName <action-name> -ArgsYaml (ConvertFrom-Yaml $yaml)
 ```
 
 ## GitHub Action example
@@ -33,10 +34,13 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName <action-name> -ArgsJson '{
   uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: <action-name>
-    args_json: >-
-      {
-        "Param1": "value"
-      }
+    args_yaml: |
+      Param1: value
+    # Legacy JSON format:
+    # args_json: >-
+    #   {
+    #     "Param1": "value"
+    #   }
 ```
 
 ## Return Codes

--- a/docs/UnifiedDispatcher.md
+++ b/docs/UnifiedDispatcher.md
@@ -14,14 +14,17 @@ See [Common Parameters](common-parameters.md) for a complete list of dispatcher 
 
 ## Cross‑platform
 
-Works on **Windows and Linux** as long as LabVIEW and [g-cli](https://github.com/ni/g-cli) are installed and available on `PATH`. For non‑standard installs, pass `gcliPath` in `args_json` (adapters will prepend it to `PATH`).
+Works on **Windows and Linux** as long as LabVIEW and [g-cli](https://github.com/ni/g-cli) are installed and available on `PATH`. For non‑standard installs, pass `gcliPath` in `args_yaml` (legacy `args_json` is also supported; adapters will prepend it to `PATH`).
 
 ## Example (CLI)
 
 ```powershell
-pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests `
-  -ArgsJson '{ "MinimumSupportedLVVersion": "2021", "SupportedBitness": "64", "gcliPath": "/opt/gcli/bin" }' `
-  -LogLevel INFO
+$yaml = @'
+MinimumSupportedLVVersion: "2021"
+SupportedBitness: "64"
+gcliPath: "/opt/gcli/bin"
+'@
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsYaml (ConvertFrom-Yaml $yaml) -LogLevel INFO
 ```
 
 ## Composite Action usage
@@ -30,8 +33,10 @@ pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests `
 - uses: ./
   with:
     action_name: run-unit-tests
-    args_json: >
-      { "MinimumSupportedLVVersion":"2021", "SupportedBitness":"64", "gcliPath":"/opt/gcli/bin" }
+    args_yaml: |
+      MinimumSupportedLVVersion: '2021'
+      SupportedBitness: '64'
+      gcliPath: /opt/gcli/bin
 ```
 
 ## Matrix example (Windows and Linux)
@@ -48,12 +53,10 @@ jobs:
       - uses: ./
         with:
           action_name: run-unit-tests
-          args_json: >
-            {
-              "MinimumSupportedLVVersion": "2021",
-              "SupportedBitness": "64",
-              "gcliPath": "/opt/gcli/bin"
-            }
+          args_yaml: |
+            MinimumSupportedLVVersion: '2021'
+            SupportedBitness: '64'
+            gcliPath: /opt/gcli/bin
 ```
 
 ## SemVer policy

--- a/docs/action-call-reference.md
+++ b/docs/action-call-reference.md
@@ -1,6 +1,6 @@
 # Action Call Reference
 
-Use the composite action to invoke any adapter by specifying its `action_name` and JSON arguments. Each section below shows a sample GitHub Actions step for calling one of the available actions. Refer to the linked action documentation for parameter details and return codes. See [common parameters](common-parameters.md) for options shared across actions.
+Use the composite action to invoke any adapter by specifying its `action_name` and YAML arguments. Legacy JSON via `args_json` is still supported. The examples below retain the JSON format for brevity; convert them to `args_yaml` as needed. Refer to the linked action documentation for YAML examples, parameter details, and return codes. See [common parameters](common-parameters.md) for options shared across actions.
 
 ## add-token-to-labview
 

--- a/docs/actions/run-unit-tests.md
+++ b/docs/actions/run-unit-tests.md
@@ -20,10 +20,11 @@ None.
 ## CLI example
 
 ```powershell
-pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{
-  "MinimumSupportedLVVersion": "2020",
-  "SupportedBitness": "64"
-}'
+$yaml = @'
+MinimumSupportedLVVersion: "2020"
+SupportedBitness: "64"
+'@
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsYaml (ConvertFrom-Yaml $yaml)
 ```
 
 ## GitHub Action example
@@ -33,11 +34,15 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{
   uses: LabVIEW-Community-CI-CD/open-source-actions@v1
   with:
     action_name: run-unit-tests
-    args_json: >-
-      {
-        "MinimumSupportedLVVersion": "2020",
-        "SupportedBitness": "64"
-      }
+    args_yaml: |
+      MinimumSupportedLVVersion: '2020'
+      SupportedBitness: '64'
+    # Legacy JSON format:
+    # args_json: >-
+    #   {
+    #     "MinimumSupportedLVVersion": "2020",
+    #     "SupportedBitness": "64"
+    #   }
 ```
 
 ## Return Codes

--- a/docs/common-parameters.md
+++ b/docs/common-parameters.md
@@ -58,7 +58,7 @@ pwsh ./actions/Invoke-OSAction.ps1 -Describe run-unit-tests
 
 ### `gcliPath`
 
-Optional path to the NI g-cli executable. When provided in `args_json`, the dispatcher prepends it to `PATH`. Default: assumes `g-cli` is already on `PATH`.
+Optional path to the NI g-cli executable. When provided in `args_yaml`, the dispatcher prepends it to `PATH`. Default: assumes `g-cli` is already on `PATH`. The legacy `args_json` field is still supported.
 
 Example:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,37 +13,36 @@ jobs:
         uses: LabVIEW-Community-CI-CD/open-source-actions@v1
         with:
           action_name: build-lvlibp
-          args_json: >
-            {
-              "MinimumSupportedLVVersion": "2019",
-              "SupportedBitness": "32",
-              "RelativePath": ".",
-              "LabVIEW_Project": "MyProject.lvproj",
-              "Build_Spec": "My Build",
-              "Major": 1,
-              "Minor": 0,
-              "Patch": 0,
-              "Build": 123,
-              "Commit": "abcdef"
-            }
+          args_yaml: |
+            MinimumSupportedLVVersion: '2019'
+            SupportedBitness: '32'
+            RelativePath: .
+            LabVIEW_Project: MyProject.lvproj
+            Build_Spec: My Build
+            Major: 1
+            Minor: 0
+            Patch: 0
+            Build: 123
+            Commit: abcdef
 ```
 
-In this step, the composite action invokes the dispatcher to run the **Build** task. The `args_json` contains all parameters the action needs (here, to build a 32-bit LV library). The dispatcher will locate the appropriate script and execute it, failing the step if a problem occurs (non-zero exit).
+In this step, the composite action invokes the dispatcher to run the **Build** task. The `args_yaml` contains all parameters the action needs (here, to build a 32-bit LV library). The dispatcher will locate the appropriate script and execute it, failing the step if a problem occurs (non-zero exit). The legacy `args_json` input remains available.
 3. **Invoke via PowerShell (CLI):** You can also call the dispatcher script directly. For example, the above build can be run in a PowerShell session or script:
 
 ```powershell
-pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -ArgsJson '{
-  "MinimumSupportedLVVersion": "2019",
-  "SupportedBitness": "32",
-  "RelativePath": ".",
-  "LabVIEW_Project": "MyProject.lvproj",
-  "Build_Spec": "My Build",
-  "Major": 1,
-  "Minor": 0,
-  "Patch": 0,
-  "Build": 123,
-  "Commit": "abcdef"
-}'
+$yaml = @'
+MinimumSupportedLVVersion: "2019"
+SupportedBitness: "32"
+RelativePath: .
+LabVIEW_Project: MyProject.lvproj
+Build_Spec: "My Build"
+Major: 1
+Minor: 0
+Patch: 0
+Build: 123
+Commit: abcdef
+'@
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -ArgsYaml (ConvertFrom-Yaml $yaml)
 ```
 
 This will import the **OpenSourceActions** module and run the **Build** adapter. On completion, the script returns with an exit code (0 for success or a non-zero error code). You can include optional flags like `-WorkingDirectory` to change directory before execution, or `-DryRun` to simulate the action (see below). For details on these and other dispatcher flags, see [Common Parameters](common-parameters.md).


### PR DESCRIPTION
## Summary
- allow passing YAML arguments via `args_yaml`
- add `ArgsYaml` to dispatcher and merge with parsed JSON
- document `args_yaml` as preferred format and mark `args_json` legacy

## Testing
- `npm test`
- `pwsh -Command "Invoke-Pester -CI -Path ./tests/pester"`

------
https://chatgpt.com/codex/tasks/task_e_689f56aa16608329ba4ae4177b1511da