### PR TITLE
ci: target ubuntu-24.04 runner

### DIFF
--- a/.github/branch_protection_rules.yml
+++ b/.github/branch_protection_rules.yml
@@ -2,9 +2,9 @@ actions:
   required_status_checks:
     - docs-lint
     - node-tests
-    - dispatcher-tests (ubuntu-latest)
+    - dispatcher-tests (ubuntu-24.04)
     - dispatcher-tests (windows-latest)
-    - dispatcher-dryrun-tests (ubuntu-latest)
+    - dispatcher-dryrun-tests (ubuntu-24.04)
     - dispatcher-dryrun-tests (windows-latest)
-    - scriptpath-tests (ubuntu-latest)
+    - scriptpath-tests (ubuntu-24.04)
     - scriptpath-tests (windows-latest)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   node-ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -50,7 +50,7 @@ jobs:
   ps-ci:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-24.04, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
 
   report:
     needs: [node-ci, ps-ci]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: always()
     steps:
       - uses: actions/checkout@v4

--- a/docs/UnifiedDispatcher.md
+++ b/docs/UnifiedDispatcher.md
@@ -43,7 +43,7 @@ jobs:
   unit-tests:
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest, ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- run CI workflows on the ubuntu-24.04 runner
- update branch protection checks for ubuntu-24.04
- document ubuntu-24.04 in dispatcher examples

## Testing
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_689fe1f6446c83299cbba6b5f0a68079