### PR TITLE
chore: move XML and YAML parsers to runtime deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,15 +11,15 @@
     "generate:summary": "node --loader ts-node/esm scripts/generate-ci-summary.ts"
   },
   "dependencies": {
-    "glob": "^10.3.10"
+    "glob": "^10.3.10",
+    "js-yaml": "^4.1.0",
+    "xml2js": "^0.6.2"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",
     "@types/xml2js": "^0.4.14",
-    "js-yaml": "^4.1.0",
     "ts-node": "^10.9.1",
     "tsx": "^4.7.0",
-    "typescript": "^5.4.0",
-    "xml2js": "^0.6.2"
+    "typescript": "^5.4.0"
   }
 }


### PR DESCRIPTION
## Summary
- move `js-yaml` and `xml2js` from devDependencies to dependencies
- keep XML parser type definitions in dev dependencies

## Testing
- `npm install`
- `npm test`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester -Output Minimal" | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689fc4b8e1ec8329ae7f82a793b12774