### PR TITLE
feat: allow retaining unit test reports

### DIFF
--- a/scripts/run-unit-tests/README.md
+++ b/scripts/run-unit-tests/README.md
@@ -1,6 +1,7 @@
 # Run Unit Tests ✅
 
 Invoke **`RunUnitTests.ps1`** to execute LabVIEW unit tests and output a result table.
+Reports are deleted when all tests pass; set `keep_report` to retain them.
 
 ## Inputs
 
@@ -8,6 +9,7 @@ Invoke **`RunUnitTests.ps1`** to execute LabVIEW unit tests and output a result 
 |------|----------|---------|-------------|
 | `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW major version. |
 | `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
+| `keep_report` | No | `true` | Skip cleanup so `UnitTestReport.xml` remains on disk. |
 
 ## Quick-start
 
@@ -16,6 +18,7 @@ Invoke **`RunUnitTests.ps1`** to execute LabVIEW unit tests and output a result 
   with:
     minimum_supported_lv_version: 2024
     supported_bitness: 64
+    # keep_report: true
 ```
 
 ## License

--- a/scripts/run-unit-tests/RunUnitTests.ps1
+++ b/scripts/run-unit-tests/RunUnitTests.ps1
@@ -16,6 +16,9 @@
 .PARAMETER SupportedBitness
     Bitness for LabVIEW (e.g., "64").
 
+.PARAMETER KeepReport
+    Skip cleanup so the UnitTestReport.xml remains on disk.
+
 .NOTES
     PowerShell 7.5+ assumed for cross-platform support.
     This script *requires* that g-cli and LabVIEW be compatible with the OS.
@@ -29,7 +32,10 @@ param(
     [Parameter(Mandatory=$true)]
     [ValidateSet("32","64")]
     [string]
-    $SupportedBitness
+    $SupportedBitness,
+
+    [switch]
+    $KeepReport
 )
 
 # --------------------------------------------------------------------
@@ -241,7 +247,12 @@ function Cleanup {
 # -------------------  EXECUTION FLOW  -------------------
 Setup
 MainSequence
-#Cleanup
+if (-not $KeepReport) {
+    Cleanup
+}
+else {
+    Write-Host "`nSkipping Cleanup; retaining UnitTestReport.xml."
+}
 
 # -------------------  FINAL EXIT CODE  ------------------
 if ($Script:OriginalExitCode -ne 0) {


### PR DESCRIPTION
## Summary
- add `-KeepReport` switch to `RunUnitTests.ps1`
- document optional report retention in run-unit-tests README

## Testing
- `npm run check:node` *(fails: Node.js >=24 required, 20.19.4 found)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required, 20.19.4 found)*
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bb3f3a888329b01976361f008c69