### PR TITLE
docs: clarify composite action path for deploy-docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,4 +8,6 @@
 
 ## Development Notes
 - Composite actions live at the repository root (e.g., `run-unit-tests/action.yml`) and dispatch to scripts in `actions/`.
+- When referencing these composite actions in workflows, use their root-level path (for example, `./setup-mkdocs`).
+  Prefixing with `actions/` (such as `./actions/setup-mkdocs`) will fail to resolve the action and can break jobs like `deploy-docs`.
 - Use a single commit; do not create new branches.


### PR DESCRIPTION
## Summary
- document that composite actions reside at repo root and must be referenced with root-relative paths

## Testing
- `npm test`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f6a8b81a48329aad9ab3ef67c9232