### PR TITLE
Add numeric IDs to traceability matrix rows

### DIFF
--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -4,7 +4,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { collectTestCases, loadRequirements, mapToRequirements } from '../generate-ci-summary.ts';
+import { collectTestCases, loadRequirements, mapToRequirements, groupToMarkdown } from '../generate-ci-summary.ts';
 import { writeErrorSummary } from '../error-handler.ts';
 
 const fileUrl = new URL('../generate-ci-summary.ts', import.meta.url);
@@ -40,4 +40,18 @@ test('associates classname with requirement', async () => {
   const req = groups.find((g) => g.id === 'REQ-001');
   assert(req && req.tests.some((t) => t.className === 'Dispatcher.Tests'));
   await fs.rm(dir, { recursive: true, force: true });
+});
+
+test('groupToMarkdown assigns numeric identifiers', () => {
+  const groups = [{
+    id: 'REQ-XYZ',
+    tests: [
+      { id: 'a', name: 'alpha', status: 'Passed', duration: 0, requirements: [] },
+      { id: 'b', name: 'beta', status: 'Failed', duration: 0, requirements: [] },
+    ],
+  }];
+  const md = groupToMarkdown(groups);
+  assert.match(md, /\| ID \| Requirement \| Test ID \| Status \|/);
+  assert.match(md, /\| 0 \| REQ-XYZ \| alpha \| Passed \|/);
+  assert.match(md, /\| 1 \| REQ-XYZ \| beta \| Failed \|/);
 });

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -154,7 +154,7 @@ function buildSummary(groups: RequirementGroup[]) {
   return { passed, failed, skipped, duration, rate };
 }
 
-function groupToMarkdown(groups: RequirementGroup[], limit?: number) {
+export function groupToMarkdown(groups: RequirementGroup[], limit?: number) {
   const lines: string[] = [];
   let count = 0;
   for (const g of groups) {
@@ -162,13 +162,14 @@ function groupToMarkdown(groups: RequirementGroup[], limit?: number) {
     const passedCount = g.tests.filter((t) => t.status === 'Passed').length;
     const pct = total === 0 ? 0 : Math.round((passedCount / total) * 100);
     const header = `${g.id} (${pct}% passed)`;
-    const table = ['| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |', '| --- | --- | --- | --- | --- | --- |'];
-      for (const t of g.tests) {
-        if (limit && count >= limit) break;
-        const evidence = t.evidence ? `[link](${t.evidence})` : '';
-        table.push(`| ${g.id} | ${t.name} | ${t.status} | ${t.duration.toFixed(3)} | ${t.owner ?? g.owner ?? ''} | ${evidence} |`);
-        count++;
-      }
+    const table = ['| ID | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |',
+      '| --- | --- | --- | --- | --- | --- | --- |'];
+    for (const t of g.tests) {
+      if (limit && count >= limit) break;
+      const evidence = t.evidence ? `[link](${t.evidence})` : '';
+      table.push(`| ${count} | ${g.id} | ${t.name} | ${t.status} | ${t.duration.toFixed(3)} | ${t.owner ?? g.owner ?? ''} | ${evidence} |`);
+      count++;
+    }
     const content = table.join('\n');
     if (g.tests.length > 5) {
       lines.push(`<details><summary>${header}</summary>\n\n${content}\n\n</details>`);


### PR DESCRIPTION
## Summary
- number rows in traceability matrix with an incrementing ID
- test markdown generation for numeric identifiers

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command '$PSVersionTable.PSVersion'`
- `pwsh -NoLogo -Command "Install-Module -Name Pester,powershell-yaml -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a0de00140c83299009948ff43716b5