### PR TITLE
feat: disable CI summary output

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ npm install
 npm test
 ```
 
-For CI, `npm run test:ci` emits a JUnit XML report that [scripts/generate-ci-summary.ts](scripts/generate-ci-summary.ts) parses to build the step summary and requirement traceability files.
+For CI, `npm run test:ci` emits a JUnit XML report that [scripts/generate-ci-summary.ts](scripts/generate-ci-summary.ts) parses to build requirement traceability files.
 
 Pester tests cover the dispatcher and helper modules. See [docs/testing-pester.md](docs/testing-pester.md) for guidelines on using the canonical argument helper and adding new tests. Run them with:
 

--- a/actions/Invoke-OSAction.ps1
+++ b/actions/Invoke-OSAction.ps1
@@ -58,18 +58,11 @@ function Show-Description([string]$Name) {
   $cmd = Get-Command $funcName -ErrorAction Stop
 
   $consoleLines = @("$key parameters:")
-  $summaryLines = @("### $key parameters")
   foreach ($p in $cmd.Parameters.Values) {
     $consoleLines += " - $($p.Name): $($p.ParameterType.Name)"
-    $summaryLines += "- ``$($p.Name)``: ``$($p.ParameterType.Name)``"
   }
 
   $consoleLines | ForEach-Object { Write-Output $_ }
-
-  if ($env:GITHUB_STEP_SUMMARY) {
-    $summary = ($summaryLines -join [Environment]::NewLine) + [Environment]::NewLine
-    Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $summary
-  }
 }
 
 function Filter-Args([hashtable]$InputArgs, [string]$FuncName, [string]$ActionNameForWarn, [switch]$ReturnUnknownParams) {

--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -53,4 +53,4 @@ MkDocs serves the site at <http://127.0.0.1:8000/> by default. The server automa
 
 ## JUnit integration
 
-The CI pipeline collects JUnit XML output from both Node and PowerShell tests. `scripts/generate-ci-summary.ts` parses these files to build the GitHub step summary and requirement traceability report. Use `npm run test:ci` to produce the Node JUnit report when verifying documentation updates.
+The CI pipeline collects JUnit XML output from both Node and PowerShell tests. `scripts/generate-ci-summary.ts` parses these files to build the requirement traceability report. Use `npm run test:ci` to produce the Node JUnit report when verifying documentation updates.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -16,7 +16,6 @@ provides a human‑readable summary for quick reference.
 Each test file is annotated with its corresponding requirement ID to maintain
 traceability between requirements and test coverage.
 
-During CI runs, `scripts/generate-ci-summary.ts` writes a compact step summary
-with overall pass/fail counts, pass rate, and a link to the `traceability.md`
+During CI runs, `scripts/generate-ci-summary.ts` produces the `traceability.md`
 artifact, which contains the full requirement traceability matrix.
 

--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -16,18 +16,16 @@ test('generate-ci-summary features', async () => {
   assert.match(content, /<details><summary>/);
 });
 
-test('writes useful summary for non-Error throws', async () => {
+test('writeErrorSummary skips summary file for non-Error throws', async () => {
   const tmp = new URL('./tmp-summary.md', import.meta.url);
   await fs.rm(tmp, { force: true });
   process.env.GITHUB_STEP_SUMMARY = fileURLToPath(tmp);
   const err = Object.create(null);
   err.message = 'boom';
   await writeErrorSummary(err);
-  const summary = await fs.readFile(tmp, 'utf8');
-  assert.match(summary, /boom/);
-  assert.doesNotMatch(summary, /\[Object: null prototype\]/);
+  const exists = await fs.stat(tmp).then(() => true, () => false);
+  assert.strictEqual(exists, false);
   delete process.env.GITHUB_STEP_SUMMARY;
-  await fs.rm(tmp, { force: true });
 });
 
 test('associates classname with requirement', async () => {

--- a/scripts/error-handler.ts
+++ b/scripts/error-handler.ts
@@ -1,5 +1,3 @@
-import fs from 'fs/promises';
-
 export function formatError(err: unknown): string {
   if (err instanceof Error) {
     return err.stack ?? err.message;
@@ -21,16 +19,5 @@ export function formatError(err: unknown): string {
 }
 
 export async function writeErrorSummary(err: unknown): Promise<void> {
-  const msg = `### Error\n\n${formatError(err)}`;
-  if (process.env.GITHUB_STEP_SUMMARY) {
-    try {
-      await fs.appendFile(process.env.GITHUB_STEP_SUMMARY, msg + '\n');
-    } catch (appendErr: unknown) {
-      console.error(
-        'Failed to append error summary:',
-        appendErr instanceof Error ? appendErr.message : String(appendErr),
-      );
-    }
-  }
-  console.error('Error generating CI summary:', err);
+  console.error(`Error generating CI summary: ${formatError(err)}`);
 }

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -276,18 +276,10 @@ async function main() {
 
   const matrixMd = groupToMarkdown(groups);
 
-  const summaryLines = [`- Passed: ${totals.passed}`, `- Failed: ${totals.failed}`, `- Skipped: ${totals.skipped}`, `- Pass rate: ${totals.rate.toFixed(2)}%`, `- Duration: ${totals.duration.toFixed(3)} s`, `- Commit: ${(process.env.GITHUB_SHA || '').slice(0,7)}`, `- Run ID: ${process.env.GITHUB_RUN_ID || ''}`, `- [Full traceability matrix](traceability.md)`];
-  const summary = `### Summary\n${summaryLines.join('\n')}`;
-
   const wrapperFiles = await glob('*/action.yml', { nodir: true });
   const wrapperDirs = wrapperFiles.map(f => path.dirname(f)).sort();
   console.log('Discovered wrapper directories:', wrapperDirs.join(', '));
   const { docs, markdown } = await generateActionDocs(dispatcherRegistryFile, wrapperDirs);
-
-  const finalSummary = redact(summary);
-  if (process.env.GITHUB_STEP_SUMMARY) {
-    await fs.appendFile(process.env.GITHUB_STEP_SUMMARY, finalSummary + '\n');
-  }
 
   await fs.writeFile(path.join('artifacts','traceability.json'), JSON.stringify({ requirements: groups, totals }, null, 2));
   await fs.writeFile(path.join('artifacts','traceability.md'), redact(`### Test Traceability Matrix\n\n${matrixMd}`));


### PR DESCRIPTION
## Summary
- stop writing GitHub step summaries in CI scripts and PowerShell dispatcher
- update error handler, tests, and documentation for new behavior

## Testing
- `npm run check:node` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"` *(fails: command not found: pwsh)*

------
https://chatgpt.com/codex/tasks/task_e_68a01793fb708329a81c03551442caf2