### PR TITLE
chore: tag Pester tests with requirements

### DIFF
--- a/tests/pester/Dispatcher.DryRun.Tests.ps1
+++ b/tests/pester/Dispatcher.DryRun.Tests.ps1
@@ -10,7 +10,7 @@ $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
 $global:dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
 Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
 
-Describe 'Unified Dispatcher — DryRun behavior for all actions' {
+Describe 'Unified Dispatcher — DryRun behavior for all actions [REQ-002]' {
   $script:args = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
   $extra = @{
        VIP_LVVersion             = '2021'
@@ -42,14 +42,14 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions' {
     Where-Object { $_ -match '^\s+- ' } |
     ForEach-Object { @{ Action = $_.Trim().Substring(2); ArgsJson = $script:argsJson } }
 
-  It "describes <Action>" -ForEach $actions {
+  It "describes <Action> [REQ-002]" -ForEach $actions {
     param($Action, $ArgsJson)
     Write-Host "Testing $Action with ArgsJson $ArgsJson"
     pwsh -NoProfile -File $global:dispatcher -Describe $Action -ArgsJson $ArgsJson *> $null
     $LASTEXITCODE | Should -Be 0
   }
 
-  It "prints description before dry-run <Action>" -ForEach $actions {
+  It "prints description before dry-run <Action> [REQ-002]" -ForEach $actions {
     param($Action, $ArgsJson)
     Write-Host "Testing $Action with ArgsJson $ArgsJson"
     $describeOut = & $global:dispatcher -Describe $Action -ArgsJson $ArgsJson 6>&1 | Out-String
@@ -58,7 +58,7 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions' {
     $describeOut | Should -Match "$Action parameters:"
   }
 
-  It "dry-runs <Action> and warns on unknown args" -ForEach $actions {
+  It "dry-runs <Action> and warns on unknown args [REQ-002]" -ForEach $actions {
     param($Action, $ArgsJson)
     Write-Host "Testing $Action with ArgsJson $ArgsJson"
     $out = & $global:dispatcher -ActionName $Action -ArgsJson $ArgsJson -DryRun *>&1 | Out-String

--- a/tests/pester/Dispatcher.InvalidPaths.Tests.ps1
+++ b/tests/pester/Dispatcher.InvalidPaths.Tests.ps1
@@ -9,15 +9,15 @@ $repoRoot   = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
 $global:dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
 Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
 
-Describe 'Invalid RelativePath handling' {
-    It 'fails when RelativePath does not exist' {
+Describe 'Invalid RelativePath handling [REQ-005]' {
+    It 'fails when RelativePath does not exist [REQ-005]' {
         $json = @{ RelativePath = 'NoSuchDir' } | ConvertTo-Json -Compress
         $out = pwsh -NonInteractive -NoProfile -File $global:dispatcher -ActionName set-development-mode -ArgsJson $json *>&1 | Out-String
         $LASTEXITCODE | Should -Not -Be 0
         $out | Should -Match 'An unexpected error occurred during script execution'
     }
 
-    It 'fails when RelativePath is missing' {
+    It 'fails when RelativePath is missing [REQ-005]' {
         $out = pwsh -NonInteractive -NoProfile -File $global:dispatcher -ActionName set-development-mode -ArgsJson '{}' *>&1 | Out-String
         $LASTEXITCODE | Should -Not -Be 0
         $out | Should -Match 'missing mandatory'

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -11,8 +11,8 @@ $global:dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
 Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
 
 
-Describe 'Unified Dispatcher — discovery and validation' {
-  It 'lists available actions' {
+Describe 'Unified Dispatcher — discovery and validation [REQ-001]' {
+  It 'lists available actions [REQ-001]' {
     $json = Get-LabVIEWIconEditorArgsJson
     $out = pwsh -NoProfile -File $global:dispatcher -ListActions -ArgsJson $json | Out-String
     $out | Should -Match 'apply-vipc'
@@ -20,7 +20,7 @@ Describe 'Unified Dispatcher — discovery and validation' {
     $out | Should -Match 'missing-in-project'
     $out | Should -Match 'run-unit-tests'
   }
-  It 'describes a known action (build-lvlibp)' {
+  It 'describes a known action (build-lvlibp) [REQ-001]' {
     $json = Get-LabVIEWIconEditorArgsJson
     $out = pwsh -NoProfile -File $global:dispatcher -Describe build-lvlibp -ArgsJson $json | Out-String
     $out | Should -Match 'Major'
@@ -30,23 +30,23 @@ Describe 'Unified Dispatcher — discovery and validation' {
     $out | Should -Match 'Commit'
   }
 
-  It 'fails gracefully on unknown action' {
+  It 'fails gracefully on unknown action [REQ-001]' {
     $json = Get-LabVIEWIconEditorArgsJson
     pwsh -NoProfile -File $global:dispatcher -ActionName no-such-action -ArgsJson $json *>$null
     $LASTEXITCODE | Should -Be 1
   }
 }
 
-Describe 'ArgsJson path handling' {
-  It 'handles Windows paths without manual escaping' {
+Describe 'ArgsJson path handling [REQ-001]' {
+  It 'handles Windows paths without manual escaping [REQ-001]' {
     $json = Get-LabVIEWIconEditorArgsJson
     & $global:dispatcher -ActionName set-development-mode -ArgsJson $json -DryRun *> $null
     $LASTEXITCODE | Should -Be 0
   }
 }
 
-Describe 'ArgsFile handling' {
-  It 'merges file arguments with inline overrides' {
+Describe 'ArgsFile handling [REQ-001]' {
+  It 'merges file arguments with inline overrides [REQ-001]' {
     $jsonFile = Join-Path $TestDrive 'args.json'
     @{ MinimumSupportedLVVersion = '2021'; SupportedBitness = '32' } | ConvertTo-Json -Compress | Set-Content -Path $jsonFile
 
@@ -59,8 +59,8 @@ Describe 'ArgsFile handling' {
 }
 
 
-Describe 'Filter-Args helper' {
-  It 'returns UnknownParams when requested' {
+Describe 'Filter-Args helper [REQ-001]' {
+  It 'returns UnknownParams when requested [REQ-001]' {
     $ast = [System.Management.Automation.Language.Parser]::ParseFile($global:dispatcher, [ref]$null, [ref]$null)
     $funcAst = $ast.Find({ param($a) $a -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $a.Name -eq 'Filter-Args' }, $true)
     Invoke-Expression $funcAst.Extent.Text
@@ -72,8 +72,8 @@ Describe 'Filter-Args helper' {
   }
 }
 
-  Describe 'close-labview parameter aliases' {
-    It 'accepts camelCase args' {
+  Describe 'close-labview parameter aliases [REQ-001]' {
+    It 'accepts camelCase args [REQ-001]' {
       $base = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
       $json = @{
         MinimumSupportedLVVersion = $base.MinimumSupportedLVVersion
@@ -83,7 +83,7 @@ Describe 'Filter-Args helper' {
       $LASTEXITCODE | Should -Be 0
     }
 
-    It 'accepts snake_case args without warnings' {
+    It 'accepts snake_case args without warnings [REQ-001]' {
       $base = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
       $json = @{
         minimum_supported_lv_version = $base.MinimumSupportedLVVersion

--- a/tests/pester/RelativePath.Actions.Tests.ps1
+++ b/tests/pester/RelativePath.Actions.Tests.ps1
@@ -9,8 +9,8 @@ $repoRoot   = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
 $dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
 Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
 
-Describe 'add-token-to-labview resolves RelativePath' {
-    It 'dry-runs without warnings' {
+Describe 'add-token-to-labview resolves RelativePath [REQ-003]' {
+    It 'dry-runs without warnings [REQ-003]' {
         $json = Get-LabVIEWIconEditorArgsJson
         $out = & $dispatcher -ActionName add-token-to-labview -ArgsJson $json -DryRun *>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
@@ -21,8 +21,8 @@ Describe 'add-token-to-labview resolves RelativePath' {
     }
 }
 
-Describe 'apply-vipc resolves RelativePath' {
-    It 'dry-runs without warnings' {
+Describe 'apply-vipc resolves RelativePath [REQ-003]' {
+    It 'dry-runs without warnings [REQ-003]' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ MinimumSupportedLVVersion = $b.MinimumSupportedLVVersion; SupportedBitness = $b.SupportedBitness; RelativePath = $b.RelativePath; VIP_LVVersion = '2021'; VIPCPath = 'dummy.vipc' } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName apply-vipc -ArgsJson $args -DryRun *>&1 | Out-String
@@ -34,8 +34,8 @@ Describe 'apply-vipc resolves RelativePath' {
     }
 }
 
-Describe 'build-vi-package resolves RelativePath' {
-    It 'dry-runs without warnings' {
+Describe 'build-vi-package resolves RelativePath [REQ-003]' {
+    It 'dry-runs without warnings [REQ-003]' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ MinimumSupportedLVVersion=$b.MinimumSupportedLVVersion; SupportedBitness=$b.SupportedBitness; LabVIEWMinorRevision='2021'; RelativePath=$b.RelativePath; VIPBPath='dummy.vipb'; Major=1; Minor=0; Patch=0; Build=1; Commit='deadbeef'; DisplayInformationJSON='{}'; ReleaseNotesFile='notes.md' } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName build-vi-package -ArgsJson $args -DryRun *>&1 | Out-String
@@ -47,8 +47,8 @@ Describe 'build-vi-package resolves RelativePath' {
     }
 }
 
-Describe 'build resolves RelativePath' {
-    It 'dry-runs without warnings' {
+Describe 'build resolves RelativePath [REQ-003]' {
+    It 'dry-runs without warnings [REQ-003]' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ RelativePath=$b.RelativePath; Major=1; Minor=0; Patch=0; Build=1; Commit='deadbeef'; LabVIEWMinorRevision='2021'; CompanyName='Company'; AuthorName='Author' } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName build -ArgsJson $args -DryRun *>&1 | Out-String
@@ -60,8 +60,8 @@ Describe 'build resolves RelativePath' {
     }
 }
 
-Describe 'build-lvlibp resolves RelativePath' {
-    It 'dry-runs without warnings' {
+Describe 'build-lvlibp resolves RelativePath [REQ-003]' {
+    It 'dry-runs without warnings [REQ-003]' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ MinimumSupportedLVVersion=$b.MinimumSupportedLVVersion; SupportedBitness=$b.SupportedBitness; RelativePath=$b.RelativePath; LabVIEW_Project='My.lvproj'; Build_Spec='MyBuild'; Major=1; Minor=0; Patch=0; Build=1; Commit='deadbeef' } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName build-lvlibp -ArgsJson $args -DryRun *>&1 | Out-String
@@ -73,8 +73,8 @@ Describe 'build-lvlibp resolves RelativePath' {
     }
 }
 
-Describe 'modify-vipb-display-info resolves RelativePath' {
-    It 'dry-runs without warnings' {
+Describe 'modify-vipb-display-info resolves RelativePath [REQ-003]' {
+    It 'dry-runs without warnings [REQ-003]' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ SupportedBitness=$b.SupportedBitness; RelativePath=$b.RelativePath; VIPBPath='dummy.vipb'; MinimumSupportedLVVersion=$b.MinimumSupportedLVVersion; LabVIEWMinorRevision='2021'; Major=1; Minor=0; Patch=0; Build=1; Commit='deadbeef'; DisplayInformationJSON='{}'; ReleaseNotesFile='notes.md' } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName modify-vipb-display-info -ArgsJson $args -DryRun *>&1 | Out-String
@@ -86,8 +86,8 @@ Describe 'modify-vipb-display-info resolves RelativePath' {
     }
 }
 
-Describe 'prepare-labview-source resolves RelativePath' {
-    It 'dry-runs without warnings' {
+Describe 'prepare-labview-source resolves RelativePath [REQ-003]' {
+    It 'dry-runs without warnings [REQ-003]' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ MinimumSupportedLVVersion=$b.MinimumSupportedLVVersion; SupportedBitness=$b.SupportedBitness; RelativePath=$b.RelativePath; LabVIEW_Project='My.lvproj'; Build_Spec='MyBuild' } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName prepare-labview-source -ArgsJson $args -DryRun *>&1 | Out-String
@@ -99,8 +99,8 @@ Describe 'prepare-labview-source resolves RelativePath' {
     }
 }
 
-Describe 'restore-setup-lv-source resolves RelativePath' {
-    It 'dry-runs without warnings' {
+Describe 'restore-setup-lv-source resolves RelativePath [REQ-003]' {
+    It 'dry-runs without warnings [REQ-003]' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ MinimumSupportedLVVersion=$b.MinimumSupportedLVVersion; SupportedBitness=$b.SupportedBitness; RelativePath=$b.RelativePath; LabVIEW_Project='My.lvproj'; Build_Spec='MyBuild' } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName restore-setup-lv-source -ArgsJson $args -DryRun *>&1 | Out-String
@@ -112,8 +112,8 @@ Describe 'restore-setup-lv-source resolves RelativePath' {
     }
 }
 
-Describe 'revert-development-mode resolves RelativePath' {
-    It 'dry-runs without warnings' {
+Describe 'revert-development-mode resolves RelativePath [REQ-003]' {
+    It 'dry-runs without warnings [REQ-003]' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ RelativePath=$b.RelativePath } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName revert-development-mode -ArgsJson $args -DryRun *>&1 | Out-String
@@ -125,8 +125,8 @@ Describe 'revert-development-mode resolves RelativePath' {
     }
 }
 
-Describe 'set-development-mode resolves RelativePath' {
-    It 'dry-runs without warnings' {
+Describe 'set-development-mode resolves RelativePath [REQ-003]' {
+    It 'dry-runs without warnings [REQ-003]' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ RelativePath=$b.RelativePath } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName set-development-mode -ArgsJson $args -DryRun *>&1 | Out-String

--- a/tests/pester/ScriptPath.Tests.ps1
+++ b/tests/pester/ScriptPath.Tests.ps1
@@ -29,8 +29,8 @@ $cases = foreach ($name in $actionNames) {
     }
 }
 
-Describe 'Action script paths' {
-    It 'has script for <Name>' -TestCases $cases {
+Describe 'Action script paths [REQ-004]' {
+    It 'has script for <Name> [REQ-004]' -TestCases $cases {
         param($Name, $Path)
         Test-Path $Path | Should -BeTrue
     }


### PR DESCRIPTION
## Summary
- append requirement IDs to Pester Describe/It blocks
- verify tags appear in generated JUnit and collectTestCases output

## Testing
- `npm run check:node` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `/tmp/pwsh/pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`
- `/tmp/pwsh/pwsh -NoLogo -Command "Invoke-Pester -OutputFormat JUnitXml -OutputFile junit.xml -Path ./tests/pester"`
- `npx --yes tsx -e "import { collectTestCases } from './scripts/generate-ci-summary.ts'; (async () => { const t = await collectTestCases(['junit.xml'], '.'); console.log(t.filter(tc => tc.requirements.length > 0).slice(0,5)); })();"`


------
https://chatgpt.com/codex/tasks/task_e_689fff5046a48329a18db98dad58592f