### PR TITLE
Handle non-Error throws in CI summary

### DIFF
--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -1,6 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { writeErrorSummary } from '../error-handler.ts';
 
 const fileUrl = new URL('../generate-ci-summary.ts', import.meta.url);
 
@@ -9,4 +11,18 @@ test('generate-ci-summary features', async () => {
   assert.match(content, /TEST_RESULTS_GLOBS/);
   assert.match(content, /<redacted>/);
   assert.match(content, /<details><summary>/);
+});
+
+test('writes useful summary for non-Error throws', async () => {
+  const tmp = new URL('./tmp-summary.md', import.meta.url);
+  await fs.rm(tmp, { force: true });
+  process.env.GITHUB_STEP_SUMMARY = fileURLToPath(tmp);
+  const err = Object.create(null);
+  err.message = 'boom';
+  await writeErrorSummary(err);
+  const summary = await fs.readFile(tmp, 'utf8');
+  assert.match(summary, /boom/);
+  assert.doesNotMatch(summary, /\[Object: null prototype\]/);
+  delete process.env.GITHUB_STEP_SUMMARY;
+  await fs.rm(tmp, { force: true });
 });

--- a/scripts/error-handler.ts
+++ b/scripts/error-handler.ts
@@ -1,0 +1,36 @@
+import fs from 'fs/promises';
+
+export function formatError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.stack ?? err.message;
+  }
+  if (err && typeof err === 'object') {
+    const stack = (err as any).stack;
+    if (typeof stack === 'string' && stack) return stack;
+    try {
+      return JSON.stringify(err);
+    } catch {
+      // ignore
+    }
+  }
+  try {
+    return String(err);
+  } catch {
+    return 'Unknown error';
+  }
+}
+
+export async function writeErrorSummary(err: unknown): Promise<void> {
+  const msg = `### Error\n\n${formatError(err)}`;
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    try {
+      await fs.appendFile(process.env.GITHUB_STEP_SUMMARY, msg + '\n');
+    } catch (appendErr: unknown) {
+      console.error(
+        'Failed to append error summary:',
+        appendErr instanceof Error ? appendErr.message : String(appendErr),
+      );
+    }
+  }
+  console.error('Error generating CI summary:', err);
+}

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -5,6 +5,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import { glob } from 'glob';
 import { parseStringPromise } from 'xml2js';
 import yaml from 'js-yaml';
+import { writeErrorSummary } from './error-handler';
 
 interface TestCase {
   id: string;
@@ -296,19 +297,10 @@ async function main() {
   }
 }
 
-main().catch(async (err: unknown) => {
-  const msg = `### Error\n\n${err instanceof Error ? err.message : String(err)}`;
-  if (process.env.GITHUB_STEP_SUMMARY) {
-    try {
-      await fs.appendFile(process.env.GITHUB_STEP_SUMMARY, msg + '\n');
-    } catch (appendErr: unknown) {
-      console.error(
-        'Failed to append error summary:',
-        appendErr instanceof Error ? appendErr.message : String(appendErr),
-      );
-    }
-  }
-  console.error('Error generating CI summary:', err);
-  process.exit(1);
-});
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main().catch(async (err: unknown) => {
+    await writeErrorSummary(err);
+    process.exit(1);
+  });
+}
 


### PR DESCRIPTION
## Summary
- Gracefully format non-Error values and include stack traces in CI summary error handler
- Ensure generate-ci-summary only runs when executed directly and delegates error handling
- Test non-Error throw to verify readable summary output

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"` *(fails: command not found, attempted installation)*

------
https://chatgpt.com/codex/tasks/task_e_689ff2f6fbb48329a627d0afcb0bea07