### PR TITLE
test: add run-unit-tests workflow test

### DIFF
--- a/.github/workflows/run-unit-tests-self-hosted.yml
+++ b/.github/workflows/run-unit-tests-self-hosted.yml
@@ -1,0 +1,27 @@
+name: Run unit tests (self-hosted test)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run-unit-tests:
+    runs-on: [self-hosted, self-hosted-windows-lv]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: LabVIEW-Community-CI-CD/labview-icon-editor
+          path: ../../labview-icon-editor/labview-icon-editor
+      - name: Run unit tests action
+        uses: ./run-unit-tests/action.yml
+        with:
+          minimum_supported_lv_version: '2021'
+          supported_bitness: '64'
+          project_path: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\source\\lv_icon.lvproj'
+          test_config: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\tests\\unittest-config.cfg'
+          working_directory: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor'
+      - name: Upload unit test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-results
+          path: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\UnitTestReport.xml'

--- a/tests/pester/RunUnitTests.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RunUnitTests.SelfHosted.Workflow.Tests.ps1
@@ -1,0 +1,27 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module powershell-yaml
+
+Describe 'RunUnitTests.SelfHosted.Workflow [REQ-011]' {
+    It 'runs run-unit-tests action and uploads unit-test results [REQ-011]' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $workflowPath = Join-Path $repoRoot '.github/workflows/run-unit-tests-self-hosted.yml'
+        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml
+        $job = $wf.jobs.'run-unit-tests'
+        $testStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq './run-unit-tests/action.yml' } | Select-Object -First 1
+        $artifactStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq 'actions/upload-artifact@v4' -and $_['with']['path'] -match 'UnitTestReport\.xml' } | Select-Object -First 1
+
+        $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+
+        $testStep.with.minimum_supported_lv_version | Should -Be '2021'
+        $testStep.with.supported_bitness | Should -Be '64'
+        $testStep.with.project_path | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\source\\lv_icon.lvproj'
+        $testStep.with.test_config | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\tests\\unittest-config.cfg'
+
+        $artifactStep | Should -Not -BeNullOrEmpty
+        $artifactStep.with.name | Should -Be 'unit-test-results'
+        $artifactStep.with.path | Should -Match 'UnitTestReport\.xml'
+    }
+}


### PR DESCRIPTION
## Summary
- verify self-hosted workflow calls run-unit-tests action
- ensure unit test results uploaded as artifact

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a09c07a1808329a6fb14d2f51b205a