### PR TITLE
Add self-hosted workflow for apply-vipc action

### DIFF
--- a/.github/workflows/apply-vipc-self-hosted.yml
+++ b/.github/workflows/apply-vipc-self-hosted.yml
@@ -1,0 +1,21 @@
+name: Apply VIPC (self-hosted test)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  apply-vipc:
+    runs-on: [self-hosted, self-hosted-windows-lv]
+    strategy:
+      matrix:
+        dry_run: [true, false]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run apply-vipc action (dry_run=${{ matrix.dry_run }})
+        uses: ./apply-vipc/action.yml
+        with:
+          minimum_supported_lv_version: '2020'
+          vip_lv_version: '2020'
+          supported_bitness: '64'
+          relative_path: '.'
+          dry_run: ${{ matrix.dry_run }}

--- a/requirements.json
+++ b/requirements.json
@@ -24,6 +24,91 @@
       "id": "REQ-005",
       "description": "Dispatcher fails when RelativePath is missing or invalid.",
       "tests": ["Dispatcher.InvalidPaths.Tests"]
+    },
+    {
+      "id": "REQ-006",
+      "description": "Workflow tests the composite action defined in apply-vipc/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv with dry_run true.",
+      "tests": ["ApplyVipc.SelfHosted.DryRunTrue.Workflow"]
+    },
+    {
+      "id": "REQ-007",
+      "description": "Workflow tests the composite action defined in apply-vipc/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv with dry_run false.",
+      "tests": ["ApplyVipc.SelfHosted.DryRunFalse.Workflow"]
+    },
+    {
+      "id": "REQ-008",
+      "description": "Workflow tests the composite action defined in add-token-to-labview/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
+      "tests": ["AddTokenToLabview.SelfHosted.Workflow"]
+    },
+    {
+      "id": "REQ-009",
+      "description": "Workflow tests the composite action defined in build/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
+      "tests": ["Build.SelfHosted.Workflow"]
+    },
+    {
+      "id": "REQ-010",
+      "description": "Workflow tests the composite action defined in build-lvlibp/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
+      "tests": ["BuildLvlibp.SelfHosted.Workflow"]
+    },
+    {
+      "id": "REQ-011",
+      "description": "Workflow tests the composite action defined in build-vi-package/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
+      "tests": ["BuildViPackage.SelfHosted.Workflow"]
+    },
+    {
+      "id": "REQ-012",
+      "description": "Workflow tests the composite action defined in close-labview/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
+      "tests": ["CloseLabview.SelfHosted.Workflow"]
+    },
+    {
+      "id": "REQ-013",
+      "description": "Workflow tests the composite action defined in generate-release-notes/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
+      "tests": ["GenerateReleaseNotes.SelfHosted.Workflow"]
+    },
+    {
+      "id": "REQ-014",
+      "description": "Workflow tests the composite action defined in missing-in-project/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
+      "tests": ["MissingInProject.SelfHosted.Workflow"]
+    },
+    {
+      "id": "REQ-015",
+      "description": "Workflow tests the composite action defined in modify-vipb-display-info/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
+      "tests": ["ModifyVipbDisplayInfo.SelfHosted.Workflow"]
+    },
+    {
+      "id": "REQ-016",
+      "description": "Workflow tests the composite action defined in prepare-labview-source/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
+      "tests": ["PrepareLabviewSource.SelfHosted.Workflow"]
+    },
+    {
+      "id": "REQ-017",
+      "description": "Workflow tests the composite action defined in rename-file/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
+      "tests": ["RenameFile.SelfHosted.Workflow"]
+    },
+    {
+      "id": "REQ-018",
+      "description": "Workflow tests the composite action defined in restore-setup-lv-source/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
+      "tests": ["RestoreSetupLvSource.SelfHosted.Workflow"]
+    },
+    {
+      "id": "REQ-019",
+      "description": "Workflow tests the composite action defined in revert-development-mode/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
+      "tests": ["RevertDevelopmentMode.SelfHosted.Workflow"]
+    },
+    {
+      "id": "REQ-020",
+      "description": "Workflow tests the composite action defined in run-unit-tests/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
+      "tests": ["RunUnitTests.SelfHosted.Workflow"]
+    },
+    {
+      "id": "REQ-021",
+      "description": "Workflow tests the composite action defined in set-development-mode/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
+      "tests": ["SetDevelopmentMode.SelfHosted.Workflow"]
+    },
+    {
+      "id": "REQ-022",
+      "description": "Workflow tests the composite action defined in setup-mkdocs/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
+      "tests": ["SetupMkdocs.SelfHosted.Workflow"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- invoke apply-vipc composite action explicitly via apply-vipc/action.yml on self-hosted runner
- record requirements for exercising all composite actions on the self-hosted runner

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a01c7278d88329b525c43c7c5a8b5e