### PR TITLE
feat: support args file for dispatcher arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This composite action wraps the dispatcher script [`actions/Invoke-OSAction.ps1`
 | `action_name` | yes | – | Name of the action to execute (e.g. `run-unit-tests`). |
 | `args_yaml` | no | _(none)_ | YAML string of arguments for the selected action. |
 | `args_json` | no | `{}` | **Legacy.** JSON string of arguments for the selected action. |
+| `args_file` | no | _(none)_ | Path to a YAML or JSON file containing arguments. Values from `args_yaml`/`args_json` override file entries. |
 | `working_directory` | no | _(none)_ | Directory where the action runs. Set when your project files are not at the repository root. |
 | `log_level` | no | `INFO` | Verbosity level (`ERROR`, `WARN`, `INFO`, `DEBUG`). Increase to `DEBUG` for troubleshooting. |
 | `dry_run` | no | `false` | Simulate the action without side effects. Helpful for verifying inputs. |
@@ -59,6 +60,38 @@ Enable debug logging and perform a dry run:
     dry_run: true
 ```
 
+Use arguments from a separate YAML file:
+
+```yaml
+# .github/os-action.yml
+MinimumSupportedLVVersion: "2021"
+SupportedBitness: "64"
+
+- name: Run tests with file args
+  uses: LabVIEW-Community-CI-CD/open-source-actions@v1
+  with:
+    action_name: run-unit-tests
+    args_file: .github/os-action.yml
+```
+
+Use a JSON file and override a value inline:
+
+```yaml
+# .github/os-action.json
+{
+  "MinimumSupportedLVVersion": "2021",
+  "SupportedBitness": "32"
+}
+
+- name: Override file args
+  uses: LabVIEW-Community-CI-CD/open-source-actions@v1
+  with:
+    action_name: run-unit-tests
+    args_file: .github/os-action.json
+    args_yaml: |
+      SupportedBitness: '64'
+```
+
 ### Outputs
 
 This action does not emit outputs. Check logs or uploaded artifacts for results.
@@ -73,6 +106,12 @@ MinimumSupportedLVVersion: "2021"
 SupportedBitness: "64"
 '@
 pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsYaml (ConvertFrom-Yaml $yaml)
+```
+
+You can also load arguments from a file:
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsFile ./config/run-tests.yaml
 ```
 
 ### Discovering actions

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,11 @@ inputs:
     required: false
     default: ''
     type: string
+  args_file:
+    description: 'Path to a JSON or YAML file containing arguments for the selected action.'
+    required: false
+    default: ''
+    type: string
   working_directory:
     description: 'Working directory where the action will run.'
     required: false
@@ -50,6 +55,10 @@ runs:
         $params = @{
           ActionName = '${{ inputs.action_name }}'
           LogLevel   = '${{ inputs.log_level }}'
+        }
+
+        if ('${{ inputs.args_file }}' -ne '') {
+          $params['ArgsFile'] = '${{ inputs.args_file }}'
         }
 
         if ($yaml.Trim()) {

--- a/actions/Invoke-OSAction.ps1
+++ b/actions/Invoke-OSAction.ps1
@@ -3,6 +3,7 @@ param(
   [Parameter(Position=0)] [string] $ActionName,
   [Parameter()] [string] $ArgsJson = '{}',
   [Parameter()] [hashtable] $ArgsYaml,
+  [Parameter()] [string] $ArgsFile,
   [Parameter()] [string] $WorkingDirectory,
   [Parameter()] [ValidateSet('ERROR','WARN','INFO','DEBUG')] [string] $LogLevel = 'INFO',
   [switch] $DryRun,
@@ -115,11 +116,37 @@ try {
   if (-not $Registry.Contains($key)) { throw "Unknown ActionName '$ActionName'. Use -ListActions to see options." }
   $funcName = $Registry[$key]
 
-  # Parse ArgsJson → case-insensitive hashtable
+  # Parse ArgsFile/ArgsJson/ArgsYaml → case-insensitive hashtable
   $argsHash = @{}
+  if ($ArgsFile) {
+    if (-not (Test-Path $ArgsFile)) { throw "ArgsFile '$ArgsFile' not found" }
+    $ext = [System.IO.Path]::GetExtension($ArgsFile).ToLowerInvariant()
+    $content = Get-Content -Path $ArgsFile -Raw
+    try {
+      switch ($ext) {
+        '.json' {
+          $fileArgs = ConvertFrom-Json -InputObject $content -AsHashtable -ErrorAction Stop
+        }
+        '.yaml' {
+          $fileArgs = ConvertFrom-Yaml -Yaml $content -ErrorAction Stop | ConvertTo-Json -Depth 32 | ConvertFrom-Json -AsHashtable
+        }
+        '.yml' {
+          $fileArgs = ConvertFrom-Yaml -Yaml $content -ErrorAction Stop | ConvertTo-Json -Depth 32 | ConvertFrom-Json -AsHashtable
+        }
+        default {
+          throw "Unsupported ArgsFile extension '$ext'. Use .json, .yaml, or .yml."
+        }
+      }
+    }
+    catch {
+      throw "ArgsFile could not be parsed: $($_.Exception.Message)"
+    }
+    foreach ($k in $fileArgs.Keys) { $argsHash[$k] = $fileArgs[$k] }
+  }
+
   if ($ArgsJson -and $ArgsJson.Trim()) {
     try {
-      $argsHash = ConvertFrom-Json -InputObject $ArgsJson -AsHashtable -ErrorAction Stop
+      $jsonHash = ConvertFrom-Json -InputObject $ArgsJson -AsHashtable -ErrorAction Stop
     }
     catch {
       # If parsing fails (commonly due to unescaped Windows backslashes),
@@ -128,13 +155,14 @@ try {
       # each separator.
         $escapedJson = $ArgsJson.Replace('\', '\\')
       try {
-        $argsHash = ConvertFrom-Json -InputObject $escapedJson -AsHashtable -ErrorAction Stop
+        $jsonHash = ConvertFrom-Json -InputObject $escapedJson -AsHashtable -ErrorAction Stop
         Write-Warning 'ArgsJson contained unescaped backslashes. They were automatically escaped.'
       }
       catch {
         throw "ArgsJson is not valid JSON: $($_.Exception.Message)"
       }
     }
+    foreach ($k in $jsonHash.Keys) { $argsHash[$k] = $jsonHash[$k] }
   }
   if ($ArgsYaml) {
     foreach ($k in $ArgsYaml.Keys) {

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -45,6 +45,19 @@ Describe 'ArgsJson path handling' {
   }
 }
 
+Describe 'ArgsFile handling' {
+  It 'merges file arguments with inline overrides' {
+    $jsonFile = Join-Path $TestDrive 'args.json'
+    @{ MinimumSupportedLVVersion = '2021'; SupportedBitness = '32' } | ConvertTo-Json -Compress | Set-Content -Path $jsonFile
+
+    $override = @{ SupportedBitness = '64' }
+
+    $out = & $global:dispatcher -ActionName close-labview -ArgsFile $jsonFile -ArgsYaml $override -DryRun *>&1 | Out-String
+    $LASTEXITCODE | Should -Be 0
+    $out | Should -Match '"SupportedBitness":"64"'
+  }
+}
+
 
 Describe 'Filter-Args helper' {
   It 'returns UnknownParams when requested' {


### PR DESCRIPTION
## Summary
- allow passing an `args_file` to composite action and dispatcher
- merge file-based args with inline `args_json`/`args_yaml`, preferring inline overrides
- document file-based configuration and add regression test

## Testing
- `npm test`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_689f5b0d1f9c8329992fdcc4ad433a37