### PR TITLE
docs: document GitHub Action inputs

### DIFF
--- a/docs/actions/add-token-to-labview.md
+++ b/docs/actions/add-token-to-labview.md
@@ -28,6 +28,20 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName add-token-to-labview -ArgsJso
 }'
 ```
 
+## GitHub Action inputs
+
+GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
+
+| Input | CLI parameter | Description |
+| --- | --- | --- |
+| `minimum_supported_lv_version` | `MinimumSupportedLVVersion` | Minimum LabVIEW version supported. |
+| `supported_bitness` | `SupportedBitness` | "32" or "64" bitness of LabVIEW. |
+| `relative_path` | `RelativePath` | Relative path containing the token target. |
+| `gcli_path` | `gcliPath` | Optional path to the g-cli executable. |
+| `working_directory` | `WorkingDirectory` | Working directory where the action will run. |
+| `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
+| `dry_run` | `DryRun` | If true, simulate the action without side effects. |
+
 ## GitHub Action example
 
 ```yaml

--- a/docs/actions/apply-vipc.md
+++ b/docs/actions/apply-vipc.md
@@ -32,6 +32,22 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName apply-vipc -ArgsJson '{
 }'
 ```
 
+## GitHub Action inputs
+
+GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
+
+| Input | CLI parameter | Description |
+| --- | --- | --- |
+| `minimum_supported_lv_version` | `MinimumSupportedLVVersion` | Minimum LabVIEW version supported. |
+| `vip_lv_version` | `VIP_LVVersion` | LabVIEW version associated with the VI Package. |
+| `supported_bitness` | `SupportedBitness` | "32" or "64" bitness of LabVIEW. |
+| `relative_path` | `RelativePath` | Relative path containing the LabVIEW project. |
+| `vipc_path` | `VIPCPath` | Path to the VIPC file. |
+| `gcli_path` | `gcliPath` | Optional path to the g-cli executable. |
+| `working_directory` | `WorkingDirectory` | Working directory where the action will run. |
+| `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
+| `dry_run` | `DryRun` | If true, simulate the action without side effects. |
+
 ## GitHub Action example
 
 ```yaml

--- a/docs/actions/build-lvlibp.md
+++ b/docs/actions/build-lvlibp.md
@@ -42,6 +42,27 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -ArgsJson '{
 }'
 ```
 
+## GitHub Action inputs
+
+GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
+
+| Input | CLI parameter | Description |
+| --- | --- | --- |
+| `minimum_supported_lv_version` | `MinimumSupportedLVVersion` | Minimum LabVIEW version supported. |
+| `supported_bitness` | `SupportedBitness` | "32" or "64" bitness of LabVIEW. |
+| `relative_path` | `RelativePath` | Relative path containing the LabVIEW project. |
+| `labview_project` | `LabVIEW_Project` | Path to the LabVIEW project file. |
+| `build_spec` | `Build_Spec` | Name of the build specification. |
+| `major` | `Major` | Major version component. |
+| `minor` | `Minor` | Minor version component. |
+| `patch` | `Patch` | Patch version component. |
+| `build` | `Build` | Build number. |
+| `commit` | `Commit` | Commit identifier. |
+| `gcli_path` | `gcliPath` | Optional path to the g-cli executable. |
+| `working_directory` | `WorkingDirectory` | Working directory where the action will run. |
+| `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
+| `dry_run` | `DryRun` | If true, simulate the action without side effects. |
+
 ## GitHub Action example
 
 ```yaml

--- a/docs/actions/build-vi-package.md
+++ b/docs/actions/build-vi-package.md
@@ -44,6 +44,29 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-vi-package -ArgsJson '{
 }'
 ```
 
+## GitHub Action inputs
+
+GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
+
+| Input | CLI parameter | Description |
+| --- | --- | --- |
+| `minimum_supported_lv_version` | `MinimumSupportedLVVersion` | Minimum LabVIEW version supported. |
+| `supported_bitness` | `SupportedBitness` | "32" or "64" bitness of LabVIEW. |
+| `labview_minor_revision` | `LabVIEWMinorRevision` | LabVIEW minor revision. |
+| `relative_path` | `RelativePath` | Relative path containing the project. |
+| `vipb_path` | `VIPBPath` | Path to the VIPB file. |
+| `major` | `Major` | Major version component. |
+| `minor` | `Minor` | Minor version component. |
+| `patch` | `Patch` | Patch version component. |
+| `build` | `Build` | Build number. |
+| `commit` | `Commit` | Commit identifier. |
+| `display_information_json` | `DisplayInformationJSON` | JSON string of display information. |
+| `release_notes_file` | `ReleaseNotesFile` | Optional path to release notes file. |
+| `gcli_path` | `gcliPath` | Optional path to the g-cli executable. |
+| `working_directory` | `WorkingDirectory` | Working directory where the action will run. |
+| `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
+| `dry_run` | `DryRun` | If true, simulate the action without side effects. |
+
 ## GitHub Action example
 
 ```yaml

--- a/docs/actions/build.md
+++ b/docs/actions/build.md
@@ -40,6 +40,26 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build -ArgsJson '{
 }'
 ```
 
+## GitHub Action inputs
+
+GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
+
+| Input | CLI parameter | Description |
+| --- | --- | --- |
+| `relative_path` | `RelativePath` | Relative path containing the LabVIEW project. |
+| `major` | `Major` | Major version component. |
+| `minor` | `Minor` | Minor version component. |
+| `patch` | `Patch` | Patch version component. |
+| `build` | `Build` | Build number. |
+| `commit` | `Commit` | Commit identifier. |
+| `labview_minor_revision` | `LabVIEWMinorRevision` | LabVIEW minor revision. |
+| `company_name` | `CompanyName` | Company name for the build. |
+| `author_name` | `AuthorName` | Author name for the build. |
+| `gcli_path` | `gcliPath` | Optional path to the g-cli executable. |
+| `working_directory` | `WorkingDirectory` | Working directory where the action will run. |
+| `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
+| `dry_run` | `DryRun` | If true, simulate the action without side effects. |
+
 ## GitHub Action example
 
 ```yaml

--- a/docs/actions/close-labview.md
+++ b/docs/actions/close-labview.md
@@ -26,6 +26,19 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName close-labview -ArgsJson '{
 }'
 ```
 
+## GitHub Action inputs
+
+GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
+
+| Input | CLI parameter | Description |
+| --- | --- | --- |
+| `minimum_supported_lv_version` | `MinimumSupportedLVVersion` | Minimum LabVIEW version supported. |
+| `supported_bitness` | `SupportedBitness` | "32" or "64" bitness of LabVIEW. |
+| `gcli_path` | `gcliPath` | Optional path to the g-cli executable. |
+| `working_directory` | `WorkingDirectory` | Working directory where the action will run. |
+| `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
+| `dry_run` | `DryRun` | If true, simulate the action without side effects. |
+
 ## GitHub Action example
 
 ```yaml

--- a/docs/actions/generate-release-notes.md
+++ b/docs/actions/generate-release-notes.md
@@ -24,6 +24,18 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName generate-release-notes -ArgsJ
 }'
 ```
 
+## GitHub Action inputs
+
+GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
+
+| Input | CLI parameter | Description |
+| --- | --- | --- |
+| `output_path` | `OutputPath` | Path to output markdown file. |
+| `gcli_path` | `gcliPath` | Optional path to the g-cli executable. |
+| `working_directory` | `WorkingDirectory` | Working directory where the action will run. |
+| `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
+| `dry_run` | `DryRun` | If true, simulate the action without side effects. |
+
 ## GitHub Action example
 
 ```yaml

--- a/docs/actions/missing-in-project.md
+++ b/docs/actions/missing-in-project.md
@@ -28,6 +28,20 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName missing-in-project -ArgsJson 
 }'
 ```
 
+## GitHub Action inputs
+
+GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
+
+| Input | CLI parameter | Description |
+| --- | --- | --- |
+| `lv_version` | `LVVersion` | LabVIEW version to use. |
+| `arch` | `Arch` | Target architecture (32 or 64). |
+| `project_file` | `ProjectFile` | Path to the LabVIEW project (.lvproj). |
+| `gcli_path` | `gcliPath` | Optional path to the g-cli executable. |
+| `working_directory` | `WorkingDirectory` | Working directory where the action will run. |
+| `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
+| `dry_run` | `DryRun` | If true, simulate the action without side effects. |
+
 ## GitHub Action example
 
 ```yaml

--- a/docs/actions/modify-vipb-display-info.md
+++ b/docs/actions/modify-vipb-display-info.md
@@ -44,6 +44,29 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName modify-vipb-display-info -Arg
 }'
 ```
 
+## GitHub Action inputs
+
+GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
+
+| Input | CLI parameter | Description |
+| --- | --- | --- |
+| `supported_bitness` | `SupportedBitness` | "32" or "64" bitness of LabVIEW. |
+| `relative_path` | `RelativePath` | Relative path containing the project. |
+| `vipb_path` | `VIPBPath` | Path to the VIPB file. |
+| `minimum_supported_lv_version` | `MinimumSupportedLVVersion` | Minimum LabVIEW version supported. |
+| `labview_minor_revision` | `LabVIEWMinorRevision` | LabVIEW minor revision. |
+| `major` | `Major` | Major version component. |
+| `minor` | `Minor` | Minor version component. |
+| `patch` | `Patch` | Patch version component. |
+| `build` | `Build` | Build number. |
+| `commit` | `Commit` | Commit identifier. |
+| `display_information_json` | `DisplayInformationJSON` | JSON string of display information. |
+| `release_notes_file` | `ReleaseNotesFile` | Optional path to release notes file. |
+| `gcli_path` | `gcliPath` | Optional path to the g-cli executable. |
+| `working_directory` | `WorkingDirectory` | Working directory where the action will run. |
+| `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
+| `dry_run` | `DryRun` | If true, simulate the action without side effects. |
+
 ## GitHub Action example
 
 ```yaml

--- a/docs/actions/prepare-labview-source.md
+++ b/docs/actions/prepare-labview-source.md
@@ -32,6 +32,22 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName prepare-labview-source -ArgsJ
 }'
 ```
 
+## GitHub Action inputs
+
+GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
+
+| Input | CLI parameter | Description |
+| --- | --- | --- |
+| `minimum_supported_lv_version` | `MinimumSupportedLVVersion` | Minimum LabVIEW version supported. |
+| `supported_bitness` | `SupportedBitness` | "32" or "64" bitness of LabVIEW. |
+| `relative_path` | `RelativePath` | Relative path containing the project. |
+| `labview_project` | `LabVIEW_Project` | Path to the LabVIEW project file. |
+| `build_spec` | `Build_Spec` | Name of the build specification. |
+| `gcli_path` | `gcliPath` | Optional path to the g-cli executable. |
+| `working_directory` | `WorkingDirectory` | Working directory where the action will run. |
+| `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
+| `dry_run` | `DryRun` | If true, simulate the action without side effects. |
+
 ## GitHub Action example
 
 ```yaml

--- a/docs/actions/rename-file.md
+++ b/docs/actions/rename-file.md
@@ -26,6 +26,19 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName rename-file -ArgsJson '{
 }'
 ```
 
+## GitHub Action inputs
+
+GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
+
+| Input | CLI parameter | Description |
+| --- | --- | --- |
+| `current_filename` | `CurrentFilename` | Existing file name. |
+| `new_filename` | `NewFilename` | New file name. |
+| `gcli_path` | `gcliPath` | Optional path to the g-cli executable. |
+| `working_directory` | `WorkingDirectory` | Working directory where the action will run. |
+| `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
+| `dry_run` | `DryRun` | If true, simulate the action without side effects. |
+
 ## GitHub Action example
 
 ```yaml

--- a/docs/actions/restore-setup-lv-source.md
+++ b/docs/actions/restore-setup-lv-source.md
@@ -32,6 +32,22 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName restore-setup-lv-source -Args
 }'
 ```
 
+## GitHub Action inputs
+
+GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
+
+| Input | CLI parameter | Description |
+| --- | --- | --- |
+| `minimum_supported_lv_version` | `MinimumSupportedLVVersion` | Minimum LabVIEW version supported. |
+| `supported_bitness` | `SupportedBitness` | "32" or "64" bitness of LabVIEW. |
+| `relative_path` | `RelativePath` | Relative path containing the project. |
+| `labview_project` | `LabVIEW_Project` | Path to the LabVIEW project file. |
+| `build_spec` | `Build_Spec` | Name of the build specification. |
+| `gcli_path` | `gcliPath` | Optional path to the g-cli executable. |
+| `working_directory` | `WorkingDirectory` | Working directory where the action will run. |
+| `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
+| `dry_run` | `DryRun` | If true, simulate the action without side effects. |
+
 ## GitHub Action example
 
 ```yaml

--- a/docs/actions/revert-development-mode.md
+++ b/docs/actions/revert-development-mode.md
@@ -24,6 +24,18 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName revert-development-mode -Args
 }'
 ```
 
+## GitHub Action inputs
+
+GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
+
+| Input | CLI parameter | Description |
+| --- | --- | --- |
+| `relative_path` | `RelativePath` | Relative path containing the repository. |
+| `gcli_path` | `gcliPath` | Optional path to the g-cli executable. |
+| `working_directory` | `WorkingDirectory` | Working directory where the action will run. |
+| `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
+| `dry_run` | `DryRun` | If true, simulate the action without side effects. |
+
 ## GitHub Action example
 
 ```yaml

--- a/docs/actions/run-unit-tests.md
+++ b/docs/actions/run-unit-tests.md
@@ -27,6 +27,19 @@ SupportedBitness: "64"
 pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsYaml (ConvertFrom-Yaml $yaml)
 ```
 
+## GitHub Action inputs
+
+GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
+
+| Input | CLI parameter | Description |
+| --- | --- | --- |
+| `minimum_supported_lv_version` | `MinimumSupportedLVVersion` | LabVIEW version for the test run. |
+| `supported_bitness` | `SupportedBitness` | "32" or "64" bitness of LabVIEW. |
+| `gcli_path` | `gcliPath` | Optional path to the g-cli executable. |
+| `working_directory` | `WorkingDirectory` | Working directory where the action will run. |
+| `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
+| `dry_run` | `DryRun` | If true, simulate the action without side effects. |
+
 ## GitHub Action example
 
 ```yaml

--- a/docs/actions/set-development-mode.md
+++ b/docs/actions/set-development-mode.md
@@ -24,6 +24,18 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName set-development-mode -ArgsJso
 }'
 ```
 
+## GitHub Action inputs
+
+GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
+
+| Input | CLI parameter | Description |
+| --- | --- | --- |
+| `relative_path` | `RelativePath` | Relative path containing the repository. |
+| `gcli_path` | `gcliPath` | Optional path to the g-cli executable. |
+| `working_directory` | `WorkingDirectory` | Working directory where the action will run. |
+| `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
+| `dry_run` | `DryRun` | If true, simulate the action without side effects. |
+
 ## GitHub Action example
 
 ```yaml


### PR DESCRIPTION
## Summary
- document GitHub Action inputs and map to corresponding CLI parameters across action docs
- clarify snake_case vs PascalCase naming and link to common CLI parameters

## Testing
- `npm run check:node` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a032f0382083299f373e23e189308d