### PR TITLE
test: ensure missing-in-project workflow

### DIFF
--- a/tests/pester/MissingInProject.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/MissingInProject.SelfHosted.Workflow.Tests.ps1
@@ -1,0 +1,41 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module powershell-yaml
+
+Describe 'MissingInProject.SelfHosted.Workflow [REQ-014]' {
+    It 'runs missing-in-project action on a self-hosted runner and uploads findings report [REQ-014]' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $wfDir = Join-Path $repoRoot '.github/workflows'
+        $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'
+        $workflowFound = $false
+
+        foreach ($wfFile in $workflowFiles) {
+            $wf = Get-Content -Raw $wfFile.FullName | ConvertFrom-Yaml
+            foreach ($jobEntry in $wf.jobs.GetEnumerator()) {
+                $job = $jobEntry.Value
+                $missingStep = $job.steps | Where-Object { $_.uses -eq './missing-in-project/action.yml' } | Select-Object -First 1
+                if ($null -ne $missingStep) {
+                    $workflowFound = $true
+                    $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+                    $missingStep.uses | Should -Be './missing-in-project/action.yml'
+                    $missingStep.with.lv_version | Should -Not -BeNullOrEmpty
+                    $missingStep.with.arch | Should -Not -BeNullOrEmpty
+                    $missingStep.with.project_file | Should -Not -BeNullOrEmpty
+                    $missingStep.with.relative_path | Should -Not -BeNullOrEmpty
+                    $artifactStep = $job.steps | Where-Object {
+                        $_.ContainsKey('uses') -and $_.uses -like 'actions/upload-artifact@*' -and (
+                            ($_.with.name -match 'missing') -or ($_.with.path -match 'missing')
+                        )
+                    } | Select-Object -First 1
+                    $artifactStep | Should -Not -BeNullOrEmpty
+                }
+            }
+        }
+
+        if (-not $workflowFound) {
+            Set-ItResult -Skipped -Because 'No workflow found using missing-in-project action'
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Pester test to validate missing-in-project action usage

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a09be1ad7483299120a53b30b7fbc5