### PR TITLE
test: add build-vi-package workflow test

### DIFF
--- a/tests/pester/BuildViPackage.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/BuildViPackage.SelfHosted.Workflow.Tests.ps1
@@ -1,0 +1,33 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module powershell-yaml
+
+Describe 'BuildViPackage.SelfHosted.Workflow [REQ-011]' {
+    It 'runs build-vi-package action and uploads vi package artifact [REQ-011]' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $workflowPath = Join-Path $repoRoot '.github/workflows/build-vi-package-self-hosted.yml'
+        if (-not (Test-Path $workflowPath)) {
+            Set-ItResult -Skipped -Because 'Workflow file not found'
+            return
+        }
+        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml
+        $job = $wf.jobs.'build-vi-package'
+        $buildStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq './build-vi-package/action.yml' } | Select-Object -First 1
+        $artifactStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq 'actions/upload-artifact@v4' -and $_['with']['path'] -match '\.vip$' } | Select-Object -First 1
+
+        $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+
+        $buildStep.with.vipb_path | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\Tooling\\deployment\\NI Icon editor.vipb'
+        $buildStep.with.major | Should -Be '1'
+        $buildStep.with.minor | Should -Be '0'
+        $buildStep.with.patch | Should -Be '0'
+        $buildStep.with.build | Should -Be '2'
+        $buildStep.with.commit | Should -Be 'abcdef'
+
+        $artifactStep | Should -Not -BeNullOrEmpty
+        $artifactStep.with.path | Should -Match '\.vip$'
+        $artifactStep.with.name | Should -Be 'build-vi-package-artifact'
+    }
+}


### PR DESCRIPTION
## Summary
- test self-hosted workflow for build-vi-package action

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a099e474f48329ad03bc6cb9559c8d