### PR TITLE
test: add set-development-mode workflow test

### DIFF
--- a/tests/pester/SetDevelopmentMode.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/SetDevelopmentMode.SelfHosted.Workflow.Tests.ps1
@@ -1,0 +1,42 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module powershell-yaml
+
+Describe 'SetDevelopmentMode.SelfHosted.Workflow [REQ-021]' {
+    It 'runs set-development-mode action on a self-hosted runner and uploads logs [REQ-021]' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $wfDir = Join-Path $repoRoot '.github/workflows'
+        $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'
+        $workflowFound = $false
+
+        foreach ($wfFile in $workflowFiles) {
+            $wf = Get-Content -Raw $wfFile.FullName | ConvertFrom-Yaml
+            foreach ($jobEntry in $wf.jobs.GetEnumerator()) {
+                $job = $jobEntry.Value
+                $setStep = $job.steps | Where-Object { $_.uses -eq './set-development-mode/action.yml' } | Select-Object -First 1
+                if ($null -ne $setStep) {
+                    $workflowFound = $true
+                    $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+                    $setStep.with.relative_path | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor'
+                    $setStep.with.gcli_path | Should -Not -BeNullOrEmpty
+                    $setStep.with.working_directory | Should -Not -BeNullOrEmpty
+                    $setStep.with.log_level | Should -Not -BeNullOrEmpty
+                    $setStep.with.dry_run | Should -Not -BeNullOrEmpty
+                    $artifactStep = $job.steps | Where-Object {
+                        $_.ContainsKey('uses') -and $_.uses -like 'actions/upload-artifact@*' -and (
+                            ($_.with.path -match 'log') -or ($_.with.path -match 'dev') -or
+                            ($_.with.name -match 'log') -or ($_.with.name -match 'dev')
+                        )
+                    } | Select-Object -First 1
+                    $artifactStep | Should -Not -BeNullOrEmpty
+                }
+            }
+        }
+
+        if (-not $workflowFound) {
+            Set-ItResult -Skipped -Because 'No workflow found using set-development-mode action'
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add workflow test ensuring set-development-mode action uses relative_path and flags

## Testing
- `npm run check:node` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Import-Module Pester; Invoke-Pester -CI -Path ./tests/pester"`

------
https://chatgpt.com/codex/tasks/task_e_68a0a3180ea48329af90f4976bd480d6