### PR TITLE
Include root-level test files in npm test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "test": "node --loader ts-node/esm --test scripts/**/*.test.js",
+    "test": "node --loader ts-node/esm --test scripts/**/*.test.js scripts/*.test.js",
     "test:ci": "mkdir -p test-results && node --loader ts-node/esm --test --test-reporter=junit --test-reporter-destination test-results/node-junit.xml"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Ensure `npm test` runs test files in both nested and root `scripts` directories

## Testing
- `npm install`
- `npm test`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_689f6dc2245083299f0a445c7cad1916