### PR TITLE
Add Apply VIPC self-hosted workflow tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
             Remove-Module Pester -ErrorAction SilentlyContinue
             Install-Module -Name Pester -MinimumVersion 5.0.0 -Scope CurrentUser -Force -SkipPublisherCheck
           }
+      - name: Install powershell-yaml
+        shell: pwsh
+        run: Install-Module -Name powershell-yaml -Scope CurrentUser -Force
       - name: Run Pester
         shell: pwsh
         run: |

--- a/tests/pester/ApplyVipc.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/ApplyVipc.SelfHosted.Workflow.Tests.ps1
@@ -1,0 +1,55 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module powershell-yaml
+
+Describe 'ApplyVipc.SelfHosted.DryRunTrue.Workflow [REQ-006]' {
+    It 'runs apply-vipc action with dry_run true [REQ-006]' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $workflowPath = Join-Path $repoRoot '.github/workflows/apply-vipc-self-hosted.yml'
+        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml
+        $job = $wf.jobs.'apply-vipc'
+        $applyStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq './apply-vipc/action.yml' } | Select-Object -First 1
+        $checkoutIconRepoStep = $job.steps | Where-Object { $_.ContainsKey('with') -and $_['with']['repository'] -eq 'LabVIEW-Community-CI-CD/labview-icon-editor' } | Select-Object -First 1
+
+        $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+        $job.strategy.matrix.dry_run | Should -Contain $true
+
+        $checkoutIconRepoStep.uses | Should -Be 'actions/checkout@v4'
+        $checkoutIconRepoStep.with.path | Should -Be '../../labview-icon-editor/labview-icon-editor'
+
+        $applyStep.uses | Should -Be './apply-vipc/action.yml'
+        $applyStep.with.minimum_supported_lv_version | Should -Be '2021'
+        $applyStep.with.vip_lv_version | Should -Be '2021'
+        $applyStep.with.supported_bitness | Should -Be '64'
+        $applyStep.with.relative_path | Should -Be 'C:\actions-runner\_work\labview-icon-editor\labview-icon-editor'
+        $applyStep.with.vipc_path | Should -Be 'C:\actions-runner\_work\labview-icon-editor\labview-icon-editor\.github\actions\apply-vipc\runner_dependencies.vipc'
+        $applyStep.with.dry_run | Should -Be '${{ matrix.dry_run }}'
+    }
+}
+
+Describe 'ApplyVipc.SelfHosted.DryRunFalse.Workflow [REQ-007]' {
+    It 'runs apply-vipc action with dry_run false [REQ-007]' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $workflowPath = Join-Path $repoRoot '.github/workflows/apply-vipc-self-hosted.yml'
+        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml
+        $job = $wf.jobs.'apply-vipc'
+        $applyStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq './apply-vipc/action.yml' } | Select-Object -First 1
+        $checkoutIconRepoStep = $job.steps | Where-Object { $_.ContainsKey('with') -and $_['with']['repository'] -eq 'LabVIEW-Community-CI-CD/labview-icon-editor' } | Select-Object -First 1
+
+        $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+        $job.strategy.matrix.dry_run | Should -Contain $false
+
+        $checkoutIconRepoStep.uses | Should -Be 'actions/checkout@v4'
+        $checkoutIconRepoStep.with.path | Should -Be '../../labview-icon-editor/labview-icon-editor'
+
+        $applyStep.uses | Should -Be './apply-vipc/action.yml'
+        $applyStep.with.minimum_supported_lv_version | Should -Be '2021'
+        $applyStep.with.vip_lv_version | Should -Be '2021'
+        $applyStep.with.supported_bitness | Should -Be '64'
+        $applyStep.with.relative_path | Should -Be 'C:\actions-runner\_work\labview-icon-editor\labview-icon-editor'
+        $applyStep.with.vipc_path | Should -Be 'C:\actions-runner\_work\labview-icon-editor\labview-icon-editor\.github\actions\apply-vipc\runner_dependencies.vipc'
+        $applyStep.with.dry_run | Should -Be '${{ matrix.dry_run }}'
+    }
+}


### PR DESCRIPTION
## Summary
- add Pester tests for Apply VIPC workflow with dry_run true and false

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a0257dacb883299375d2b35d7f114e