### PR TITLE
refactor(ci): centralize summary generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,6 @@ jobs:
           path: test-results/node-junit.xml
           if-no-files-found: error
       - run: npm run derive:registry
-      - run: npm run generate:summary
-        if: always()
-        env:
-          TEST_RESULTS_GLOB: "**/junit*.xml"
-          REQ_MAPPING_FILE: "requirements.json"
-          DISPATCHER_REGISTRY: "dispatchers.json"
-          EVIDENCE_DIR: "test-screenshots"
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -67,9 +60,9 @@ jobs:
         shell: pwsh
         run: |
           if (Test-Path "tests/pester") {
+            $OutDir = Join-Path $env:GITHUB_WORKSPACE 'pester-results'
+            New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
             if ('${{ matrix.os }}' -eq 'windows-latest') {
-              $OutDir = Join-Path $env:GITHUB_WORKSPACE 'pester-results'
-              New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
               Import-Module Pester -MinimumVersion 5.0.0
               $cfg = [PesterConfiguration]::Default
               $cfg.Run.Path = './tests/pester'
@@ -79,11 +72,12 @@ jobs:
               $cfg.TestResult.OutputPath = (Join-Path $OutDir 'pester-junit.xml')
               Invoke-Pester -Configuration $cfg
             } else {
-              Invoke-Pester -CI -Path tests/pester
+              Invoke-Pester -Path tests/pester -PassThru |
+                Export-JunitXml -Path (Join-Path $OutDir 'pester-junit.xml') | Out-Null
             }
           }
       - uses: actions/upload-artifact@v4
-        if: ${{ matrix.os == 'windows-latest' && always() }}
+        if: always()
         with:
           name: pester-junit-${{ matrix.os }}
           path: pester-results/pester-junit.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,19 +62,14 @@ jobs:
           if (Test-Path "tests/pester") {
             $OutDir = Join-Path $env:GITHUB_WORKSPACE 'pester-results'
             New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
-            if ('${{ matrix.os }}' -eq 'windows-latest') {
-              Import-Module Pester -MinimumVersion 5.0.0
-              $cfg = [PesterConfiguration]::Default
-              $cfg.Run.Path = './tests/pester'
-              $cfg.Run.Exit = $true
-              $cfg.TestResult.Enabled = $true
-              $cfg.TestResult.OutputFormat = 'JUnitXml'
-              $cfg.TestResult.OutputPath = (Join-Path $OutDir 'pester-junit.xml')
-              Invoke-Pester -Configuration $cfg
-            } else {
-              Invoke-Pester -Path tests/pester -PassThru |
-                Export-JunitXml -Path (Join-Path $OutDir 'pester-junit.xml') | Out-Null
-            }
+            Import-Module Pester -MinimumVersion 5.0.0
+            $cfg = [PesterConfiguration]::Default
+            $cfg.Run.Path = './tests/pester'
+            $cfg.Run.Exit = $true
+            $cfg.TestResult.Enabled = $true
+            $cfg.TestResult.OutputFormat = 'JUnitXml'
+            $cfg.TestResult.OutputPath = (Join-Path $OutDir 'pester-junit.xml')
+            Invoke-Pester -Configuration $cfg
           }
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
## Summary
- stop generating job summaries in node-ci
- output Pester results to JUnit XML without touching step summary
- ensure report job consolidates all JUnit results into one summary

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a00456d12483299916714878dd9098