### PR TITLE
Clarify external repo handling in REQ-012

### DIFF
--- a/requirements.json
+++ b/requirements.json
@@ -57,7 +57,7 @@
     },
     {
       "id": "REQ-012",
-      "description": "Workflow tests the composite action defined in close-labview/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
+      "description": "Workflow clones an external repository and operates on it without modification using the composite action defined in close-labview/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
       "tests": ["CloseLabview.SelfHosted.Workflow"]
     },
     {


### PR DESCRIPTION
## Summary
- clarify that REQ-012's workflow clones and operates on an external repository without modifying it

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- ⚠️ `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"` (missing `pwsh`, attempted install failed)


------
https://chatgpt.com/codex/tasks/task_e_68a0a87a302c8329a5c3b46425b633a4