### PR TITLE
docs: add Build Icon Editor example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,43 @@ Enable debug logging and perform a dry run:
     dry_run: true
   ```
 
+Build Icon Editor:
+
+Chain the [apply-vipc](docs/actions/apply-vipc.md), [set-development-mode](docs/actions/set-development-mode.md), [build](docs/actions/build.md), and [revert-development-mode](docs/actions/revert-development-mode.md) actions to build the LabVIEW Icon Editor:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    repository: LabVIEW-Community-CI-CD/labview-icon-editor
+    path: labview-icon-editor
+- uses: LabVIEW-Community-CI-CD/open-source-actions/apply-vipc@v1
+  with:
+    minimum_supported_lv_version: '2021'
+    vip_lv_version: '2021'
+    supported_bitness: '64'
+    relative_path: labview-icon-editor
+    vipc_path: labview-icon-editor/.github/actions/apply-vipc/runner_dependencies.vipc
+- uses: LabVIEW-Community-CI-CD/open-source-actions/set-development-mode@v1
+  with:
+    minimum_supported_lv_version: '2021'
+    supported_bitness: '64'
+    relative_path: labview-icon-editor
+- uses: LabVIEW-Community-CI-CD/open-source-actions/build@v1
+  with:
+    relative_path: labview-icon-editor
+    major: 1
+    minor: 0
+    patch: 0
+    build: 0
+    commit: abcdef
+    labview_minor_revision: '3'
+    company_name: 'Acme Corp'
+    author_name: 'Jane Doe'
+- uses: LabVIEW-Community-CI-CD/open-source-actions/revert-development-mode@v1
+  with:
+    relative_path: labview-icon-editor
+```
+
 ## CLI/dispatcher usage
 
 If you prefer or need to run tasks directly, call the dispatcher script [actions/Invoke-OSAction.ps1](actions/Invoke-OSAction.ps1) yourself:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -46,6 +46,48 @@ pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -ArgsYaml (Conve
 This will import the **OpenSourceActions** module and run the **Build** adapter. On completion, the script returns with an exit code (0 for success or a non-zero error code). You can include optional flags like `-WorkingDirectory` to change directory before execution, or `-DryRun` to simulate the action (see below). For details on these and other dispatcher flags, see [Common Parameters](common-parameters.md).
 4. **Confirm Results:** After running, check the console output and exit code. The unified dispatcher prints informative logs (at INFO level by default) and any errors encountered. For GitHub Actions, a non-zero exit code will mark the step as failed, surfacing any error messages thrown by the adapter or underlying script.
 
+### Build Icon Editor
+
+Chain the [apply-vipc](actions/apply-vipc.md), [set-development-mode](actions/set-development-mode.md), [build](actions/build.md), and [revert-development-mode](actions/revert-development-mode.md) actions to build the LabVIEW Icon Editor:
+
+```yaml
+jobs:
+  build_icon_editor:
+    runs-on: [self-hosted, self-hosted-windows-lv]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: LabVIEW-Community-CI-CD/labview-icon-editor
+          path: labview-icon-editor
+      - uses: LabVIEW-Community-CI-CD/open-source-actions/apply-vipc@v1
+        with:
+          minimum_supported_lv_version: '2021'
+          vip_lv_version: '2021'
+          supported_bitness: '64'
+          relative_path: labview-icon-editor
+          vipc_path: labview-icon-editor/.github/actions/apply-vipc/runner_dependencies.vipc
+      - uses: LabVIEW-Community-CI-CD/open-source-actions/set-development-mode@v1
+        with:
+          minimum_supported_lv_version: '2021'
+          supported_bitness: '64'
+          relative_path: labview-icon-editor
+      - uses: LabVIEW-Community-CI-CD/open-source-actions/build@v1
+        with:
+          relative_path: labview-icon-editor
+          major: 1
+          minor: 0
+          patch: 0
+          build: 0
+          commit: abcdef
+          labview_minor_revision: '3'
+          company_name: 'Acme Corp'
+          author_name: 'Jane Doe'
+      - uses: LabVIEW-Community-CI-CD/open-source-actions/revert-development-mode@v1
+        with:
+          relative_path: labview-icon-editor
+```
+
 ## Need help?
 
 See the [troubleshooting guide](troubleshooting.md) for help with setup issues, missing dependencies, and exit codes.


### PR DESCRIPTION
## Summary
- document Build Icon Editor workflow using apply-vipc, set-development-mode, build, and revert-development-mode actions
- cross-link actions in README and quickstart

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a037e8edc483298cd124a9457da0cc