### PR TITLE
test: add prepare labview source workflow test

### DIFF
--- a/tests/pester/PrepareLabviewSource.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/PrepareLabviewSource.SelfHosted.Workflow.Tests.ps1
@@ -1,0 +1,41 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module powershell-yaml
+
+Describe 'PrepareLabviewSource.SelfHosted.Workflow [REQ-011]' {
+    It 'runs prepare-labview-source action and uploads prepared source artifact [REQ-011]' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $wfDir = Join-Path $repoRoot '.github/workflows'
+        $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'
+        $workflowFound = $false
+
+        foreach ($wfFile in $workflowFiles) {
+            $wf = Get-Content -Raw $wfFile.FullName | ConvertFrom-Yaml
+            foreach ($jobEntry in $wf.jobs.GetEnumerator()) {
+                $job = $jobEntry.Value
+                $prepareStep = $job.steps | Where-Object { $_.uses -eq './prepare-labview-source/action.yml' } | Select-Object -First 1
+                if ($null -ne $prepareStep) {
+                    $workflowFound = $true
+                    $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+                    $prepareStep.uses | Should -Be './prepare-labview-source/action.yml'
+                    $prepareStep.with.relative_path | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor'
+                    $prepareStep.with.labview_project | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\source\\lv_icon.lvproj'
+                    $prepareStep.with.build_spec | Should -Be 'Editor Packed Library'
+                    $artifactStep = $job.steps | Where-Object {
+                        $_.ContainsKey('uses') -and $_.uses -like 'actions/upload-artifact@*' -and (
+                            ($_.with.path -match 'source' -and $_.with.path -match '\\.zip$') -or
+                            ($_.with.name -match 'source')
+                        )
+                    } | Select-Object -First 1
+                    $artifactStep | Should -Not -BeNullOrEmpty
+                }
+            }
+        }
+
+        if (-not $workflowFound) {
+            Set-ItResult -Skipped -Because 'No workflow found using prepare-labview-source action'
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Pester test to verify `prepare-labview-source` workflow inputs and artifact upload

## Testing
- `npm run check:node` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"` *(container failed: AddTokenToLabview.SelfHosted.Workflow.Tests.ps1, ApplyVipc.SelfHosted.Workflow.Tests.ps1, Build.SelfHosted.Workflow.Tests.ps1, BuildLvlibp.SelfHosted.Workflow.Tests.ps1, PrepareLabviewSource.SelfHosted.Workflow.Tests.ps1)*

------
https://chatgpt.com/codex/tasks/task_e_68a09beffd188329b72844b08b4c7b3b