### PR TITLE
feat: derive registry deterministically

### DIFF
--- a/scripts/derive-dispatcher-registry.ts
+++ b/scripts/derive-dispatcher-registry.ts
@@ -30,8 +30,11 @@ function parseParams(block: string): Record<string, ParamInfo> {
     const defVal = defMatch ? defMatch[1].trim().replace(/^['"]|['"]$/g,'') : undefined;
     params[name] = { type, required, default: defVal, description: '' };
   }
+  const collator = new Intl.Collator('en');
   const sorted: Record<string, ParamInfo> = {};
-  for (const k of Object.keys(params).sort()) sorted[k] = params[k];
+  for (const [k, v] of Object.entries(params).sort((a, b) => collator.compare(a[0], b[0]))) {
+    sorted[k] = v;
+  }
   return sorted;
 }
 
@@ -61,8 +64,9 @@ async function main() {
       registry[fn] = { description, parameters: parseParams(paramsBlock) };
     }
   }
+  const collator = new Intl.Collator('en');
   const sorted: Record<string, FuncInfo> = {};
-  for (const fn of Object.keys(registry).sort()) sorted[fn] = registry[fn];
+  for (const fn of Object.keys(registry).sort(collator.compare)) sorted[fn] = registry[fn];
   await fs.writeFile('dispatchers.json', JSON.stringify(sorted, null, 2));
 }
 

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -281,7 +281,8 @@ async function main() {
   const matrixMd = groupToMarkdown(groups, tests.length > 100 ? 100 : undefined);
   const summary = `${summaryLines.join('\n')}` + `\n\n### Test Traceability Matrix\n\n${matrixMd}`;
 
-  const wrapperDirs = ['add-token-to-labview','apply-vipc','build-lvlibp','build-vi-package','build','close-labview','generate-release-notes','missing-in-project','modify-vipb-display-info','prepare-labview-source','rename-file','restore-setup-lv-source','revert-development-mode','run-unit-tests','set-development-mode','setup-mkdocs'];
+  const wrapperFiles = await glob('*/action.yml', { nodir: true });
+  const wrapperDirs = wrapperFiles.map(f => path.dirname(f)).sort();
   const { docs, markdown } = await generateActionDocs(dispatcherRegistryFile, wrapperDirs);
 
   const actionDocMd = `### Action Documentation\n\n${markdown}`;


### PR DESCRIPTION
## Summary
- ensure dispatcher registry sorts parameters and functions in a deterministic order
- auto-discover wrapper action directories for documentation generation

## Testing
- `npm test`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_689fb04598cc83299db75fdaf4812c88