### PR TITLE
ci: add paths filter for docs deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,37 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [actions]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    concurrency:
+      group: pages
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - 'README.md'
+      - uses: ./setup-mkdocs
+        if: steps.changes.outputs.docs == 'true'
+      - run: mkdocs build --strict
+        if: steps.changes.outputs.docs == 'true'
+      - uses: actions/upload-pages-artifact@v3
+        if: steps.changes.outputs.docs == 'true'
+        with:
+          path: site
+      - uses: actions/deploy-pages@v4
+        if: steps.changes.outputs.docs == 'true'


### PR DESCRIPTION
## Summary
- add docs deployment workflow with path filter

## Testing
- `npm install`
- `npm test`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_689f76ac07308329b5a9d930f05fe506