### PR TITLE
Generate traceability summary in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           path: test-results/node-junit.xml
           if-no-files-found: error
       - run: npm run derive:registry
+      - run: npm run generate:summary
       - uses: actions/upload-artifact@v4
         if: always()
         with:


### PR DESCRIPTION
## Summary
- run npm run generate:summary after deriving dispatcher registry

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a012b61dac832987f869cf6b2e7dc9