### PR TITLE
chore: update Windows runner label

### DIFF
--- a/.github/branch_protection_rules.yml
+++ b/.github/branch_protection_rules.yml
@@ -3,8 +3,8 @@ actions:
     - docs-lint
     - node-tests
     - dispatcher-tests (ubuntu-24.04)
-    - dispatcher-tests (self-hosted-windows-lv)
+    - dispatcher-tests (icon-editor-windows)
     - dispatcher-dryrun-tests (ubuntu-24.04)
-    - dispatcher-dryrun-tests (self-hosted-windows-lv)
+    - dispatcher-dryrun-tests (icon-editor-windows)
     - scriptpath-tests (ubuntu-24.04)
-    - scriptpath-tests (self-hosted-windows-lv)
+    - scriptpath-tests (icon-editor-windows)

--- a/.github/workflows/apply-vipc-self-hosted.yml
+++ b/.github/workflows/apply-vipc-self-hosted.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   apply-vipc:
-    runs-on: [self-hosted, self-hosted-windows-lv]
+    runs-on: [self-hosted, icon-editor-windows]
     strategy:
       matrix:
         dry_run: [true, false]

--- a/.github/workflows/build-lvlibp-self-hosted.yml
+++ b/.github/workflows/build-lvlibp-self-hosted.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-lvlibp:
-    runs-on: [self-hosted, self-hosted-windows-lv]
+    runs-on: [self-hosted, icon-editor-windows]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/checkout@v4

--- a/.github/workflows/build-self-hosted.yml
+++ b/.github/workflows/build-self-hosted.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: [self-hosted, self-hosted-windows-lv]
+    runs-on: [self-hosted, icon-editor-windows]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
         include:
           - os: ubuntu-24.04
             runs-on: ubuntu-24.04
-          - os: self-hosted-windows-lv
-            runs-on: [self-hosted, self-hosted-windows-lv]
+          - os: icon-editor-windows
+            runs-on: [self-hosted, icon-editor-windows]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/close-labview-external.yml
+++ b/.github/workflows/close-labview-external.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   close-labview:
-    runs-on: [self-hosted, self-hosted-windows-lv]
+    runs-on: [self-hosted, icon-editor-windows]
     steps:
       - uses: actions/checkout@v4
       - name: Checkout target repository

--- a/.github/workflows/run-unit-tests-self-hosted.yml
+++ b/.github/workflows/run-unit-tests-self-hosted.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   run-unit-tests:
-    runs-on: [self-hosted, self-hosted-windows-lv]
+    runs-on: [self-hosted, icon-editor-windows]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/checkout@v4

--- a/docs/UnifiedDispatcher.md
+++ b/docs/UnifiedDispatcher.md
@@ -46,8 +46,8 @@ jobs:
         include:
           - os: ubuntu-24.04
             runs-on: ubuntu-24.04
-          - os: self-hosted-windows-lv
-            runs-on: [self-hosted, self-hosted-windows-lv]
+          - os: icon-editor-windows
+            runs-on: [self-hosted, icon-editor-windows]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@
 ```yaml
 jobs:
   build_lvlibp:
-    runs-on: [self-hosted, self-hosted-windows-lv]
+    runs-on: [self-hosted, icon-editor-windows]
     steps:
       - uses: actions/checkout@v3
       - name: Build Packed Library (32-bit)
@@ -53,7 +53,7 @@ Chain the [apply-vipc](actions/apply-vipc.md), [set-development-mode](actions/se
 ```yaml
 jobs:
   build_icon_editor:
-    runs-on: [self-hosted, self-hosted-windows-lv]
+    runs-on: [self-hosted, icon-editor-windows]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/checkout@v4

--- a/requirements.json
+++ b/requirements.json
@@ -37,153 +37,153 @@
     },
     {
       "id": "REQ-006",
-      "description": "Workflow checks out the LabVIEW icon editor repository and tests the composite action defined in apply-vipc/action.yml with minimum_supported_lv_version '2021', vip_lv_version '2021', supported_bitness '64', relative_path 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor', and vipc_path 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\.github\\actions\\apply-vipc\\runner_dependencies.vipc' on a self-hosted Windows runner labeled self-hosted-windows-lv with dry_run true.",
-      "owner": "self-hosted-windows-lv",
-      "runner_label": "self-hosted-windows-lv",
+      "description": "Workflow checks out the LabVIEW icon editor repository and tests the composite action defined in apply-vipc/action.yml with minimum_supported_lv_version '2021', vip_lv_version '2021', supported_bitness '64', relative_path 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor', and vipc_path 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\.github\\actions\\apply-vipc\\runner_dependencies.vipc' on a self-hosted Windows runner labeled icon-editor-windows with dry_run true.",
+      "owner": "icon-editor-windows",
+      "runner_label": "icon-editor-windows",
       "tests": [
         "ApplyVipc.SelfHosted.DryRunTrue.Workflow"
       ]
     },
     {
       "id": "REQ-007",
-      "description": "Workflow checks out the LabVIEW icon editor repository and tests the composite action defined in apply-vipc/action.yml with minimum_supported_lv_version '2021', vip_lv_version '2021', supported_bitness '64', relative_path 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor', and vipc_path 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\.github\\actions\\apply-vipc\\runner_dependencies.vipc' on a self-hosted Windows runner labeled self-hosted-windows-lv with dry_run false.",
-      "owner": "self-hosted-windows-lv",
-      "runner_label": "self-hosted-windows-lv",
+      "description": "Workflow checks out the LabVIEW icon editor repository and tests the composite action defined in apply-vipc/action.yml with minimum_supported_lv_version '2021', vip_lv_version '2021', supported_bitness '64', relative_path 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor', and vipc_path 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\.github\\actions\\apply-vipc\\runner_dependencies.vipc' on a self-hosted Windows runner labeled icon-editor-windows with dry_run false.",
+      "owner": "icon-editor-windows",
+      "runner_label": "icon-editor-windows",
       "tests": [
         "ApplyVipc.SelfHosted.DryRunFalse.Workflow"
       ]
     },
     {
       "id": "REQ-008",
-      "description": "Workflow tests the composite action defined in add-token-to-labview/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
-      "owner": "self-hosted-windows-lv",
-      "runner_label": "self-hosted-windows-lv",
+      "description": "Workflow tests the composite action defined in add-token-to-labview/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
+      "owner": "icon-editor-windows",
+      "runner_label": "icon-editor-windows",
       "tests": [
         "AddTokenToLabview.SelfHosted.Workflow"
       ]
     },
     {
       "id": "REQ-009",
-      "description": "Workflow tests the composite action defined in build/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
-      "owner": "self-hosted-windows-lv",
-      "runner_label": "self-hosted-windows-lv",
+      "description": "Workflow tests the composite action defined in build/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
+      "owner": "icon-editor-windows",
+      "runner_label": "icon-editor-windows",
       "tests": [
         "Build.SelfHosted.Workflow"
       ]
     },
     {
       "id": "REQ-010",
-      "description": "Workflow tests the composite action defined in build-lvlibp/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
-      "owner": "self-hosted-windows-lv",
-      "runner_label": "self-hosted-windows-lv",
+      "description": "Workflow tests the composite action defined in build-lvlibp/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
+      "owner": "icon-editor-windows",
+      "runner_label": "icon-editor-windows",
       "tests": [
         "BuildLvlibp.SelfHosted.Workflow"
       ]
     },
     {
       "id": "REQ-011",
-      "description": "Workflow tests the composite action defined in build-vi-package/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
-      "owner": "self-hosted-windows-lv",
-      "runner_label": "self-hosted-windows-lv",
+      "description": "Workflow tests the composite action defined in build-vi-package/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
+      "owner": "icon-editor-windows",
+      "runner_label": "icon-editor-windows",
       "tests": [
         "BuildViPackage.SelfHosted.Workflow"
       ]
     },
     {
       "id": "REQ-012",
-      "description": "Workflow clones an external repository and operates on it without modification using the composite action defined in close-labview/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
-      "owner": "self-hosted-windows-lv",
-      "runner_label": "self-hosted-windows-lv",
+      "description": "Workflow clones an external repository and operates on it without modification using the composite action defined in close-labview/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
+      "owner": "icon-editor-windows",
+      "runner_label": "icon-editor-windows",
       "tests": [
         "CloseLabview.SelfHosted.Workflow"
       ]
     },
     {
       "id": "REQ-013",
-      "description": "Workflow tests the composite action defined in generate-release-notes/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
-      "owner": "self-hosted-windows-lv",
-      "runner_label": "self-hosted-windows-lv",
+      "description": "Workflow tests the composite action defined in generate-release-notes/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
+      "owner": "icon-editor-windows",
+      "runner_label": "icon-editor-windows",
       "tests": [
         "GenerateReleaseNotes.SelfHosted.Workflow"
       ]
     },
     {
       "id": "REQ-014",
-      "description": "Workflow tests the composite action defined in missing-in-project/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
-      "owner": "self-hosted-windows-lv",
-      "runner_label": "self-hosted-windows-lv",
+      "description": "Workflow tests the composite action defined in missing-in-project/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
+      "owner": "icon-editor-windows",
+      "runner_label": "icon-editor-windows",
       "tests": [
         "MissingInProject.SelfHosted.Workflow"
       ]
     },
     {
       "id": "REQ-015",
-      "description": "Workflow tests the composite action defined in modify-vipb-display-info/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
-      "owner": "self-hosted-windows-lv",
-      "runner_label": "self-hosted-windows-lv",
+      "description": "Workflow tests the composite action defined in modify-vipb-display-info/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
+      "owner": "icon-editor-windows",
+      "runner_label": "icon-editor-windows",
       "tests": [
         "ModifyVipbDisplayInfo.SelfHosted.Workflow"
       ]
     },
     {
       "id": "REQ-016",
-      "description": "Workflow tests the composite action defined in prepare-labview-source/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
-      "owner": "self-hosted-windows-lv",
-      "runner_label": "self-hosted-windows-lv",
+      "description": "Workflow tests the composite action defined in prepare-labview-source/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
+      "owner": "icon-editor-windows",
+      "runner_label": "icon-editor-windows",
       "tests": [
         "PrepareLabviewSource.SelfHosted.Workflow"
       ]
     },
     {
       "id": "REQ-017",
-      "description": "Workflow tests the composite action defined in rename-file/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
-      "owner": "self-hosted-windows-lv",
-      "runner_label": "self-hosted-windows-lv",
+      "description": "Workflow tests the composite action defined in rename-file/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
+      "owner": "icon-editor-windows",
+      "runner_label": "icon-editor-windows",
       "tests": [
         "RenameFile.SelfHosted.Workflow"
       ]
     },
     {
       "id": "REQ-018",
-      "description": "Workflow tests the composite action defined in restore-setup-lv-source/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
-      "owner": "self-hosted-windows-lv",
-      "runner_label": "self-hosted-windows-lv",
+      "description": "Workflow tests the composite action defined in restore-setup-lv-source/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
+      "owner": "icon-editor-windows",
+      "runner_label": "icon-editor-windows",
       "tests": [
         "RestoreSetupLvSource.SelfHosted.Workflow"
       ]
     },
     {
       "id": "REQ-019",
-      "description": "Workflow tests the composite action defined in revert-development-mode/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
-      "owner": "self-hosted-windows-lv",
-      "runner_label": "self-hosted-windows-lv",
+      "description": "Workflow tests the composite action defined in revert-development-mode/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
+      "owner": "icon-editor-windows",
+      "runner_label": "icon-editor-windows",
       "tests": [
         "RevertDevelopmentMode.SelfHosted.Workflow"
       ]
     },
     {
       "id": "REQ-020",
-      "description": "Workflow tests the composite action defined in run-unit-tests/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
-      "owner": "self-hosted-windows-lv",
-      "runner_label": "self-hosted-windows-lv",
+      "description": "Workflow tests the composite action defined in run-unit-tests/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
+      "owner": "icon-editor-windows",
+      "runner_label": "icon-editor-windows",
       "tests": [
         "RunUnitTests.SelfHosted.Workflow"
       ]
     },
     {
       "id": "REQ-021",
-      "description": "Workflow tests the composite action defined in set-development-mode/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
-      "owner": "self-hosted-windows-lv",
-      "runner_label": "self-hosted-windows-lv",
+      "description": "Workflow tests the composite action defined in set-development-mode/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
+      "owner": "icon-editor-windows",
+      "runner_label": "icon-editor-windows",
       "tests": [
         "SetDevelopmentMode.SelfHosted.Workflow"
       ]
     },
     {
       "id": "REQ-022",
-      "description": "Workflow tests the composite action defined in setup-mkdocs/action.yml on a self-hosted Windows runner labeled self-hosted-windows-lv.",
-      "owner": "self-hosted-windows-lv",
-      "runner_label": "self-hosted-windows-lv",
+      "description": "Workflow tests the composite action defined in setup-mkdocs/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
+      "owner": "icon-editor-windows",
+      "runner_label": "icon-editor-windows",
       "tests": [
         "SetupMkdocs.SelfHosted.Workflow"
       ]

--- a/scripts/missing-in-project/README.md
+++ b/scripts/missing-in-project/README.md
@@ -60,7 +60,7 @@ Results are returned as standard GitHub Action outputs so downstream jobs can d
 jobs:
   missing-in-project-check:
     needs: [changes, apply-deps]
-    runs-on: self-hosted-windows-lv
+    runs-on: icon-editor-windows
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -87,7 +87,7 @@ If you want **any** missing file to abort the pipeline immediately, place the st
 jobs:
   missing-in-project-check:
     needs: [changes, apply-deps]
-    runs-on: self-hosted-windows-lv
+    runs-on: icon-editor-windows
     strategy:
       matrix:
         arch: [32, 64]

--- a/tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1
@@ -18,7 +18,7 @@ Describe 'AddTokenToLabview.SelfHosted.Workflow [REQ-008]' {
                 $addStep = $job.steps | Where-Object { $_.uses -eq './add-token-to-labview/action.yml' } | Select-Object -First 1
                 if ($null -ne $addStep) {
                     $workflowFound = $true
-                    $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+                    $job.'runs-on' | Should -Be @('self-hosted','icon-editor-windows')
                     $addStep.uses | Should -Be './add-token-to-labview/action.yml'
                     $addStep.with.minimum_supported_lv_version | Should -Not -BeNullOrEmpty
                     $addStep.with.supported_bitness | Should -Not -BeNullOrEmpty

--- a/tests/pester/ApplyVipc.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/ApplyVipc.SelfHosted.Workflow.Tests.ps1
@@ -13,7 +13,7 @@ Describe 'ApplyVipc.SelfHosted.DryRunTrue.Workflow [REQ-006]' {
         $applyStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq './apply-vipc/action.yml' } | Select-Object -First 1
         $checkoutIconRepoStep = $job.steps | Where-Object { $_.ContainsKey('with') -and $_['with']['repository'] -eq 'LabVIEW-Community-CI-CD/labview-icon-editor' } | Select-Object -First 1
 
-        $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+        $job.'runs-on' | Should -Be @('self-hosted','icon-editor-windows')
         $job.strategy.matrix.dry_run | Should -Contain $true
 
         $checkoutIconRepoStep.uses | Should -Be 'actions/checkout@v4'
@@ -38,7 +38,7 @@ Describe 'ApplyVipc.SelfHosted.DryRunFalse.Workflow [REQ-007]' {
         $applyStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq './apply-vipc/action.yml' } | Select-Object -First 1
         $checkoutIconRepoStep = $job.steps | Where-Object { $_.ContainsKey('with') -and $_['with']['repository'] -eq 'LabVIEW-Community-CI-CD/labview-icon-editor' } | Select-Object -First 1
 
-        $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+        $job.'runs-on' | Should -Be @('self-hosted','icon-editor-windows')
         $job.strategy.matrix.dry_run | Should -Contain $false
 
         $checkoutIconRepoStep.uses | Should -Be 'actions/checkout@v4'

--- a/tests/pester/Build.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/Build.SelfHosted.Workflow.Tests.ps1
@@ -13,7 +13,7 @@ Describe 'Build.SelfHosted.Workflow [REQ-009]' {
         $buildStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq './build/action.yml' } | Select-Object -First 1
         $artifactStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq 'actions/upload-artifact@v4' -and $_['with']['path'] -match 'lv_icon_x64\.lvlibp' } | Select-Object -First 1
 
-        $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+        $job.'runs-on' | Should -Be @('self-hosted','icon-editor-windows')
 
         $buildStep.with.relative_path | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor'
         $buildStep.with.major | Should -Be '1'

--- a/tests/pester/BuildLvlibp.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/BuildLvlibp.SelfHosted.Workflow.Tests.ps1
@@ -13,7 +13,7 @@ Describe 'BuildLvlibp.SelfHosted.Workflow [REQ-010]' {
         $buildStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq './build-lvlibp/action.yml' } | Select-Object -First 1
         $artifactStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq 'actions/upload-artifact@v4' -and $_['with']['path'] -match '\.lvlibp$' } | Select-Object -First 1
 
-        $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+        $job.'runs-on' | Should -Be @('self-hosted','icon-editor-windows')
 
         $buildStep.with.minimum_supported_lv_version | Should -Be '2021'
         $buildStep.with.supported_bitness | Should -Be '64'

--- a/tests/pester/BuildViPackage.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/BuildViPackage.SelfHosted.Workflow.Tests.ps1
@@ -17,7 +17,7 @@ Describe 'BuildViPackage.SelfHosted.Workflow [REQ-011]' {
         $buildStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq './build-vi-package/action.yml' } | Select-Object -First 1
         $artifactStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq 'actions/upload-artifact@v4' -and $_['with']['path'] -match '\.vip$' } | Select-Object -First 1
 
-        $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+        $job.'runs-on' | Should -Be @('self-hosted','icon-editor-windows')
 
         $buildStep.with.vipb_path | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\Tooling\\deployment\\NI Icon editor.vipb'
         $buildStep.with.major | Should -Be '1'

--- a/tests/pester/CloseLabview.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/CloseLabview.SelfHosted.Workflow.Tests.ps1
@@ -22,7 +22,7 @@ Describe 'CloseLabview.SelfHosted.Workflow [REQ-012]' {
             $closeSteps = $job.steps | Where-Object { $_.uses -eq './close-labview/action.yml' }
             if ($closeSteps) {
                 $jobFound = $true
-                $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+                $job.'runs-on' | Should -Be @('self-hosted','icon-editor-windows')
                 $bitness = $closeSteps | ForEach-Object { $_.with.supported_bitness }
                 $bitness | Should -Contain '32'
                 $bitness | Should -Contain '64'

--- a/tests/pester/MissingInProject.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/MissingInProject.SelfHosted.Workflow.Tests.ps1
@@ -18,7 +18,7 @@ Describe 'MissingInProject.SelfHosted.Workflow [REQ-014]' {
                 $missingStep = $job.steps | Where-Object { $_.uses -eq './missing-in-project/action.yml' } | Select-Object -First 1
                 if ($null -ne $missingStep) {
                     $workflowFound = $true
-                    $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+                    $job.'runs-on' | Should -Be @('self-hosted','icon-editor-windows')
                     $missingStep.uses | Should -Be './missing-in-project/action.yml'
                     $missingStep.with.lv_version | Should -Not -BeNullOrEmpty
                     $missingStep.with.arch | Should -Not -BeNullOrEmpty

--- a/tests/pester/ModifyVipbDisplayInfo.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/ModifyVipbDisplayInfo.SelfHosted.Workflow.Tests.ps1
@@ -18,7 +18,7 @@ Describe 'ModifyVipbDisplayInfo.SelfHosted.Workflow [REQ-015]' {
                 $modStep = $job.steps | Where-Object { $_.uses -eq './modify-vipb-display-info/action.yml' } | Select-Object -First 1
                 if ($null -ne $modStep) {
                     $workflowFound = $true
-                    $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+                    $job.'runs-on' | Should -Be @('self-hosted','icon-editor-windows')
                     $modStep.uses | Should -Be './modify-vipb-display-info/action.yml'
                     $modStep.with.supported_bitness | Should -Not -BeNullOrEmpty
                     $modStep.with.relative_path | Should -Not -BeNullOrEmpty

--- a/tests/pester/PrepareLabviewSource.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/PrepareLabviewSource.SelfHosted.Workflow.Tests.ps1
@@ -18,7 +18,7 @@ Describe 'PrepareLabviewSource.SelfHosted.Workflow [REQ-011]' {
                 $prepareStep = $job.steps | Where-Object { $_.uses -eq './prepare-labview-source/action.yml' } | Select-Object -First 1
                 if ($null -ne $prepareStep) {
                     $workflowFound = $true
-                    $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+                    $job.'runs-on' | Should -Be @('self-hosted','icon-editor-windows')
                     $prepareStep.uses | Should -Be './prepare-labview-source/action.yml'
                     $prepareStep.with.relative_path | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor'
                     $prepareStep.with.labview_project | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\source\\lv_icon.lvproj'

--- a/tests/pester/RenameFile.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RenameFile.SelfHosted.Workflow.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'RenameFile.SelfHosted.Workflow [REQ-011]' {
                 if ($null -ne $renameStep) {
                     $workflowFound = $true
 
-                    $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+                    $job.'runs-on' | Should -Be @('self-hosted','icon-editor-windows')
                     $renameStep.uses | Should -Be './rename-file/action.yml'
                     $renameStep.with.current_filename | Should -Not -BeNullOrEmpty
                     $renameStep.with.new_filename | Should -Not -BeNullOrEmpty

--- a/tests/pester/RestoreSetupLvSource.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RestoreSetupLvSource.SelfHosted.Workflow.Tests.ps1
@@ -18,7 +18,7 @@ Describe 'RestoreSetupLvSource.SelfHosted.Workflow [REQ-018]' {
                 $restoreStep = $job.steps | Where-Object { $_.uses -eq './restore-setup-lv-source/action.yml' } | Select-Object -First 1
                 if ($null -ne $restoreStep) {
                     $workflowFound = $true
-                    $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+                    $job.'runs-on' | Should -Be @('self-hosted','icon-editor-windows')
                     $restoreStep.with.relative_path | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor'
                     $restoreStep.env | Should -Not -BeNullOrEmpty
                     $artifactStep = $job.steps | Where-Object {

--- a/tests/pester/RevertDevelopmentMode.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RevertDevelopmentMode.SelfHosted.Workflow.Tests.ps1
@@ -18,7 +18,7 @@ Describe 'RevertDevelopmentMode.SelfHosted.Workflow [REQ-019]' {
                 $revertStep = $job.steps | Where-Object { $_.uses -eq './revert-development-mode/action.yml' } | Select-Object -First 1
                 if ($null -ne $revertStep) {
                     $workflowFound = $true
-                    $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+                    $job.'runs-on' | Should -Be @('self-hosted','icon-editor-windows')
                     $revertStep.uses | Should -Be './revert-development-mode/action.yml'
                     $revertStep.with.relative_path | Should -Not -BeNullOrEmpty
                     $uploadStep = $job.steps | Where-Object {

--- a/tests/pester/RunUnitTests.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RunUnitTests.SelfHosted.Workflow.Tests.ps1
@@ -13,7 +13,7 @@ Describe 'RunUnitTests.SelfHosted.Workflow [REQ-011]' {
         $testStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq './run-unit-tests/action.yml' } | Select-Object -First 1
         $artifactStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq 'actions/upload-artifact@v4' -and $_['with']['path'] -match 'UnitTestReport\.xml' } | Select-Object -First 1
 
-        $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+        $job.'runs-on' | Should -Be @('self-hosted','icon-editor-windows')
 
         $testStep.with.minimum_supported_lv_version | Should -Be '2021'
         $testStep.with.supported_bitness | Should -Be '64'

--- a/tests/pester/SetDevelopmentMode.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/SetDevelopmentMode.SelfHosted.Workflow.Tests.ps1
@@ -18,7 +18,7 @@ Describe 'SetDevelopmentMode.SelfHosted.Workflow [REQ-021]' {
                 $setStep = $job.steps | Where-Object { $_.uses -eq './set-development-mode/action.yml' } | Select-Object -First 1
                 if ($null -ne $setStep) {
                     $workflowFound = $true
-                    $job.'runs-on' | Should -Be @('self-hosted','self-hosted-windows-lv')
+                    $job.'runs-on' | Should -Be @('self-hosted','icon-editor-windows')
                     $setStep.with.relative_path | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor'
                     $setStep.with.gcli_path | Should -Not -BeNullOrEmpty
                     $setStep.with.working_directory | Should -Not -BeNullOrEmpty


### PR DESCRIPTION
## Summary
- switch Windows runner references to `icon-editor-windows`
- update requirement owners and workflows

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Install-Module -Name Pester,powershell-yaml -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a0d379ebb08329861b2d4415a8dd70