### PR TITLE
Fix path restoration tests mock

### DIFF
--- a/tests/pester/PathRestoration.Actions.Tests.ps1
+++ b/tests/pester/PathRestoration.Actions.Tests.ps1
@@ -11,7 +11,7 @@ Describe 'Adapters restore PATH' {
         New-Item -ItemType Directory -Path $gcliPath -Force | Out-Null
     }
     AfterAll {
-        Remove-Item -Path $gcliPath -Recurse -Force
+        Remove-Item -Path $gcliPath -Recurse -Force -ErrorAction SilentlyContinue
     }
 
     $cases = @(
@@ -35,7 +35,7 @@ Describe 'Adapters restore PATH' {
     foreach ($case in $cases) {
         It "restores PATH after $($case.Func)" {
             $originalPath = $env:PATH
-            Mock $case.Script { $global:LASTEXITCODE = 0 }
+            Mock (Get-Command $case.Script).Name { $global:LASTEXITCODE = 0 }
             & $case.Func @case.Args -gcliPath $gcliPath | Out-Null
             $env:PATH | Should -Be $originalPath
         }


### PR DESCRIPTION
## Summary
- mock path restoration actions by command name
- make cleanup resilient if directory creation fails

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path tests/pester/PathRestoration.Actions.Tests.ps1 -Output Detailed"`
- `npm run check:node` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"` *(fails: Container failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c5f6a05c832982dfee7035ef1f2d