### PR TITLE
test: add build self-hosted workflow test

### DIFF
--- a/.github/workflows/build-self-hosted.yml
+++ b/.github/workflows/build-self-hosted.yml
@@ -1,0 +1,31 @@
+name: Build (self-hosted test)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: [self-hosted, self-hosted-windows-lv]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: LabVIEW-Community-CI-CD/labview-icon-editor
+          path: ../../labview-icon-editor/labview-icon-editor
+      - name: Run build action
+        uses: ./build/action.yml
+        with:
+          relative_path: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor'
+          major: '1'
+          minor: '0'
+          patch: '0'
+          build: '1'
+          commit: 'abcdef'
+          labview_minor_revision: '3'
+          company_name: 'Acme Corp'
+          author_name: 'Jane Doe'
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact
+          path: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\resource\\plugins\\lv_icon_x64.lvlibp'

--- a/tests/pester/Build.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/Build.SelfHosted.Workflow.Tests.ps1
@@ -1,0 +1,32 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module powershell-yaml
+
+Describe 'Build.SelfHosted.Workflow [REQ-009]' {
+    It 'runs build action with required inputs [REQ-009]' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $workflowPath = Join-Path $repoRoot '.github/workflows/build-self-hosted.yml'
+        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml
+        $job = $wf.jobs.'build'
+        $buildStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq './build/action.yml' } | Select-Object -First 1
+        $artifactStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq 'actions/upload-artifact@v4' -and $_['with']['path'] -match 'lv_icon_x64\.lvlibp' } | Select-Object -First 1
+
+        $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+
+        $buildStep.with.relative_path | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor'
+        $buildStep.with.major | Should -Be '1'
+        $buildStep.with.minor | Should -Be '0'
+        $buildStep.with.patch | Should -Be '0'
+        $buildStep.with.build | Should -Be '1'
+        $buildStep.with.commit | Should -Be 'abcdef'
+        $buildStep.with.labview_minor_revision | Should -Be '3'
+        $buildStep.with.company_name | Should -Be 'Acme Corp'
+        $buildStep.with.author_name | Should -Be 'Jane Doe'
+
+        $artifactStep | Should -Not -BeNullOrEmpty
+        $artifactStep.with.path | Should -Match 'lv_icon_x64\.lvlibp'
+        $artifactStep.with.name | Should -Be 'build-artifact'
+    }
+}


### PR DESCRIPTION
## Summary
- add self-hosted build workflow
- verify build action inputs and artifact upload via Pester

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a03e5f57808329a19a88900ee21ec1