### PR TITLE
docs: link to local scripts

### DIFF
--- a/docs/UnifiedDispatcher.md
+++ b/docs/UnifiedDispatcher.md
@@ -2,8 +2,8 @@
 
 This package adds a single, stable entrypoint to run LabVIEW CI/CD scripts.
 
-- **Entry script:** `actions/Invoke-OSAction.ps1`
-- **Module:** `actions/OpenSourceActions.psm1/.psd1`
+- **Entry script:** [actions/Invoke-OSAction.ps1](../actions/Invoke-OSAction.ps1)
+- **Module:** [OpenSourceActions.psm1](../actions/OpenSourceActions.psm1)/[OpenSourceActions.psd1](../actions/OpenSourceActions.psd1)
 - **Adapters included:** See [docs/index.md](index.md#action-reference) for the authoritative list of adapters
 - **Discovery:** `-ListActions` and `-Describe <name>`
 - **Dry run:** `-DryRun` logs the exact call and skips execution

--- a/docs/actions/add-token-to-labview.md
+++ b/docs/actions/add-token-to-labview.md
@@ -45,5 +45,3 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName add-token-to-labview -ArgsJso
 - non‑zero – g-cli error adding token
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
-
-Source: [scripts/add-token-to-labview/](../../scripts/add-token-to-labview/)

--- a/docs/actions/apply-vipc.md
+++ b/docs/actions/apply-vipc.md
@@ -51,5 +51,3 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName apply-vipc -ArgsJson '{
 - `1` – error applying VIPC or invalid input
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
-
-Source: [scripts/apply-vipc/](../../scripts/apply-vipc/)

--- a/docs/actions/build-lvlibp.md
+++ b/docs/actions/build-lvlibp.md
@@ -66,5 +66,3 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -ArgsJson '{
 - `1` – build failed or g-cli error
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
-
-Source: [scripts/build-lvlibp/](../../scripts/build-lvlibp/)

--- a/docs/actions/build-vi-package.md
+++ b/docs/actions/build-vi-package.md
@@ -69,5 +69,3 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-vi-package -ArgsJson '{
 - non‑zero – g-cli or build error
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
-
-Source: [scripts/build-vi-package/](../../scripts/build-vi-package/)

--- a/docs/actions/build.md
+++ b/docs/actions/build.md
@@ -63,5 +63,3 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build -ArgsJson '{
 - non‑zero – build script or g-cli error
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
-
-Source: [scripts/build/](../../scripts/build/)

--- a/docs/actions/close-labview.md
+++ b/docs/actions/close-labview.md
@@ -42,5 +42,3 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName close-labview -ArgsJson '{
 - non‑zero – g-cli error closing LabVIEW
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
-
-Source: [scripts/close-labview/](../../scripts/close-labview/)

--- a/docs/actions/generate-release-notes.md
+++ b/docs/actions/generate-release-notes.md
@@ -39,5 +39,3 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName generate-release-notes -ArgsJ
 - non‑zero – git error generating notes
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
-
-Source: [scripts/generate-release-notes/](../../scripts/generate-release-notes/)

--- a/docs/actions/missing-in-project.md
+++ b/docs/actions/missing-in-project.md
@@ -46,5 +46,3 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName missing-in-project -ArgsJson 
 - `2` – missing files found
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
-
-Source: [scripts/missing-in-project/](../../scripts/missing-in-project/)

--- a/docs/actions/modify-vipb-display-info.md
+++ b/docs/actions/modify-vipb-display-info.md
@@ -69,5 +69,3 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName modify-vipb-display-info -Arg
 - non‑zero – g-cli or build error
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
-
-Source: [scripts/modify-vipb-display-info/](../../scripts/modify-vipb-display-info/)

--- a/docs/actions/prepare-labview-source.md
+++ b/docs/actions/prepare-labview-source.md
@@ -51,5 +51,3 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName prepare-labview-source -ArgsJ
 - non‑zero – g-cli error preparing source
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
-
-Source: [scripts/prepare-labview-source/](../../scripts/prepare-labview-source/)

--- a/docs/actions/rename-file.md
+++ b/docs/actions/rename-file.md
@@ -42,5 +42,3 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName rename-file -ArgsJson '{
 - non‑zero – file not found or rename failed
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
-
-Source: [scripts/rename-file/](../../scripts/rename-file/)

--- a/docs/actions/restore-setup-lv-source.md
+++ b/docs/actions/restore-setup-lv-source.md
@@ -51,5 +51,3 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName restore-setup-lv-source -Args
 - non‑zero – g-cli error restoring setup
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
-
-Source: [scripts/restore-setup-lv-source/](../../scripts/restore-setup-lv-source/)

--- a/docs/actions/revert-development-mode.md
+++ b/docs/actions/revert-development-mode.md
@@ -39,5 +39,3 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName revert-development-mode -Args
 - non‑zero – script or g-cli error
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
-
-Source: [scripts/revert-development-mode/](../../scripts/revert-development-mode/)

--- a/docs/actions/run-unit-tests.md
+++ b/docs/actions/run-unit-tests.md
@@ -44,5 +44,3 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsYaml (Con
 - `3` – g-cli or test run error
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
-
-Source: [scripts/run-unit-tests/](../../scripts/run-unit-tests/)

--- a/docs/actions/set-development-mode.md
+++ b/docs/actions/set-development-mode.md
@@ -39,5 +39,3 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName set-development-mode -ArgsJso
 - non‑zero – script or g-cli error
 
 For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).
-
-Source: [scripts/set-development-mode/](../../scripts/set-development-mode/)

--- a/docs/common-parameters.md
+++ b/docs/common-parameters.md
@@ -1,6 +1,6 @@
 # Common Parameters
 
-Calls to `actions/Invoke-OSAction.ps1` share a core set of flags and environment variables.
+Calls to [actions/Invoke-OSAction.ps1](../actions/Invoke-OSAction.ps1) share a core set of flags and environment variables.
 
 ## Command-line flags
 

--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -4,7 +4,7 @@ To keep documentation consistent and easy to review, please follow these rules w
 
 ## Action documentation
 
-Action documentation lives under [docs/actions/](actions/). Keep these files in sync with their corresponding implementations in [`scripts/`](../scripts).
+Action documentation lives under [docs/actions/](actions/). Keep these files in sync with their corresponding implementations in [scripts/](../scripts).
 
 ## Markdown linting
 


### PR DESCRIPTION
## Summary
- Link documentation directly to repository scripts using relative paths
- Drop obsolete source references from action docs to reduce confusion

## Testing
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"` *(failed: command not found)*
- `apt-get install -y powershell` *(failed: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689fd67b2e0c8329be55c694985012f7