### PR TITLE
chore: append traceability matrix to summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,7 @@ jobs:
           REQ_MAPPING_FILE: requirements.json
           DISPATCHER_REGISTRY: dispatchers.json
           EVIDENCE_DIR: test-screenshots
+      - name: Print test traceability matrix
+        run: |
+          cat artifacts/traceability.md >> "$GITHUB_STEP_SUMMARY"
+          cat artifacts/traceability.md


### PR DESCRIPTION
## Summary
- append traceability matrix to step summary in CI report

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a01a82e5408329be0c509f22a7f72d