### PR TITLE
Add tag verification to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,8 @@ jobs:
   release:
     needs: tests
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.release_meta.outputs.tag }}
     permissions:
       contents: write
     steps:
@@ -80,4 +82,31 @@ jobs:
           release_name: ${{ steps.release_meta.outputs.tag }}
           draft: false
           prerelease: ${{ steps.release_meta.outputs.prerelease }}
+
+  verify:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: false
+
+      - name: Verify release tag
+        env:
+          TAG: ${{ needs.release.outputs.tag }}
+        run: |
+          if git show-ref --tags --quiet "$TAG"; then
+            echo "Tag $TAG already exists" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          git fetch origin "refs/tags/$TAG:refs/tags/$TAG"
+          count=$(git rev-list --count "$TAG")
+          tag_count=${TAG##*-}
+          if [ "$count" -ne "$tag_count" ]; then
+            echo "Commit count $count does not match tag $TAG" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "Tag $TAG matches commit count $count" >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
## Summary
- verify newly created release tags against commit count
- expose tag name from release job for downstream validation

## Testing
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_689fdeae30e48329b3ddfcd1b2369bb0