### PR TITLE
test: cover build-lvlibp self-hosted workflow

### DIFF
--- a/.github/workflows/build-lvlibp-self-hosted.yml
+++ b/.github/workflows/build-lvlibp-self-hosted.yml
@@ -1,0 +1,32 @@
+name: Build LVLIBP (self-hosted test)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-lvlibp:
+    runs-on: [self-hosted, self-hosted-windows-lv]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: LabVIEW-Community-CI-CD/labview-icon-editor
+          path: ../../labview-icon-editor/labview-icon-editor
+      - name: Run build-lvlibp action
+        uses: ./build-lvlibp/action.yml
+        with:
+          minimum_supported_lv_version: '2021'
+          supported_bitness: '64'
+          relative_path: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor'
+          labview_project: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\source\\lv_icon.lvproj'
+          build_spec: 'PackedLib Build'
+          major: '1'
+          minor: '0'
+          patch: '0'
+          build: '1'
+          commit: 'abcdef'
+      - name: Upload lvlibp artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-lvlibp-artifact
+          path: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\build\\lv_icon.lvlibp'

--- a/tests/pester/BuildLvlibp.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/BuildLvlibp.SelfHosted.Workflow.Tests.ps1
@@ -1,0 +1,26 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module powershell-yaml
+
+Describe 'BuildLvlibp.SelfHosted.Workflow [REQ-010]' {
+    It 'runs build-lvlibp action and uploads lvlibp artifact [REQ-010]' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $workflowPath = Join-Path $repoRoot '.github/workflows/build-lvlibp-self-hosted.yml'
+        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml
+        $job = $wf.jobs.'build-lvlibp'
+        $buildStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq './build-lvlibp/action.yml' } | Select-Object -First 1
+        $artifactStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq 'actions/upload-artifact@v4' -and $_['with']['path'] -match '\.lvlibp$' } | Select-Object -First 1
+
+        $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+
+        $buildStep.with.minimum_supported_lv_version | Should -Be '2021'
+        $buildStep.with.supported_bitness | Should -Be '64'
+        $buildStep.with.labview_project | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\source\\lv_icon.lvproj'
+        $buildStep.with.build_spec | Should -Be 'PackedLib Build'
+
+        $artifactStep | Should -Not -BeNullOrEmpty
+        $artifactStep.with.path | Should -Match '\.lvlibp$'
+    }
+}


### PR DESCRIPTION
## Summary
- add self-hosted workflow invoking build-lvlibp action
- test workflow ensures required inputs and artifact upload

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a0977355c48329b10d50887d014846