### PR TITLE
Add Node version check and document prerequisites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-      - run: npm ci
+      - run: npm run check:node
+      - run: npm install
       - run: npm run test:ci
       - uses: actions/upload-artifact@v4
         if: always()
@@ -97,7 +98,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-      - run: npm ci
+      - run: npm run check:node
+      - run: npm install
       - uses: actions/download-artifact@v4
         with:
           path: ./downloaded

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # AGENTS.md
 
 ## Testing
+- Run `npm run check:node` to verify Node.js satisfies the required version.
 - Run `npm install` to ensure Node dependencies are available.
 - Run `npm test`.
 - Run `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md` to lint Markdown files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,9 @@
 # Contributing
 
-Contributions of all kinds are welcome. Before submitting pull requests, run the JavaScript tests and any available linters.
+Contributions of all kinds are welcome. Ensure you have Node.js 24 or newer installed, then run `npm install` to set up dependencies. Before submitting pull requests, run the JavaScript tests and any available linters.
 
 ```bash
+npm install
 npm test
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ For setup and action reference, see the [documentation](docs/index.md). The [qui
 
 ## Prerequisites
 
+- Node.js 24+ (run `npm install` after cloning to fetch ts-node and other dependencies)
 - PowerShell 7+ (`pwsh`)
 - NI LabVIEW with command-line interface support (g-cli) for LabVIEW-based actions
 - Supported platforms: Windows for LabVIEW tasks; PowerShell-only scripts also run on macOS and Linux
@@ -91,6 +92,7 @@ pwsh actions/Invoke-OSAction.ps1 -Describe run-unit-tests
 Run the JavaScript tests with:
 
 ```bash
+npm install
 npm test
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-1. **Install Requirements:** Ensure you have **NI LabVIEW** (with command-line interface support, often via *g-cli*) installed on the target runner. Most actions require LabVIEW and the NI g-cli tool to be available (Windows runners are recommended). Also verify PowerShell 7+ (`pwsh`) is available for cross-platform script execution.
+1. **Install Requirements:** Ensure you have **NI LabVIEW** (with command-line interface support, often via *g-cli*) installed on the target runner. Most actions require LabVIEW and the NI g-cli tool to be available (Windows runners are recommended). Also verify PowerShell 7+ (`pwsh`) is available for cross-platform script execution. Install **Node.js 24+** and run `npm install` to pull in the TypeScript dependencies used by helper scripts.
 2. **Invoke via Composite Action (GitHub):** Use the adapter-specific action in your workflow. For example, to **build a LabVIEW Packed Library**:
 
 ```yaml

--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
     "node": ">=24"
   },
   "scripts": {
+    "check:node": "node scripts/check-node-version.js",
+    "pretest": "npm run check:node",
+    "pretest:ci": "npm run check:node",
+    "prederive:registry": "npm run check:node",
+    "pregenerate:summary": "npm run check:node",
     "test": "node --loader ts-node/esm --test scripts/**/*.test.js scripts/*.test.js",
     "test:ci": "mkdir -p test-results && node --loader ts-node/esm --test --test-reporter=junit --test-reporter-destination test-results/node-junit.xml",
     "derive:registry": "tsx scripts/derive-dispatcher-registry.ts",

--- a/scripts/check-node-version.js
+++ b/scripts/check-node-version.js
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(resolve(__dirname, '../package.json'), 'utf8'));
+const required = pkg.engines?.node ?? '>=0';
+const current = process.versions.node;
+
+const parseMajor = (v) => parseInt(v.replace(/^>=?/, '').split('.')[0], 10);
+const requiredMajor = parseMajor(required);
+const currentMajor = parseInt(current.split('.')[0], 10);
+
+if (Number.isNaN(requiredMajor)) {
+  console.error(`Unsupported Node version range: ${required}`);
+  process.exit(1);
+}
+
+if (currentMajor < requiredMajor) {
+  console.error(`Node.js ${required} required, but ${current} found.`);
+  process.exit(1);
+}
+
+console.log(`Node.js version ${current} satisfies ${required}.`);


### PR DESCRIPTION
## Summary
- verify Node.js version before running scripts
- install Node dependencies in CI
- document Node 24+ and `npm install` prerequisites

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ff0e47e40832980bf62b04ca578a6