### PR TITLE
test: ensure self-hosted workflow adds token

### DIFF
--- a/tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1
@@ -1,0 +1,40 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module powershell-yaml
+
+Describe 'AddTokenToLabview.SelfHosted.Workflow [REQ-008]' {
+    It 'runs add-token-to-labview action on a self-hosted runner and uploads token artifact [REQ-008]' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $wfDir = Join-Path $repoRoot '.github/workflows'
+        $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'
+        $workflowFound = $false
+
+        foreach ($wfFile in $workflowFiles) {
+            $wf = Get-Content -Raw $wfFile.FullName | ConvertFrom-Yaml
+            foreach ($jobEntry in $wf.jobs.GetEnumerator()) {
+                $job = $jobEntry.Value
+                $addStep = $job.steps | Where-Object { $_.uses -eq './add-token-to-labview/action.yml' } | Select-Object -First 1
+                if ($null -ne $addStep) {
+                    $workflowFound = $true
+                    $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+                    $addStep.uses | Should -Be './add-token-to-labview/action.yml'
+                    $addStep.with.minimum_supported_lv_version | Should -Not -BeNullOrEmpty
+                    $addStep.with.supported_bitness | Should -Not -BeNullOrEmpty
+                    $addStep.with.relative_path | Should -Not -BeNullOrEmpty
+                    $uploadStep = $job.steps | Where-Object {
+                        $_.ContainsKey('uses') -and $_.uses -like 'actions/upload-artifact@*' -and (
+                            ($_.with.name -match 'token') -or ($_.with.path -match 'token')
+                        )
+                    } | Select-Object -First 1
+                    $uploadStep | Should -Not -BeNullOrEmpty
+                }
+            }
+        }
+
+        if (-not $workflowFound) {
+            Set-ItResult -Skipped -Because 'No workflow found using add-token-to-labview action'
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Pester test asserting self-hosted workflow runs add-token-to-labview and uploads token artifact

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a03bb65c888329a3ca6c0e62733d0e