### PR TITLE
Use self-hosted Windows runner

### DIFF
--- a/.github/branch_protection_rules.yml
+++ b/.github/branch_protection_rules.yml
@@ -3,8 +3,8 @@ actions:
     - docs-lint
     - node-tests
     - dispatcher-tests (ubuntu-24.04)
-    - dispatcher-tests (windows-latest)
+    - dispatcher-tests (self-hosted-windows-lv)
     - dispatcher-dryrun-tests (ubuntu-24.04)
-    - dispatcher-dryrun-tests (windows-latest)
+    - dispatcher-dryrun-tests (self-hosted-windows-lv)
     - scriptpath-tests (ubuntu-24.04)
-    - scriptpath-tests (windows-latest)
+    - scriptpath-tests (self-hosted-windows-lv)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,12 @@ jobs:
   ps-ci:
     strategy:
       matrix:
-        os: [ubuntu-24.04, windows-latest]
-    runs-on: ${{ matrix.os }}
+        include:
+          - os: ubuntu-24.04
+            runs-on: ubuntu-24.04
+          - os: self-hosted-windows-lv
+            runs-on: [self-hosted, self-hosted-windows-lv]
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4
       - name: Install Pester

--- a/docs/UnifiedDispatcher.md
+++ b/docs/UnifiedDispatcher.md
@@ -43,8 +43,12 @@ jobs:
   unit-tests:
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-24.04]
-    runs-on: ${{ matrix.os }}
+        include:
+          - os: ubuntu-24.04
+            runs-on: ubuntu-24.04
+          - os: self-hosted-windows-lv
+            runs-on: [self-hosted, self-hosted-windows-lv]
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./run-unit-tests

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@
 ```yaml
 jobs:
   build_lvlibp:
-    runs-on: windows-latest
+    runs-on: [self-hosted, self-hosted-windows-lv]
     steps:
       - uses: actions/checkout@v3
       - name: Build Packed Library (32-bit)


### PR DESCRIPTION
## Summary
- use self-hosted windows-lv runner for PowerShell tests
- document self-hosted runner usage
- adjust branch protection rules for self-hosted runner

## Testing
- `npm run check:node` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a02f7d30a4832998d5bb19babaa233