### PR TITLE
Handle summary write failures

### DIFF
--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -296,12 +296,19 @@ async function main() {
   }
 }
 
-main().catch(async (err) => {
-  const msg = `### Error\n\n${err.message}`;
+main().catch(async (err: unknown) => {
+  const msg = `### Error\n\n${err instanceof Error ? err.message : String(err)}`;
   if (process.env.GITHUB_STEP_SUMMARY) {
-    await fs.appendFile(process.env.GITHUB_STEP_SUMMARY, msg + '\n');
+    try {
+      await fs.appendFile(process.env.GITHUB_STEP_SUMMARY, msg + '\n');
+    } catch (appendErr: unknown) {
+      console.error(
+        'Failed to append error summary:',
+        appendErr instanceof Error ? appendErr.message : String(appendErr),
+      );
+    }
   }
-  console.error(err);
+  console.error('Error generating CI summary:', err);
   process.exit(1);
 });
 


### PR DESCRIPTION
## Summary
- handle unknown errors and guard summary writes in generate-ci-summary
## Testing
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_689fef4b80708329b59fbce387c6cc0f