### PR TITLE
De-duplicate requirement tags in CI summary

### DIFF
--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -91,7 +91,8 @@ export async function collectTestCases(files: string[], evidenceDir: string): Pr
           const ownerMatch = name.match(/\[Owner:([^\]]+)\]/i);
           if (ownerMatch) test.owner = ownerMatch[1];
           const reqMatches = [...name.matchAll(/\[(REQ-\d+)\]/gi)].map((m) => m[1].toUpperCase());
-          if (reqMatches.length) test.requirements.push(...reqMatches);
+          const uniqueReqMatches = new Set(reqMatches);
+          if (uniqueReqMatches.size) test.requirements.push(...uniqueReqMatches);
           tests.push(test);
         }
       }


### PR DESCRIPTION
## Summary
- avoid duplicate requirement tags in `collectTestCases`

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Install-PackageProvider -Name NuGet -Force; Set-PSRepository -InstallationPolicy Trusted -Name PSGallery; Install-Module -Name Pester,powershell-yaml -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"`

------
https://chatgpt.com/codex/tasks/task_e_68a0d4dc067c8329bb7a0af89225d111