### PR TITLE
Handle missing JUnit results gracefully

### DIFF
--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -258,9 +258,12 @@ async function main() {
     const single = process.env.TEST_RESULTS_GLOB || '**/junit*.xml';
     junitFiles = await glob(single, { nodir: true });
   }
-  if (junitFiles.length === 0) throw new Error('No JUnit files found');
-
-  const tests = await collectTestCases(junitFiles, evidenceDir);
+  let tests: TestCase[] = [];
+  if (junitFiles.length === 0) {
+    console.warn('No JUnit files found; writing empty summary.');
+  } else {
+    tests = await collectTestCases(junitFiles, evidenceDir);
+  }
   const { map, meta } = await loadRequirements(mappingFile);
   const groups = mapToRequirements(tests, map, meta);
   const totals = buildSummary(groups);


### PR DESCRIPTION
## Summary
- avoid throwing an error when JUnit files are missing
- log a warning and produce an empty summary

## Testing
- `npm run check:node` (fails: Node.js >=24 required, but 20.19.4 found)
- `npm install`
- `npm test` (fails: Node.js >=24 required, but 20.19.4 found)
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_689ffb77cd6c83299a4c58c7e77c925c