### PR TITLE
Use local setup-mkdocs action in docs workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
             docs:
               - 'docs/**'
               - 'README.md'
-      - uses: ./actions/setup-mkdocs
+      - uses: ./setup-mkdocs
         if: github.ref == 'refs/heads/actions' && needs.report.result == 'success' && steps.changes.outputs.docs == 'true'
       - run: mkdocs build --strict
         if: github.ref == 'refs/heads/actions' && needs.report.result == 'success' && steps.changes.outputs.docs == 'true'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./actions/setup-mkdocs
+      - uses: ./setup-mkdocs
       - run: mkdocs build --strict
 
   deploy-docs:
@@ -30,7 +30,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
-      - uses: ./actions/setup-mkdocs
+      - uses: ./setup-mkdocs
       - run: mkdocs build --strict
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- use root-level setup-mkdocs action in deploy-docs workflow
- reference same local action in CI deploy-docs step

## Testing
- `npm install`
- `npm test`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_689f71f87c9483298eb6a079277dd19a