### PR TITLE
Ensure gcli adapters restore PATH

### DIFF
--- a/actions/OpenSourceActions.psm1
+++ b/actions/OpenSourceActions.psm1
@@ -18,12 +18,18 @@ function InvokeAddTokenToLabVIEW {
         Write-Information "DryRun: & $scriptPath $($args | ConvertTo-Json -Compress)"
         return 0
     }
-    if ($gcliPath) {
-        $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$($env:PATH)"
+    $originalPath = $env:PATH
+    try {
+        if ($gcliPath) {
+            $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$originalPath"
+        }
+        & $scriptPath @args
+        if (-not $?) { return 1 }
+        return $LASTEXITCODE
     }
-    & $scriptPath @args
-    if (-not $?) { return 1 }
-    return $LASTEXITCODE
+    finally {
+        $env:PATH = $originalPath
+    }
 }
 
 function InvokeApplyVIPC {
@@ -50,12 +56,18 @@ function InvokeApplyVIPC {
         Write-Information "DryRun: & $scriptPath $($args | ConvertTo-Json -Compress)"
         return 0
     }
-    if ($gcliPath) {
-        $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$($env:PATH)"
+    $originalPath = $env:PATH
+    try {
+        if ($gcliPath) {
+            $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$originalPath"
+        }
+        & $scriptPath @args
+        if (-not $?) { return 1 }
+        return $LASTEXITCODE
     }
-    & $scriptPath @args
-    if (-not $?) { return 1 }
-    return $LASTEXITCODE
+    finally {
+        $env:PATH = $originalPath
+    }
 }
 
 function InvokeBuildViPackage {
@@ -96,12 +108,18 @@ function InvokeBuildViPackage {
         Write-Information "DryRun: & $scriptPath $($args | ConvertTo-Json -Compress)"
         return 0
     }
-    if ($gcliPath) {
-        $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$($env:PATH)"
+    $originalPath = $env:PATH
+    try {
+        if ($gcliPath) {
+            $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$originalPath"
+        }
+        & $scriptPath @args
+        if (-not $?) { return 1 }
+        return $LASTEXITCODE
     }
-    & $scriptPath @args
-    if (-not $?) { return 1 }
-    return $LASTEXITCODE
+    finally {
+        $env:PATH = $originalPath
+    }
 }
 
 function InvokeBuild {
@@ -136,12 +154,18 @@ function InvokeBuild {
         Write-Information "DryRun: & $scriptPath $($args | ConvertTo-Json -Compress)"
         return 0
     }
-    if ($gcliPath) {
-        $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$($env:PATH)"
+    $originalPath = $env:PATH
+    try {
+        if ($gcliPath) {
+            $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$originalPath"
+        }
+        & $scriptPath @args
+        if (-not $?) { return 1 }
+        return $LASTEXITCODE
     }
-    & $scriptPath @args
-    if (-not $?) { return 1 }
-    return $LASTEXITCODE
+    finally {
+        $env:PATH = $originalPath
+    }
 }
 
 function InvokeBuildLvlibp {
@@ -178,12 +202,18 @@ function InvokeBuildLvlibp {
         Write-Information "DryRun: & $scriptPath $($args | ConvertTo-Json -Compress)"
         return 0
     }
-    if ($gcliPath) {
-        $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$($env:PATH)"
+    $originalPath = $env:PATH
+    try {
+        if ($gcliPath) {
+            $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$originalPath"
+        }
+        & $scriptPath @args
+        if (-not $?) { return 1 }
+        return $LASTEXITCODE
     }
-    & $scriptPath @args
-    if (-not $?) { return 1 }
-    return $LASTEXITCODE
+    finally {
+        $env:PATH = $originalPath
+    }
 }
 
 function InvokeCloseLabVIEW {
@@ -204,12 +234,18 @@ function InvokeCloseLabVIEW {
         Write-Information "DryRun: & $scriptPath $($args | ConvertTo-Json -Compress)"
         return 0
     }
-    if ($gcliPath) {
-        $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$($env:PATH)"
+    $originalPath = $env:PATH
+    try {
+        if ($gcliPath) {
+            $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$originalPath"
+        }
+        & $scriptPath @args
+        if (-not $?) { return 1 }
+        return $LASTEXITCODE
     }
-    & $scriptPath @args
-    if (-not $?) { return 1 }
-    return $LASTEXITCODE
+    finally {
+        $env:PATH = $originalPath
+    }
 }
 
 function InvokeGenerateReleaseNotes {
@@ -226,12 +262,18 @@ function InvokeGenerateReleaseNotes {
         Write-Information "DryRun: & $scriptPath $($args | ConvertTo-Json -Compress)"
         return 0
     }
-    if ($gcliPath) {
-        $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$($env:PATH)"
+    $originalPath = $env:PATH
+    try {
+        if ($gcliPath) {
+            $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$originalPath"
+        }
+        & $scriptPath @args
+        if (-not $?) { return 1 }
+        return $LASTEXITCODE
     }
-    & $scriptPath @args
-    if (-not $?) { return 1 }
-    return $LASTEXITCODE
+    finally {
+        $env:PATH = $originalPath
+    }
 }
 
 function InvokeMissingInProject {
@@ -254,12 +296,18 @@ function InvokeMissingInProject {
         Write-Information "DryRun: & $scriptPath $($args | ConvertTo-Json -Compress)"
         return 0
     }
-    if ($gcliPath) {
-        $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$($env:PATH)"
+    $originalPath = $env:PATH
+    try {
+        if ($gcliPath) {
+            $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$originalPath"
+        }
+        & $scriptPath @args
+        if (-not $?) { return 1 }
+        return $LASTEXITCODE
     }
-    & $scriptPath @args
-    if (-not $?) { return 1 }
-    return $LASTEXITCODE
+    finally {
+        $env:PATH = $originalPath
+    }
 }
 
 function InvokeModifyVIPBDisplayInfo {
@@ -300,12 +348,18 @@ function InvokeModifyVIPBDisplayInfo {
         Write-Information "DryRun: & $scriptPath $($args | ConvertTo-Json -Compress)"
         return 0
     }
-    if ($gcliPath) {
-        $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$($env:PATH)"
+    $originalPath = $env:PATH
+    try {
+        if ($gcliPath) {
+            $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$originalPath"
+        }
+        & $scriptPath @args
+        if (-not $?) { return 1 }
+        return $LASTEXITCODE
     }
-    & $scriptPath @args
-    if (-not $?) { return 1 }
-    return $LASTEXITCODE
+    finally {
+        $env:PATH = $originalPath
+    }
 }
 
 function InvokePrepareLabVIEWSource {
@@ -332,12 +386,18 @@ function InvokePrepareLabVIEWSource {
         Write-Information "DryRun: & $scriptPath $($args | ConvertTo-Json -Compress)"
         return 0
     }
-    if ($gcliPath) {
-        $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$($env:PATH)"
+    $originalPath = $env:PATH
+    try {
+        if ($gcliPath) {
+            $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$originalPath"
+        }
+        & $scriptPath @args
+        if (-not $?) { return 1 }
+        return $LASTEXITCODE
     }
-    & $scriptPath @args
-    if (-not $?) { return 1 }
-    return $LASTEXITCODE
+    finally {
+        $env:PATH = $originalPath
+    }
 }
 
 function InvokeRenameFile {
@@ -358,12 +418,18 @@ function InvokeRenameFile {
         Write-Information "DryRun: & $scriptPath $($args | ConvertTo-Json -Compress)"
         return 0
     }
-    if ($gcliPath) {
-        $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$($env:PATH)"
+    $originalPath = $env:PATH
+    try {
+        if ($gcliPath) {
+            $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$originalPath"
+        }
+        & $scriptPath @args
+        if (-not $?) { return 1 }
+        return $LASTEXITCODE
     }
-    & $scriptPath @args
-    if (-not $?) { return 1 }
-    return $LASTEXITCODE
+    finally {
+        $env:PATH = $originalPath
+    }
 }
 
 function InvokeRestoreSetupLVSource {
@@ -390,12 +456,18 @@ function InvokeRestoreSetupLVSource {
         Write-Information "DryRun: & $scriptPath $($args | ConvertTo-Json -Compress)"
         return 0
     }
-    if ($gcliPath) {
-        $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$($env:PATH)"
+    $originalPath = $env:PATH
+    try {
+        if ($gcliPath) {
+            $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$originalPath"
+        }
+        & $scriptPath @args
+        if (-not $?) { return 1 }
+        return $LASTEXITCODE
     }
-    & $scriptPath @args
-    if (-not $?) { return 1 }
-    return $LASTEXITCODE
+    finally {
+        $env:PATH = $originalPath
+    }
 }
 
 function InvokeRevertDevelopmentMode {
@@ -412,12 +484,18 @@ function InvokeRevertDevelopmentMode {
         Write-Information "DryRun: & $scriptPath $($args | ConvertTo-Json -Compress)"
         return 0
     }
-    if ($gcliPath) {
-        $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$($env:PATH)"
+    $originalPath = $env:PATH
+    try {
+        if ($gcliPath) {
+            $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$originalPath"
+        }
+        & $scriptPath @args
+        if (-not $?) { return 1 }
+        return $LASTEXITCODE
     }
-    & $scriptPath @args
-    if (-not $?) { return 1 }
-    return $LASTEXITCODE
+    finally {
+        $env:PATH = $originalPath
+    }
 }
 
 function InvokeRunUnitTests {
@@ -438,12 +516,18 @@ function InvokeRunUnitTests {
         Write-Information "DryRun: & $scriptPath $($args | ConvertTo-Json -Compress)"
         return 0
     }
-    if ($gcliPath) {
-        $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$($env:PATH)"
+    $originalPath = $env:PATH
+    try {
+        if ($gcliPath) {
+            $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$originalPath"
+        }
+        & $scriptPath @args
+        if (-not $?) { return 1 }
+        return $LASTEXITCODE
     }
-    & $scriptPath @args
-    if (-not $?) { return 1 }
-    return $LASTEXITCODE
+    finally {
+        $env:PATH = $originalPath
+    }
 }
 
 function InvokeSetDevelopmentMode {
@@ -460,10 +544,16 @@ function InvokeSetDevelopmentMode {
         Write-Information "DryRun: & $scriptPath $($args | ConvertTo-Json -Compress)"
         return 0
     }
-    if ($gcliPath) {
-        $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$($env:PATH)"
+    $originalPath = $env:PATH
+    try {
+        if ($gcliPath) {
+            $env:PATH = "$gcliPath$([System.IO.Path]::PathSeparator)$originalPath"
+        }
+        & $scriptPath @args
+        if (-not $?) { return 1 }
+        return $LASTEXITCODE
     }
-    & $scriptPath @args
-    if (-not $?) { return 1 }
-    return $LASTEXITCODE
+    finally {
+        $env:PATH = $originalPath
+    }
 }

--- a/tests/pester/PathRestoration.Actions.Tests.ps1
+++ b/tests/pester/PathRestoration.Actions.Tests.ps1
@@ -1,0 +1,44 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+Import-Module (Join-Path $repoRoot 'actions' 'OpenSourceActions.psm1') -Force
+
+Describe 'Adapters restore PATH' {
+    $gcliPath = Join-Path $PSScriptRoot 'dummy-gcli'
+    BeforeAll {
+        New-Item -ItemType Directory -Path $gcliPath -Force | Out-Null
+    }
+    AfterAll {
+        Remove-Item -Path $gcliPath -Recurse -Force
+    }
+
+    $cases = @(
+        @{ Func='InvokeAddTokenToLabVIEW'; Script=[System.IO.Path]::Combine($repoRoot,'scripts','add-token-to-labview','AddTokenToLabVIEW.ps1'); Args=@{ MinimumSupportedLVVersion='2021'; SupportedBitness='64'; RelativePath='.' } },
+        @{ Func='InvokeApplyVIPC'; Script=[System.IO.Path]::Combine($repoRoot,'scripts','apply-vipc','ApplyVIPC.ps1'); Args=@{ MinimumSupportedLVVersion='2021'; VIP_LVVersion='2021'; SupportedBitness='64'; RelativePath='.'; VIPCPath='dummy.vipc' } },
+        @{ Func='InvokeBuildViPackage'; Script=[System.IO.Path]::Combine($repoRoot,'scripts','build-vi-package','build_vip.ps1'); Args=@{ MinimumSupportedLVVersion='2021'; SupportedBitness='64'; LabVIEWMinorRevision='2021'; RelativePath='.'; VIPBPath='dummy.vipb'; Major=1; Minor=0; Patch=0; Build=1; Commit='abc'; DisplayInformationJSON='{}' } },
+        @{ Func='InvokeBuild'; Script=[System.IO.Path]::Combine($repoRoot,'scripts','build','Build.ps1'); Args=@{ RelativePath='.'; Major=1; Minor=0; Patch=0; Build=1; Commit='abc'; LabVIEWMinorRevision='2021'; CompanyName='Co'; AuthorName='Auth' } },
+        @{ Func='InvokeBuildLvlibp'; Script=[System.IO.Path]::Combine($repoRoot,'scripts','build-lvlibp','Build_lvlibp.ps1'); Args=@{ MinimumSupportedLVVersion='2021'; SupportedBitness='64'; RelativePath='.'; LabVIEW_Project='Proj'; Build_Spec='Spec'; Major=1; Minor=0; Patch=0; Build=1; Commit='abc' } },
+        @{ Func='InvokeCloseLabVIEW'; Script=[System.IO.Path]::Combine($repoRoot,'scripts','close-labview','Close_LabVIEW.ps1'); Args=@{ MinimumSupportedLVVersion='2021'; SupportedBitness='64' } },
+        @{ Func='InvokeGenerateReleaseNotes'; Script=[System.IO.Path]::Combine($repoRoot,'scripts','generate-release-notes','GenerateReleaseNotes.ps1'); Args=@{ OutputPath='notes.md' } },
+        @{ Func='InvokeMissingInProject'; Script=[System.IO.Path]::Combine($repoRoot,'scripts','missing-in-project','Invoke-MissingInProjectCLI.ps1'); Args=@{ LVVersion='2021'; Arch='64'; ProjectFile='Proj.lvproj' } },
+        @{ Func='InvokeModifyVIPBDisplayInfo'; Script=[System.IO.Path]::Combine($repoRoot,'scripts','modify-vipb-display-info','ModifyVIPBDisplayInfo.ps1'); Args=@{ SupportedBitness='64'; RelativePath='.'; VIPBPath='dummy.vipb'; MinimumSupportedLVVersion='2021'; LabVIEWMinorRevision='2021'; Major=1; Minor=0; Patch=0; Build=1; Commit='abc'; DisplayInformationJSON='{}' } },
+        @{ Func='InvokePrepareLabVIEWSource'; Script=[System.IO.Path]::Combine($repoRoot,'scripts','prepare-labview-source','Prepare_LabVIEW_source.ps1'); Args=@{ MinimumSupportedLVVersion='2021'; SupportedBitness='64'; RelativePath='.'; LabVIEW_Project='Proj'; Build_Spec='Spec' } },
+        @{ Func='InvokeRenameFile'; Script=[System.IO.Path]::Combine($repoRoot,'scripts','rename-file','Rename-file.ps1'); Args=@{ CurrentFilename='a'; NewFilename='b' } },
+        @{ Func='InvokeRestoreSetupLVSource'; Script=[System.IO.Path]::Combine($repoRoot,'scripts','restore-setup-lv-source','RestoreSetupLVSource.ps1'); Args=@{ MinimumSupportedLVVersion='2021'; SupportedBitness='64'; RelativePath='.'; LabVIEW_Project='Proj'; Build_Spec='Spec' } },
+        @{ Func='InvokeRevertDevelopmentMode'; Script=[System.IO.Path]::Combine($repoRoot,'scripts','revert-development-mode','RevertDevelopmentMode.ps1'); Args=@{ RelativePath='.' } },
+        @{ Func='InvokeRunUnitTests'; Script=[System.IO.Path]::Combine($repoRoot,'scripts','run-unit-tests','RunUnitTests.ps1'); Args=@{ MinimumSupportedLVVersion='2021'; SupportedBitness='64' } },
+        @{ Func='InvokeSetDevelopmentMode'; Script=[System.IO.Path]::Combine($repoRoot,'scripts','set-development-mode','Set_Development_Mode.ps1'); Args=@{ RelativePath='.' } }
+    )
+
+    foreach ($case in $cases) {
+        It "restores PATH after $($case.Func)" {
+            $originalPath = $env:PATH
+            Mock $case.Script { $global:LASTEXITCODE = 0 }
+            & $case.Func @case.Args -gcliPath $gcliPath | Out-Null
+            $env:PATH | Should -Be $originalPath
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- preserve and restore PATH around gcli adapter execution
- add tests confirming adapters leave PATH unchanged

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a0bca7b7d0832990af2f64e5fe992f