### PR TITLE
Add rename-file workflow test

### DIFF
--- a/tests/pester/RenameFile.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RenameFile.SelfHosted.Workflow.Tests.ps1
@@ -1,0 +1,43 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module powershell-yaml
+
+Describe 'RenameFile.SelfHosted.Workflow [REQ-011]' {
+    It 'runs rename-file action on a self-hosted runner and uploads renamed file artifact [REQ-011]' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $wfDir = Join-Path $repoRoot '.github/workflows'
+        $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'
+        $workflowFound = $false
+
+        foreach ($wfFile in $workflowFiles) {
+            $wf = Get-Content -Raw $wfFile.FullName | ConvertFrom-Yaml
+            foreach ($jobEntry in $wf.jobs.GetEnumerator()) {
+                $job = $jobEntry.Value
+                $renameStep = $job.steps | Where-Object { $_.uses -eq './rename-file/action.yml' } | Select-Object -First 1
+                if ($null -ne $renameStep) {
+                    $workflowFound = $true
+
+                    $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+                    $renameStep.uses | Should -Be './rename-file/action.yml'
+                    $renameStep.with.current_filename | Should -Not -BeNullOrEmpty
+                    $renameStep.with.new_filename | Should -Not -BeNullOrEmpty
+
+                    $newFilename = $renameStep.with.new_filename
+                    $escaped = [regex]::Escape($newFilename)
+                    $uploadStep = $job.steps | Where-Object {
+                        $_.ContainsKey('uses') -and $_.uses -like 'actions/upload-artifact@*' -and (
+                            ($_.with.name -match $escaped) -or ($_.with.path -match $escaped)
+                        )
+                    } | Select-Object -First 1
+                    $uploadStep | Should -Not -BeNullOrEmpty
+                }
+            }
+        }
+
+        if (-not $workflowFound) {
+            Set-ItResult -Skipped -Because 'No workflow found using rename-file action'
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- test rename-file action in workflows for self-hosted runner usage and artifact upload

## Testing
- `npm run check:node` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a09bf882d48329b3663faae36dc9b4