### PR TITLE
Use glob-based wrapper discovery and drop unused jszip

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "generate:summary": "node --loader ts-node/esm scripts/generate-ci-summary.ts"
   },
   "dependencies": {
-    "glob": "^10.3.10",
-    "jszip": "^3.10.1"
+    "glob": "^10.3.10"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -283,6 +283,7 @@ async function main() {
 
   const wrapperFiles = await glob('*/action.yml', { nodir: true });
   const wrapperDirs = wrapperFiles.map(f => path.dirname(f)).sort();
+  console.log('Discovered wrapper directories:', wrapperDirs.join(', '));
   const { docs, markdown } = await generateActionDocs(dispatcherRegistryFile, wrapperDirs);
 
   const actionDocMd = `### Action Documentation\n\n${markdown}`;


### PR DESCRIPTION
## Summary
- log dynamically discovered wrapper action directories in CI summary generator
- remove unused jszip dependency

## Testing
- `npm install`
- `npm test`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_689fb8db991883299531071a02f98c99