### PR TITLE
Avoid redundant Node test run in report job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,6 @@ jobs:
           node-version: 24
       - run: npm run check:node
       - run: npm install
-      - run: npm run test:ci
       - uses: actions/download-artifact@v4
         with:
           path: ./downloaded
@@ -99,9 +98,8 @@ jobs:
       - run: npm run generate:summary
         env:
           TEST_RESULTS_GLOBS: |
-            test-results/**/*.xml
-            downloaded/**/*.xml
-            **/junit*.xml
+            downloaded/test-results/**/*.xml
+            downloaded/pester-junit-*/pester-junit.xml
           REQ_MAPPING_FILE: requirements.json
           DISPATCHER_REGISTRY: dispatchers.json
           EVIDENCE_DIR: test-screenshots


### PR DESCRIPTION
## Summary
- Avoid re-running Node tests in the `report` job
- Collect test results only from `node-ci` and `ps-ci` artifacts

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"` *(fails: splatting operator '@' cannot be used to reference variables in an expression)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c023e4488329a2bc23db3f67e337