### PR TITLE
Map JUnit class names to requirements

### DIFF
--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -1,7 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
 import { fileURLToPath } from 'node:url';
+import { collectTestCases, loadRequirements, mapToRequirements } from '../generate-ci-summary.ts';
 import { writeErrorSummary } from '../error-handler.ts';
 
 const fileUrl = new URL('../generate-ci-summary.ts', import.meta.url);
@@ -25,4 +28,18 @@ test('writes useful summary for non-Error throws', async () => {
   assert.doesNotMatch(summary, /\[Object: null prototype\]/);
   delete process.env.GITHUB_STEP_SUMMARY;
   await fs.rm(tmp, { force: true });
+});
+
+test('associates classname with requirement', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'junit-'));
+  const xml = `<testsuite><testcase classname="Dispatcher.Tests" name="sample" time="0.1"/></testsuite>`;
+  const xmlPath = path.join(dir, 'junit.xml');
+  await fs.writeFile(xmlPath, xml);
+  const tests = await collectTestCases([xmlPath], dir);
+  const reqPath = fileURLToPath(new URL('../../requirements.json', import.meta.url));
+  const { map, meta } = await loadRequirements(reqPath);
+  const groups = mapToRequirements(tests, map, meta);
+  const req = groups.find((g) => g.id === 'REQ-001');
+  assert(req && req.tests.some((t) => t.className === 'Dispatcher.Tests'));
+  await fs.rm(dir, { recursive: true, force: true });
 });

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -10,6 +10,7 @@ import { writeErrorSummary } from './error-handler';
 interface TestCase {
   id: string;
   name: string;
+  className?: string;
   status: 'Passed' | 'Failed' | 'Skipped';
   duration: number;
   owner?: string;
@@ -32,7 +33,7 @@ function redact(text: string): string {
   return text.replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+/g, '<redacted>');
 }
 
-async function loadRequirements(mappingFile: string) {
+export async function loadRequirements(mappingFile: string) {
   try {
     const raw = await fs.readFile(mappingFile, 'utf8');
     const parsed = JSON.parse(raw);
@@ -56,7 +57,7 @@ async function loadRequirements(mappingFile: string) {
   }
 }
 
-async function collectTestCases(files: string[], evidenceDir: string): Promise<TestCase[]> {
+export async function collectTestCases(files: string[], evidenceDir: string): Promise<TestCase[]> {
   const evidenceFiles = await fs.readdir(evidenceDir).catch(() => []);
   const tests: TestCase[] = [];
   const statusMap: Record<string, 'Passed' | 'Failed' | 'Skipped'> = {
@@ -78,12 +79,13 @@ async function collectTestCases(files: string[], evidenceDir: string): Promise<T
       if (Array.isArray(obj.testcase)) {
         for (const tc of obj.testcase) {
           const name = tc.name?.[0] ?? 'unknown';
+          const className = tc.classname?.[0];
           const id = normalizeTestId(name);
           let status: 'Passed' | 'Failed' | 'Skipped' = 'Passed';
           if (tc.failure || tc.error) status = 'Failed';
           else if (tc.skipped) status = 'Skipped';
           const duration = parseFloat(tc.time?.[0] ?? '0');
-          const test: TestCase = { id, name, status, duration, requirements: [] };
+          const test: TestCase = { id, name, className, status, duration, requirements: [] };
           const evidence = evidenceFiles.find((f) => f.startsWith(id) || f.startsWith(id + '.'));
           if (evidence) test.evidence = path.join('evidence', evidence);
           const ownerMatch = name.match(/\[Owner:([^\]]+)\]/i);
@@ -102,10 +104,12 @@ async function collectTestCases(files: string[], evidenceDir: string): Promise<T
   return tests;
 }
 
-function mapToRequirements(tests: TestCase[], mapping: Record<string, { requirements: string[]; owner?: string }>, meta: Record<string, { description?: string; owner?: string }>): RequirementGroup[] {
+export function mapToRequirements(tests: TestCase[], mapping: Record<string, { requirements: string[]; owner?: string }>, meta: Record<string, { description?: string; owner?: string }>): RequirementGroup[] {
   const groups: Map<string, RequirementGroup> = new Map();
   for (const test of tests) {
-    const mapped = mapping[test.name.toLowerCase()];
+    const mapped =
+      mapping[test.name.toLowerCase()] ||
+      (test.className ? mapping[test.className.toLowerCase()] : undefined);
     const reqs = mapped ? mapped.requirements : test.requirements;
     if (mapped && mapped.owner) test.owner = mapped.owner;
     const targetReqs = reqs.length ? reqs : ['Unmapped'];


### PR DESCRIPTION
## Summary
- capture JUnit `classname` attribute when collecting test cases
- allow requirements mapping to match on test names or class names
- verify suite-level mapping with new unit test

## Testing
- `npm run check:node` *(fails: Node.js >=24 required, found 20.19.4)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required, found 20.19.4)*
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ffca459d88329a975f3f4cb79ef14