### PR TITLE
Add external workflow for close-labview action

### DIFF
--- a/.github/workflows/close-labview-external.yml
+++ b/.github/workflows/close-labview-external.yml
@@ -1,0 +1,41 @@
+name: Close LabVIEW (external test)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  close-labview:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Checkout target repository
+        uses: actions/checkout@v4
+        with:
+          repository: LabVIEW-Community-CI-CD/labview-icon-editor
+          path: target
+      - name: Close LabVIEW (32-bit)
+        uses: ./close-labview/action.yml
+        with:
+          minimum_supported_lv_version: '2021'
+          supported_bitness: '32'
+          working_directory: '${{ github.workspace }}\\target'
+          dry_run: true
+      - name: Upload log (32-bit)
+        uses: actions/upload-artifact@v4
+        with:
+          name: close-labview-32.log
+          path: '${{ github.workspace }}\\target\\close-labview.log'
+          if-no-files-found: ignore
+      - name: Close LabVIEW (64-bit)
+        uses: ./close-labview/action.yml
+        with:
+          minimum_supported_lv_version: '2021'
+          supported_bitness: '64'
+          working_directory: '${{ github.workspace }}\\target'
+          dry_run: true
+      - name: Upload log (64-bit)
+        uses: actions/upload-artifact@v4
+        with:
+          name: close-labview-64.log
+          path: '${{ github.workspace }}\\target\\close-labview.log'
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- add external GitHub Actions workflow that runs close-labview for 32-bit and 64-bit

## Testing
- `npm run check:node` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a0a6aa88dc83298bb2e65f0719e0a7