### PR TITLE
test: enforce self-hosted runners for close-labview

### DIFF
--- a/tests/pester/CloseLabview.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/CloseLabview.SelfHosted.Workflow.Tests.ps1
@@ -22,6 +22,7 @@ Describe 'CloseLabview.SelfHosted.Workflow [REQ-012]' {
             $closeSteps = $job.steps | Where-Object { $_.uses -eq './close-labview/action.yml' }
             if ($closeSteps) {
                 $jobFound = $true
+                $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
                 $bitness = $closeSteps | ForEach-Object { $_.with.supported_bitness }
                 $bitness | Should -Contain '32'
                 $bitness | Should -Contain '64'


### PR DESCRIPTION
## Summary
- validate `close-labview` workflow jobs run only on self-hosted LabVIEW runners

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0afe5873c8329a3e64af1494b22f5