### PR TITLE
test: add restore-setup-lv-source workflow test

### DIFF
--- a/tests/pester/RestoreSetupLvSource.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RestoreSetupLvSource.SelfHosted.Workflow.Tests.ps1
@@ -1,0 +1,40 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module powershell-yaml
+
+Describe 'RestoreSetupLvSource.SelfHosted.Workflow [REQ-018]' {
+    It 'runs restore-setup-lv-source action on a self-hosted runner and uploads restoration artifacts [REQ-018]' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $wfDir = Join-Path $repoRoot '.github/workflows'
+        $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'
+        $workflowFound = $false
+
+        foreach ($wfFile in $workflowFiles) {
+            $wf = Get-Content -Raw $wfFile.FullName | ConvertFrom-Yaml
+            foreach ($jobEntry in $wf.jobs.GetEnumerator()) {
+                $job = $jobEntry.Value
+                $restoreStep = $job.steps | Where-Object { $_.uses -eq './restore-setup-lv-source/action.yml' } | Select-Object -First 1
+                if ($null -ne $restoreStep) {
+                    $workflowFound = $true
+                    $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+                    $restoreStep.with.relative_path | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor'
+                    $restoreStep.env | Should -Not -BeNullOrEmpty
+                    $artifactStep = $job.steps | Where-Object {
+                        $_.ContainsKey('uses') -and $_.uses -like 'actions/upload-artifact@*' -and (
+                            ($_.with.path -match 'restore') -or ($_.with.path -match 'snapshot') -or
+                            ($_.with.name -match 'restore') -or ($_.with.name -match 'snapshot') -or
+                            ($_.with.path -match 'log') -or ($_.with.name -match 'log')
+                        )
+                    } | Select-Object -First 1
+                    $artifactStep | Should -Not -BeNullOrEmpty
+                }
+            }
+        }
+
+        if (-not $workflowFound) {
+            Set-ItResult -Skipped -Because 'No workflow found using restore-setup-lv-source action'
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- test restore-setup-lv-source composite action usage in workflows

## Testing
- `npm run check:node` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a09bfde8288329b39632f13ecee99a