### PR TITLE
Remove unused LogLevel parameters from adapters

### DIFF
--- a/actions/Invoke-OSAction.ps1
+++ b/actions/Invoke-OSAction.ps1
@@ -170,8 +170,7 @@ try {
     }
   }
 
-  if ($DryRun)   { $argsHash['DryRun']   = $true }
-  if ($LogLevel) { $argsHash['LogLevel'] = $LogLevel }
+  if ($DryRun) { $argsHash['DryRun'] = $true }
 
   Set-LogLevel -Level $LogLevel
 

--- a/actions/OpenSourceActions.psm1
+++ b/actions/OpenSourceActions.psm1
@@ -4,7 +4,6 @@ function InvokeAddTokenToLabVIEW {
         [Parameter(Mandatory)] [string] $MinimumSupportedLVVersion,
         [Parameter(Mandatory)] [string] $SupportedBitness,
         [Parameter(Mandatory)] [string] $RelativePath,
-        [Parameter()] [string] $LogLevel = 'INFO',
         [Parameter()] [switch] $DryRun,
         [Parameter()] [string] $gcliPath
     )
@@ -35,7 +34,6 @@ function InvokeApplyVIPC {
         [Parameter(Mandatory)] [string] $SupportedBitness,
         [Parameter(Mandatory)] [string] $RelativePath,
         [Parameter()] [string] $VIPCPath,
-        [Parameter()] [string] $LogLevel = 'INFO',
         [Parameter()] [switch] $DryRun,
         [Parameter()] [string] $gcliPath
     )
@@ -75,7 +73,6 @@ function InvokeBuildViPackage {
         [Parameter(Mandatory)] [string] $Commit,
         [Parameter(Mandatory)] [string] $DisplayInformationJSON,
         [Parameter()] [string] $ReleaseNotesFile,
-        [Parameter()] [string] $LogLevel = 'INFO',
         [Parameter()] [switch] $DryRun,
         [Parameter()] [string] $gcliPath
     )
@@ -119,7 +116,6 @@ function InvokeBuild {
         [Parameter(Mandatory)] [string] $LabVIEWMinorRevision,
         [Parameter(Mandatory)] [string] $CompanyName,
         [Parameter(Mandatory)] [string] $AuthorName,
-        [Parameter()] [string] $LogLevel = 'INFO',
         [Parameter()] [switch] $DryRun,
         [Parameter()] [string] $gcliPath
     )
@@ -161,7 +157,6 @@ function InvokeBuildLvlibp {
         [Parameter(Mandatory)] [int] $Patch,
         [Parameter(Mandatory)] [int] $Build,
         [Parameter(Mandatory)] [string] $Commit,
-        [Parameter()] [string] $LogLevel = 'INFO',
         [Parameter()] [switch] $DryRun,
         [Parameter()] [string] $gcliPath
     )
@@ -196,7 +191,6 @@ function InvokeCloseLabVIEW {
     param(
         [Parameter(Mandatory)][Alias('minimum_supported_lv_version')] [string] $MinimumSupportedLVVersion,
         [Parameter(Mandatory)][Alias('supported_bitness')]          [string] $SupportedBitness,
-        [Parameter()] [string] $LogLevel = 'INFO',
         [Parameter()] [switch] $DryRun,
         [Parameter()] [string] $gcliPath
     )
@@ -222,7 +216,6 @@ function InvokeGenerateReleaseNotes {
     [CmdletBinding()]
     param(
         [Parameter()] [string] $OutputPath = 'Tooling/deployment/release_notes.md',
-        [Parameter()] [string] $LogLevel = 'INFO',
         [Parameter()] [switch] $DryRun,
         [Parameter()] [string] $gcliPath
     )
@@ -247,7 +240,6 @@ function InvokeMissingInProject {
         [Parameter(Mandatory)] [string] $LVVersion,
         [Parameter(Mandatory)] [string] $Arch,
         [Parameter(Mandatory)] [string] $ProjectFile,
-        [Parameter()] [string] $LogLevel = 'INFO',
         [Parameter()] [switch] $DryRun,
         [Parameter()] [string] $gcliPath
     )
@@ -285,7 +277,6 @@ function InvokeModifyVIPBDisplayInfo {
         [Parameter(Mandatory)] [string] $Commit,
         [Parameter(Mandatory)] [string] $DisplayInformationJSON,
         [Parameter()] [string] $ReleaseNotesFile,
-        [Parameter()] [string] $LogLevel = 'INFO',
         [Parameter()] [switch] $DryRun,
         [Parameter()] [string] $gcliPath
     )
@@ -325,7 +316,6 @@ function InvokePrepareLabVIEWSource {
         [Parameter(Mandatory)] [string] $RelativePath,
         [Parameter(Mandatory)] [string] $LabVIEW_Project,
         [Parameter(Mandatory)] [string] $Build_Spec,
-        [Parameter()] [string] $LogLevel = 'INFO',
         [Parameter()] [switch] $DryRun,
         [Parameter()] [string] $gcliPath
     )
@@ -355,7 +345,6 @@ function InvokeRenameFile {
     param(
         [Parameter(Mandatory)] [string] $CurrentFilename,
         [Parameter(Mandatory)] [string] $NewFilename,
-        [Parameter()] [string] $LogLevel = 'INFO',
         [Parameter()] [switch] $DryRun,
         [Parameter()] [string] $gcliPath
     )
@@ -385,7 +374,6 @@ function InvokeRestoreSetupLVSource {
         [Parameter(Mandatory)] [string] $RelativePath,
         [Parameter(Mandatory)] [string] $LabVIEW_Project,
         [Parameter(Mandatory)] [string] $Build_Spec,
-        [Parameter()] [string] $LogLevel = 'INFO',
         [Parameter()] [switch] $DryRun,
         [Parameter()] [string] $gcliPath
     )
@@ -414,7 +402,6 @@ function InvokeRevertDevelopmentMode {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)] [string] $RelativePath,
-        [Parameter()] [string] $LogLevel = 'INFO',
         [Parameter()] [switch] $DryRun,
         [Parameter()] [string] $gcliPath
     )
@@ -438,7 +425,6 @@ function InvokeRunUnitTests {
     param(
         [Parameter(Mandatory)] [string] $MinimumSupportedLVVersion,
         [Parameter(Mandatory)] [string] $SupportedBitness,
-        [Parameter()] [string] $LogLevel = 'INFO',
         [Parameter()] [switch] $DryRun,
         [Parameter()] [string] $gcliPath
     )
@@ -464,7 +450,6 @@ function InvokeSetDevelopmentMode {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)] [string] $RelativePath,
-        [Parameter()] [string] $LogLevel = 'INFO',
         [Parameter()] [switch] $DryRun,
         [Parameter()] [string] $gcliPath
     )

--- a/docs/adapter-authoring.md
+++ b/docs/adapter-authoring.md
@@ -35,7 +35,6 @@ function InvokeMyNewAction {
         [Parameter(Mandatory)] [string] $Param1,
         [Parameter(Mandatory)] [int] $Param2,
         [Parameter()] [string] $OptionalParam = "default",
-        [Parameter()] [string] $LogLevel = 'INFO',
         [switch] $DryRun
     )
     Write-Information "Invoking MyNewAction with Param1=$Param1 ..." -InformationAction Continue
@@ -72,7 +71,7 @@ $registry = @{
 
 ## Logging and Verbosity
 
-Use `Write-Information` for normal logs and `Write-Verbose` for debug details. Respect the `-LogLevel` parameter set by the dispatcher.
+Use `Write-Information` for normal logs and `Write-Verbose` for debug details. The dispatcher’s `-LogLevel` parameter sets verbosity before your adapter runs.
 
 ## DryRun Considerations
 


### PR DESCRIPTION
## Summary
- drop unused `LogLevel` parameter from all adapter functions
- stop forwarding `LogLevel` to adapter scripts
- update adapter authoring guide to reflect logging changes

## Testing
- `npm install`
- `npm test`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_689fc00d9dcc8329a6e20596a3594ef2