### PR TITLE
chore: check out icon editor for apply-vipc

### DIFF
--- a/.github/workflows/apply-vipc-self-hosted.yml
+++ b/.github/workflows/apply-vipc-self-hosted.yml
@@ -11,11 +11,16 @@ jobs:
         dry_run: [true, false]
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: LabVIEW-Community-CI-CD/labview-icon-editor
+          path: ../../labview-icon-editor/labview-icon-editor
       - name: Run apply-vipc action (dry_run=${{ matrix.dry_run }})
         uses: ./apply-vipc/action.yml
         with:
-          minimum_supported_lv_version: '2020'
-          vip_lv_version: '2020'
+          minimum_supported_lv_version: '2021'
+          vip_lv_version: '2021'
           supported_bitness: '64'
-          relative_path: '.'
+          relative_path: 'C:\actions-runner\_work\labview-icon-editor\labview-icon-editor'
+          vipc_path: 'C:\actions-runner\_work\labview-icon-editor\labview-icon-editor\.github\actions\apply-vipc\runner_dependencies.vipc'
           dry_run: ${{ matrix.dry_run }}

--- a/requirements.json
+++ b/requirements.json
@@ -27,12 +27,12 @@
     },
     {
       "id": "REQ-006",
-      "description": "Workflow tests the composite action defined in apply-vipc/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv with dry_run true.",
+      "description": "Workflow checks out the LabVIEW icon editor repository and tests the composite action defined in apply-vipc/action.yml with minimum_supported_lv_version '2021', vip_lv_version '2021', supported_bitness '64', relative_path 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor', and vipc_path 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\.github\\actions\\apply-vipc\\runner_dependencies.vipc' on a self-hosted Windows runner labeled self-hosted-windows-lv with dry_run true.",
       "tests": ["ApplyVipc.SelfHosted.DryRunTrue.Workflow"]
     },
     {
       "id": "REQ-007",
-      "description": "Workflow tests the composite action defined in apply-vipc/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv with dry_run false.",
+      "description": "Workflow checks out the LabVIEW icon editor repository and tests the composite action defined in apply-vipc/action.yml with minimum_supported_lv_version '2021', vip_lv_version '2021', supported_bitness '64', relative_path 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor', and vipc_path 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\.github\\actions\\apply-vipc\\runner_dependencies.vipc' on a self-hosted Windows runner labeled self-hosted-windows-lv with dry_run false.",
       "tests": ["ApplyVipc.SelfHosted.DryRunFalse.Workflow"]
     },
     {


### PR DESCRIPTION
## Summary
- checkout LabVIEW icon editor repo for apply-vipc workflow
- run apply-vipc with explicit icon editor paths and parameters
- document new behavior in requirements

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a0231e87c483299c2f1fbabdc292f5