### PR TITLE
ci: install powershell-yaml in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
             Remove-Module Pester -ErrorAction SilentlyContinue
             Install-Module -Name Pester -MinimumVersion 5.0.0 -Scope CurrentUser -Force -SkipPublisherCheck
           }
+      - name: Install powershell-yaml
+        shell: pwsh
+        run: Install-Module -Name powershell-yaml -Scope CurrentUser -Force
       - name: Run Pester
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary
- install powershell-yaml before running Pester in CI

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a02c99b71c8329affe1fdea2494120