### PR TITLE
feat: split CI summary by OS

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - icon-editor-windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,13 @@ jobs:
         include:
           - os: ubuntu-24.04
             runs-on: ubuntu-24.04
+            runner_type: default
           - os: icon-editor-windows
             runs-on: [self-hosted, icon-editor-windows]
+            runner_type: integration
     runs-on: ${{ matrix.runs-on }}
+    env:
+      RUNNER_TYPE: ${{ matrix.runner_type }}
     steps:
       - uses: actions/checkout@v4
       - name: Capture setup info
@@ -79,8 +83,15 @@ jobs:
             Install-Module -Name Pester -MinimumVersion 5.0.0 -Scope CurrentUser -Force -SkipPublisherCheck
           }
       - name: Install powershell-yaml
+        if: matrix.runner_type != 'integration'
         shell: pwsh
         run: Install-Module -Name powershell-yaml -Scope CurrentUser -Force
+      - name: Validate native YAML parsing
+        if: matrix.runner_type == 'integration'
+        shell: pwsh
+        run: |
+          $parsed = ConvertFrom-Yaml 'a: 1'
+          if ($parsed.a -ne 1) { throw 'YAML parsing failed' }
       - name: Run Pester
         shell: pwsh
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,29 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4
+      - name: Capture setup info
+        shell: pwsh
+        run: |
+          $data = [ordered]@{
+            'Current runner version' = $env:RUNNER_VERSION
+            'Runner Image'          = $env:ImageOS
+            'ImageVersion'          = $env:ImageVersion
+            'RUNNER_NAME'           = $env:RUNNER_NAME
+            'RUNNER_OS'             = $env:RUNNER_OS
+            'RUNNER_ARCH'           = $env:RUNNER_ARCH
+          }
+          $file = "setup-info-${{ matrix.os }}.md"
+          "was captured from the set up job." | Out-File -FilePath $file -Encoding utf8
+          foreach ($k in $data.Keys) {
+            if ($data[$k]) {
+              "$k: $($data[$k])" | Out-File -FilePath $file -Encoding utf8 -Append
+            }
+          }
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: setup-info-${{ matrix.os }}
+          path: setup-info-${{ matrix.os }}.md
       - name: Install Pester
         shell: pwsh
         run: |
@@ -107,3 +130,13 @@ jobs:
         run: |
           cat artifacts/traceability.md >> "$GITHUB_STEP_SUMMARY"
           cat artifacts/traceability.md
+      - name: Include setup information
+        run: |
+          echo '## ubuntu-24.04' >> "$GITHUB_STEP_SUMMARY"
+          cat downloaded/setup-info-ubuntu-24.04/setup-info-ubuntu-24.04.md >> "$GITHUB_STEP_SUMMARY"
+          echo '## icon-editor-windows' >> "$GITHUB_STEP_SUMMARY"
+          cat downloaded/setup-info-icon-editor-windows/setup-info-icon-editor-windows.md >> "$GITHUB_STEP_SUMMARY"
+          echo '## ubuntu-24.04'
+          cat downloaded/setup-info-ubuntu-24.04/setup-info-ubuntu-24.04.md
+          echo '## icon-editor-windows'
+          cat downloaded/setup-info-icon-editor-windows/setup-info-icon-editor-windows.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,8 @@ jobs:
           EVIDENCE_DIR: test-screenshots
       - name: Print test traceability matrix
         run: |
-          cat artifacts/traceability.md >> "$GITHUB_STEP_SUMMARY"
-          cat artifacts/traceability.md
+          cat "artifacts/${RUNNER_OS,,}/traceability.md" >> "$GITHUB_STEP_SUMMARY"
+          cat "artifacts/${RUNNER_OS,,}/traceability.md"
       - name: Include setup information
         run: |
           echo '## ubuntu-24.04' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,17 @@ jobs:
         if: always()
         with:
           name: traceability
-          path: artifacts/${{ toLower(runner.os) }}/traceability.*
+          path: artifacts/${{ runner.os == 'Windows' && 'windows' || runner.os == 'macOS' && 'macos' || 'linux' }}/traceability.*
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: action-docs
-          path: artifacts/${{ toLower(runner.os) }}/action-docs.*
+          path: artifacts/${{ runner.os == 'Windows' && 'windows' || runner.os == 'macOS' && 'macos' || 'linux' }}/action-docs.*
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: evidence
-          path: artifacts/${{ toLower(runner.os) }}/evidence/**
+          path: artifacts/${{ runner.os == 'Windows' && 'windows' || runner.os == 'macOS' && 'macos' || 'linux' }}/evidence/**
           if-no-files-found: ignore
 
   ps-ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           "was captured from the set up job." | Out-File -FilePath $file -Encoding utf8
           foreach ($k in $data.Keys) {
             if ($data[$k]) {
-              "$k: $($data[$k])" | Out-File -FilePath $file -Encoding utf8 -Append
+              "${k}: $($data[$k])" | Out-File -FilePath $file -Encoding utf8 -Append
             }
           }
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,17 @@ jobs:
         if: always()
         with:
           name: traceability
-          path: artifacts/traceability.*
+          path: artifacts/${{ toLower(runner.os) }}/traceability.*
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: action-docs
-          path: artifacts/action-docs.*
+          path: artifacts/${{ toLower(runner.os) }}/action-docs.*
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: evidence
-          path: artifacts/evidence/**
+          path: artifacts/${{ toLower(runner.os) }}/evidence/**
           if-no-files-found: ignore
 
   ps-ci:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Run `npm test`.
 - Run `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md` to lint Markdown files.
 - Run `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')` to verify links.
+- Run `npx --yes actionlint` to validate GitHub Actions workflows.
 - Ensure PowerShell 7.5.2 is installed.
 - Run `pwsh -NoLogo -Command "Install-Module -Name Pester,powershell-yaml -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,8 @@
 - Run `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')` to verify links.
 - Run `npx --yes actionlint` to validate GitHub Actions workflows.
 - Ensure PowerShell 7.5.2 is installed.
-- Run `pwsh -NoLogo -Command "Install-Module -Name Pester,powershell-yaml -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"`.
+- Run `pwsh -NoLogo -Command "Install-Module -Name Pester -Force -Scope AllUsers; if ($env:RUNNER_TYPE -ne 'integration') { Install-Module -Name powershell-yaml -Force -Scope AllUsers }; Invoke-Pester -CI -Path ./tests/pester"`.
+- If `$env:RUNNER_TYPE` is `integration`, verify native YAML parsing with `pwsh -NoLogo -Command "ConvertFrom-Yaml 'a: 1' | Out-Null"` before running Pester.
 
 All tests above are mandatory; they must pass before committing.
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ npm install
 npm test
 ```
 
-For CI, `npm run test:ci` emits a JUnit XML report that [scripts/generate-ci-summary.ts](scripts/generate-ci-summary.ts) parses to build requirement traceability files.
+For CI, `npm run test:ci` emits a JUnit XML report that [scripts/generate-ci-summary.ts](scripts/generate-ci-summary.ts) parses to build requirement traceability files in OS‑specific subdirectories (e.g., `artifacts/windows`, `artifacts/linux`).
 
 Pester tests cover the dispatcher and helper modules. See [docs/testing-pester.md](docs/testing-pester.md) for guidelines on using the canonical argument helper and adding new tests. Run them with:
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ npm install
 npm test
 ```
 
-For CI, `npm run test:ci` emits a JUnit XML report that [scripts/generate-ci-summary.ts](scripts/generate-ci-summary.ts) parses to build requirement traceability files in OS‑specific subdirectories (e.g., `artifacts/windows`, `artifacts/linux`).
+For CI, `npm run test:ci` emits a JUnit XML report that [scripts/generate-ci-summary.ts](scripts/generate-ci-summary.ts) parses to build requirement traceability files in OS‑specific subdirectories (e.g., `artifacts/windows`, `artifacts/linux`) based on the `RUNNER_OS` environment variable.
 
 Pester tests cover the dispatcher and helper modules. See [docs/testing-pester.md](docs/testing-pester.md) for guidelines on using the canonical argument helper and adding new tests. Run them with:
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -20,3 +20,12 @@ During CI runs, `scripts/generate-ci-summary.ts` writes requirement artifacts
 to an OS‑specific directory under `artifacts/`, such as
 `artifacts/windows/traceability.md` or `artifacts/linux/traceability.md`, using the `RUNNER_OS` environment variable.
 
+Each directory also includes a `summary.md` file with per‑OS totals. A typical
+summary might look like this:
+
+| OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
+| --- | --- | --- | --- | --- | --- |
+| overall | 10 | 0 | 2 | 12.34 | 100.00 |
+| windows | 5 | 0 | 1 | 6.17 | 100.00 |
+| linux | 5 | 0 | 1 | 6.17 | 100.00 |
+

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,31 +1,40 @@
 # Requirements
 
-This project tracks high‑level requirements and maps each one to the Pester test
-files that verify it. The authoritative mapping is stored in
-[`requirements.json`](../requirements.json) at the repository root; the table below
-provides a human‑readable summary for quick reference.
+This project tracks high‑level requirements and maps each one to the Pester test files that verify it. The authoritative mapping is stored in [`requirements.json`](../requirements.json); the table below provides a human‑readable summary for quick reference.
 
-| ID | Description | Tests |
-|----|-------------|-------|
-| REQ-001 | Dispatcher discovers available actions, describes them, and validates arguments. | `tests/pester/Dispatcher.Tests.ps1` |
-| REQ-002 | Dispatcher dry‑run mode prints descriptions and warns on unknown arguments without executing actions. | `tests/pester/Dispatcher.DryRun.Tests.ps1` |
-| REQ-003 | Actions correctly resolve and pass RelativePath arguments without warnings. | `tests/pester/RelativePath.Actions.Tests.ps1` |
-| REQ-004 | Every action script exists at the expected path. | `tests/pester/ScriptPath.Tests.ps1` |
-| REQ-005 | Dispatcher fails when RelativePath is missing or invalid. | `tests/pester/Dispatcher.InvalidPaths.Tests.ps1` |
+| ID | Description | Tests | Runner | Runner Type | Skip Dry Run |
+|----|-------------|-------|--------|-------------|--------------|
+| REQ-001 | Dispatcher discovers available actions, describes them, and validates arguments. | `tests/pester/Dispatcher.Tests.ps1` |  |  |  |
+| REQ-002 | Dispatcher dry-run mode prints descriptions and warns on unknown arguments without executing actions. | `tests/pester/Dispatcher.DryRun.Tests.ps1` |  |  |  |
+| REQ-003 | Actions correctly resolve and pass RelativePath arguments without warnings. | `tests/pester/RelativePath.Actions.Tests.ps1` |  |  |  |
+| REQ-004 | Every action script exists at the expected path. | `tests/pester/ScriptPath.Tests.ps1` |  |  |  |
+| REQ-005 | Dispatcher fails when RelativePath is missing or invalid. | `tests/pester/Dispatcher.InvalidPaths.Tests.ps1` |  |  |  |
+| REQ-006 | Workflow checks out the LabVIEW icon editor repository and tests the composite action defined in apply-vipc/action.yml with minimum_supported_lv_version '2021', vip_lv_version '2021', supported_bitness '64', relative_path 'C:\actions-runner\_work\labview-icon-editor\labview-icon-editor', and vipc_path 'C:\actions-runner\_work\labview-icon-editor\labview-icon-editor\.github\actions\apply-vipc\runner_dependencies.vipc' on a self-hosted Windows runner labeled icon-editor-windows with dry_run true. | `tests/pester/ApplyVipc.SelfHosted.DryRunTrue.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-007 | Workflow checks out the LabVIEW icon editor repository and tests the composite action defined in apply-vipc/action.yml with minimum_supported_lv_version '2021', vip_lv_version '2021', supported_bitness '64', relative_path 'C:\actions-runner\_work\labview-icon-editor\labview-icon-editor', and vipc_path 'C:\actions-runner\_work\labview-icon-editor\labview-icon-editor\.github\actions\apply-vipc\runner_dependencies.vipc' on a self-hosted Windows runner labeled icon-editor-windows with dry_run false. | `tests/pester/ApplyVipc.SelfHosted.DryRunFalse.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-008 | Workflow tests the composite action defined in add-token-to-labview/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/AddTokenToLabview.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-009 | Workflow tests the composite action defined in build/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/Build.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-010 | Workflow tests the composite action defined in build-lvlibp/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/BuildLvlibp.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-011 | Workflow tests the composite action defined in build-vi-package/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/BuildViPackage.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-012 | Workflow clones an external repository and operates on it without modification using the composite action defined in close-labview/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/CloseLabview.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-013 | Workflow tests the composite action defined in generate-release-notes/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/GenerateReleaseNotes.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-014 | Workflow tests the composite action defined in missing-in-project/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/MissingInProject.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-015 | Workflow tests the composite action defined in modify-vipb-display-info/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/ModifyVipbDisplayInfo.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-016 | Workflow tests the composite action defined in prepare-labview-source/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/PrepareLabviewSource.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-017 | Workflow tests the composite action defined in rename-file/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/RenameFile.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-018 | Workflow tests the composite action defined in restore-setup-lv-source/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/RestoreSetupLvSource.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-019 | Workflow tests the composite action defined in revert-development-mode/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/RevertDevelopmentMode.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-020 | Workflow tests the composite action defined in run-unit-tests/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/RunUnitTests.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-021 | Workflow tests the composite action defined in set-development-mode/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/SetDevelopmentMode.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-022 | Workflow tests the composite action defined in setup-mkdocs/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/SetupMkdocs.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
 
-Each test file is annotated with its corresponding requirement ID to maintain
-traceability between requirements and test coverage.
+Each test file is annotated with its corresponding requirement ID to maintain traceability between requirements and test coverage.
 
-During CI runs, `scripts/generate-ci-summary.ts` writes requirement artifacts
-to an OS‑specific directory under `artifacts/`, such as
-`artifacts/windows/traceability.md` or `artifacts/linux/traceability.md`, using the `RUNNER_OS` environment variable.
+During CI runs, `scripts/generate-ci-summary.ts` writes requirement artifacts to an OS‑specific directory under `artifacts/`, such as `artifacts/windows/traceability.md` or `artifacts/linux/traceability.md`, using the `RUNNER_OS` environment variable.
 
-Each directory also includes a `summary.md` file with per‑OS totals. A typical
-summary might look like this:
+Each directory also includes a `summary.md` file with per‑OS totals. A typical summary might look like this:
 
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
 | overall | 10 | 0 | 2 | 12.34 | 100.00 |
 | windows | 5 | 0 | 1 | 6.17 | 100.00 |
 | linux | 5 | 0 | 1 | 6.17 | 100.00 |
-

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -18,5 +18,5 @@ traceability between requirements and test coverage.
 
 During CI runs, `scripts/generate-ci-summary.ts` writes requirement artifacts
 to an OS‑specific directory under `artifacts/`, such as
-`artifacts/windows/traceability.md` or `artifacts/linux/traceability.md`.
+`artifacts/windows/traceability.md` or `artifacts/linux/traceability.md`, using the `RUNNER_OS` environment variable.
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -16,6 +16,7 @@ provides a human‑readable summary for quick reference.
 Each test file is annotated with its corresponding requirement ID to maintain
 traceability between requirements and test coverage.
 
-During CI runs, `scripts/generate-ci-summary.ts` produces the `traceability.md`
-artifact, which contains the full requirement traceability matrix.
+During CI runs, `scripts/generate-ci-summary.ts` writes requirement artifacts
+to an OS‑specific directory under `artifacts/`, such as
+`artifacts/windows/traceability.md` or `artifacts/linux/traceability.md`.
 

--- a/requirements.json
+++ b/requirements.json
@@ -1,4 +1,12 @@
 {
+  "runners": {
+    "icon-editor-windows": {
+      "owner": "icon-editor-windows",
+      "runner_label": "icon-editor-windows",
+      "runner_type": "integration",
+      "skip_dry_run": true
+    }
+  },
   "requirements": [
     {
       "id": "REQ-001",
@@ -38,8 +46,7 @@
     {
       "id": "REQ-006",
       "description": "Workflow checks out the LabVIEW icon editor repository and tests the composite action defined in apply-vipc/action.yml with minimum_supported_lv_version '2021', vip_lv_version '2021', supported_bitness '64', relative_path 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor', and vipc_path 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\.github\\actions\\apply-vipc\\runner_dependencies.vipc' on a self-hosted Windows runner labeled icon-editor-windows with dry_run true.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "ApplyVipc.SelfHosted.DryRunTrue.Workflow"
       ]
@@ -47,8 +54,7 @@
     {
       "id": "REQ-007",
       "description": "Workflow checks out the LabVIEW icon editor repository and tests the composite action defined in apply-vipc/action.yml with minimum_supported_lv_version '2021', vip_lv_version '2021', supported_bitness '64', relative_path 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor', and vipc_path 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\.github\\actions\\apply-vipc\\runner_dependencies.vipc' on a self-hosted Windows runner labeled icon-editor-windows with dry_run false.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "ApplyVipc.SelfHosted.DryRunFalse.Workflow"
       ]
@@ -56,8 +62,7 @@
     {
       "id": "REQ-008",
       "description": "Workflow tests the composite action defined in add-token-to-labview/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "AddTokenToLabview.SelfHosted.Workflow"
       ]
@@ -65,8 +70,7 @@
     {
       "id": "REQ-009",
       "description": "Workflow tests the composite action defined in build/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "Build.SelfHosted.Workflow"
       ]
@@ -74,8 +78,7 @@
     {
       "id": "REQ-010",
       "description": "Workflow tests the composite action defined in build-lvlibp/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "BuildLvlibp.SelfHosted.Workflow"
       ]
@@ -83,8 +86,7 @@
     {
       "id": "REQ-011",
       "description": "Workflow tests the composite action defined in build-vi-package/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "BuildViPackage.SelfHosted.Workflow"
       ]
@@ -92,8 +94,7 @@
     {
       "id": "REQ-012",
       "description": "Workflow clones an external repository and operates on it without modification using the composite action defined in close-labview/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "CloseLabview.SelfHosted.Workflow"
       ]
@@ -101,8 +102,7 @@
     {
       "id": "REQ-013",
       "description": "Workflow tests the composite action defined in generate-release-notes/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "GenerateReleaseNotes.SelfHosted.Workflow"
       ]
@@ -110,8 +110,7 @@
     {
       "id": "REQ-014",
       "description": "Workflow tests the composite action defined in missing-in-project/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "MissingInProject.SelfHosted.Workflow"
       ]
@@ -119,8 +118,7 @@
     {
       "id": "REQ-015",
       "description": "Workflow tests the composite action defined in modify-vipb-display-info/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "ModifyVipbDisplayInfo.SelfHosted.Workflow"
       ]
@@ -128,8 +126,7 @@
     {
       "id": "REQ-016",
       "description": "Workflow tests the composite action defined in prepare-labview-source/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "PrepareLabviewSource.SelfHosted.Workflow"
       ]
@@ -137,8 +134,7 @@
     {
       "id": "REQ-017",
       "description": "Workflow tests the composite action defined in rename-file/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "RenameFile.SelfHosted.Workflow"
       ]
@@ -146,8 +142,7 @@
     {
       "id": "REQ-018",
       "description": "Workflow tests the composite action defined in restore-setup-lv-source/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "RestoreSetupLvSource.SelfHosted.Workflow"
       ]
@@ -155,8 +150,7 @@
     {
       "id": "REQ-019",
       "description": "Workflow tests the composite action defined in revert-development-mode/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "RevertDevelopmentMode.SelfHosted.Workflow"
       ]
@@ -164,8 +158,7 @@
     {
       "id": "REQ-020",
       "description": "Workflow tests the composite action defined in run-unit-tests/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "RunUnitTests.SelfHosted.Workflow"
       ]
@@ -173,8 +166,7 @@
     {
       "id": "REQ-021",
       "description": "Workflow tests the composite action defined in set-development-mode/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "SetDevelopmentMode.SelfHosted.Workflow"
       ]
@@ -182,8 +174,7 @@
     {
       "id": "REQ-022",
       "description": "Workflow tests the composite action defined in setup-mkdocs/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "SetupMkdocs.SelfHosted.Workflow"
       ]

--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -4,6 +4,8 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
 import { fileURLToPath } from 'node:url';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { collectTestCases, loadRequirements, mapToRequirements, groupToMarkdown, buildSummary } from '../generate-ci-summary.ts';
 import { writeErrorSummary } from '../error-handler.ts';
 
@@ -70,4 +72,30 @@ test('buildSummary splits totals by OS', () => {
   assert.strictEqual(summary.byOs.windows.passed, 1);
   assert.strictEqual(summary.byOs.linux.failed, 1);
   assert.strictEqual(summary.byOs.linux.skipped, 1);
+});
+
+const execFileP = promisify(execFile);
+
+test('writes outputs to OS-specific directory', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'summary-'));
+  const junitPath = path.join(tmp, 'junit.xml');
+  await fs.writeFile(junitPath, '<testsuite><testcase name="foo" time="0"/></testsuite>');
+
+  await fs.rm('artifacts', { recursive: true, force: true });
+
+  const env = {
+    ...process.env,
+    TEST_RESULTS_GLOB: junitPath,
+    EVIDENCE_DIR: tmp,
+    RUNNER_OS: 'Windows',
+  };
+
+  await execFileP('node_modules/.bin/tsx', ['scripts/generate-ci-summary.ts'], { env });
+
+  const outDir = path.join('artifacts', 'windows');
+  const exists = await fs.stat(path.join(outDir, 'traceability.json')).then(() => true, () => false);
+  assert.strictEqual(exists, true);
+
+  await fs.rm(tmp, { recursive: true, force: true });
+  await fs.rm('artifacts', { recursive: true, force: true });
 });

--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -95,6 +95,8 @@ test('writes outputs to OS-specific directory', async () => {
   const outDir = path.join('artifacts', 'windows');
   const exists = await fs.stat(path.join(outDir, 'traceability.json')).then(() => true, () => false);
   assert.strictEqual(exists, true);
+  const summary = await fs.readFile(path.join(outDir, 'summary.md'), 'utf8');
+  assert.match(summary, /\| windows \| 1 \| 0 \| 0 \|/);
 
   await fs.rm(tmp, { recursive: true, force: true });
   await fs.rm('artifacts', { recursive: true, force: true });

--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -35,7 +35,7 @@ test('associates classname with requirement', async () => {
   const xml = `<testsuite><testcase classname="Dispatcher.Tests" name="sample" time="0.1"/></testsuite>`;
   const xmlPath = path.join(dir, 'junit.xml');
   await fs.writeFile(xmlPath, xml);
-  const tests = await collectTestCases([xmlPath], dir);
+  const tests = await collectTestCases([xmlPath], dir, 'linux');
   const reqPath = fileURLToPath(new URL('../../requirements.json', import.meta.url));
   const { map, meta } = await loadRequirements(reqPath);
   const groups = mapToRequirements(tests, map, meta);

--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -4,7 +4,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { collectTestCases, loadRequirements, mapToRequirements, groupToMarkdown } from '../generate-ci-summary.ts';
+import { collectTestCases, loadRequirements, mapToRequirements, groupToMarkdown, buildSummary } from '../generate-ci-summary.ts';
 import { writeErrorSummary } from '../error-handler.ts';
 
 const fileUrl = new URL('../generate-ci-summary.ts', import.meta.url);
@@ -54,4 +54,20 @@ test('groupToMarkdown assigns numeric identifiers', () => {
   assert.match(md, /\| ID \| Requirement \| Test ID \| Status \|/);
   assert.match(md, /\| 0 \| REQ-XYZ \| alpha \| Passed \|/);
   assert.match(md, /\| 1 \| REQ-XYZ \| beta \| Failed \|/);
+});
+
+test('buildSummary splits totals by OS', () => {
+  const groups = [{
+    id: 'REQ-1',
+    tests: [
+      { id: 'a', name: 'alpha', status: 'Passed', duration: 1, requirements: [], os: 'windows' },
+      { id: 'b', name: 'beta', status: 'Failed', duration: 1, requirements: [], os: 'linux' },
+      { id: 'c', name: 'gamma', status: 'Skipped', duration: 1, requirements: [], os: 'linux' },
+    ],
+  }];
+  const summary = buildSummary(groups);
+  assert.strictEqual(summary.overall.passed, 1);
+  assert.strictEqual(summary.byOs.windows.passed, 1);
+  assert.strictEqual(summary.byOs.linux.failed, 1);
+  assert.strictEqual(summary.byOs.linux.skipped, 1);
 });

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -300,6 +300,18 @@ async function main() {
 
   const matrixMd = groupToMarkdown(groups);
 
+  const summaryLines = [
+    '### Test Summary',
+    '| OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |',
+    '| --- | --- | --- | --- | --- | --- |',
+    `| overall | ${totals.overall.passed} | ${totals.overall.failed} | ${totals.overall.skipped} | ${totals.overall.duration.toFixed(2)} | ${totals.overall.rate.toFixed(2)} |`,
+  ];
+  for (const os of Object.keys(totals.byOs).sort()) {
+    const t = totals.byOs[os];
+    summaryLines.push(`| ${os} | ${t.passed} | ${t.failed} | ${t.skipped} | ${t.duration.toFixed(2)} | ${t.rate.toFixed(2)} |`);
+  }
+  const summaryMd = summaryLines.join('\n');
+
   const wrapperFiles = await glob('*/action.yml', { nodir: true });
   const wrapperDirs = wrapperFiles.map(f => path.dirname(f)).sort();
   console.log('Discovered wrapper directories:', wrapperDirs.join(', '));
@@ -307,6 +319,7 @@ async function main() {
 
   await fs.writeFile(path.join(outDir, 'traceability.json'), JSON.stringify({ requirements: groups, totals }, null, 2));
   await fs.writeFile(path.join(outDir, 'traceability.md'), redact(`### Test Traceability Matrix\n\n${matrixMd}`));
+  await fs.writeFile(path.join(outDir, 'summary.md'), redact(summaryMd));
   await fs.writeFile(path.join(outDir, 'action-docs.json'), JSON.stringify(docs, null, 2));
   await fs.writeFile(path.join(outDir, 'action-docs.md'), redact(markdown));
 

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -300,7 +300,9 @@ async function main() {
   const groups = mapToRequirements(tests, map, meta);
   const totals = buildSummary(groups);
 
-  await fs.mkdir('artifacts', { recursive: true });
+  const osDir = (process.env.RUNNER_OS ?? 'unknown').toLowerCase();
+  const outDir = path.join('artifacts', osDir);
+  await fs.mkdir(outDir, { recursive: true });
 
   const matrixMd = groupToMarkdown(groups);
 
@@ -309,14 +311,14 @@ async function main() {
   console.log('Discovered wrapper directories:', wrapperDirs.join(', '));
   const { docs, markdown } = await generateActionDocs(dispatcherRegistryFile, wrapperDirs);
 
-  await fs.writeFile(path.join('artifacts','traceability.json'), JSON.stringify({ requirements: groups, totals }, null, 2));
-  await fs.writeFile(path.join('artifacts','traceability.md'), redact(`### Test Traceability Matrix\n\n${matrixMd}`));
-  await fs.writeFile(path.join('artifacts','action-docs.json'), JSON.stringify(docs, null, 2));
-  await fs.writeFile(path.join('artifacts','action-docs.md'), redact(markdown));
+  await fs.writeFile(path.join(outDir, 'traceability.json'), JSON.stringify({ requirements: groups, totals }, null, 2));
+  await fs.writeFile(path.join(outDir, 'traceability.md'), redact(`### Test Traceability Matrix\n\n${matrixMd}`));
+  await fs.writeFile(path.join(outDir, 'action-docs.json'), JSON.stringify(docs, null, 2));
+  await fs.writeFile(path.join(outDir, 'action-docs.md'), redact(markdown));
 
   try {
     await fs.access(evidenceDir);
-    await fs.cp(evidenceDir, path.join('artifacts','evidence'), { recursive: true });
+    await fs.cp(evidenceDir, path.join(outDir, 'evidence'), { recursive: true });
   } catch {
     // ignore missing evidence
   }

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -58,18 +58,12 @@ export async function loadRequirements(mappingFile: string) {
   }
 }
 
-export async function collectTestCases(files: string[], evidenceDir: string): Promise<TestCase[]> {
+export async function collectTestCases(files: string[], evidenceDir: string, os?: string): Promise<TestCase[]> {
   const evidenceFiles = await fs.readdir(evidenceDir).catch(() => []);
   const tests: TestCase[] = [];
-  const statusMap: Record<string, 'Passed' | 'Failed' | 'Skipped'> = {
-    passed: 'Passed',
-    failed: 'Failed',
-    skipped: 'Skipped',
-  };
+  const osType = (os ?? process.env.RUNNER_OS ?? 'unknown').toLowerCase();
   for (const file of files) {
     const xml = await fs.readFile(file, 'utf8');
-    const osMatch = file.toLowerCase().match(/(windows|linux|macos)/);
-    const osType = osMatch ? osMatch[1] : 'unknown';
     const data = await parseStringPromise(xml, { explicitArray: true, mergeAttrs: true });
     const suites: any[] = [];
     if (data.testsuite) suites.push(data.testsuite);
@@ -275,6 +269,7 @@ async function main() {
   const mappingFile = process.env.REQ_MAPPING_FILE || 'requirements.json';
   const dispatcherRegistryFile = process.env.DISPATCHER_REGISTRY || 'dispatchers.json';
   const evidenceDir = process.env.EVIDENCE_DIR || 'test-screenshots';
+  const osType = (process.env.RUNNER_OS ?? 'unknown').toLowerCase();
 
   let junitFiles: string[] = [];
   const plural = process.env.TEST_RESULTS_GLOBS;
@@ -294,14 +289,13 @@ async function main() {
   if (junitFiles.length === 0) {
     console.warn('No JUnit files found; writing empty summary.');
   } else {
-    tests = await collectTestCases(junitFiles, evidenceDir);
+    tests = await collectTestCases(junitFiles, evidenceDir, osType);
   }
   const { map, meta } = await loadRequirements(mappingFile);
   const groups = mapToRequirements(tests, map, meta);
   const totals = buildSummary(groups);
 
-  const osDir = (process.env.RUNNER_OS ?? 'unknown').toLowerCase();
-  const outDir = path.join('artifacts', osDir);
+  const outDir = path.join('artifacts', osType);
   await fs.mkdir(outDir, { recursive: true });
 
   const matrixMd = groupToMarkdown(groups);

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -23,6 +23,9 @@ interface RequirementGroup {
   id: string;
   description?: string;
   owner?: string;
+  runner_label?: string;
+  runner_type?: string;
+  skip_dry_run?: boolean;
   tests: TestCase[];
 }
 
@@ -38,15 +41,21 @@ export async function loadRequirements(mappingFile: string) {
   try {
     const raw = await fs.readFile(mappingFile, 'utf8');
     const parsed = JSON.parse(raw);
+    const defaults: Record<string, any> = parsed.runners || parsed.defaults || {};
     const map: Record<string, { requirements: string[]; owner?: string }> = {};
-    const meta: Record<string, { description?: string; owner?: string }> = {};
+    const meta: Record<string, { description?: string; owner?: string; runner_label?: string; runner_type?: string; skip_dry_run?: boolean }> = {};
     if (Array.isArray(parsed.requirements)) {
       for (const r of parsed.requirements) {
-        meta[r.id] = { description: r.description, owner: r.owner };
+        const def = (r.runner && defaults[r.runner]) || {};
+        const owner = r.owner ?? def.owner;
+        const runner_label = r.runner_label ?? def.runner_label;
+        const runner_type = r.runner_type ?? def.runner_type;
+        const skip_dry_run = r.skip_dry_run ?? def.skip_dry_run;
+        meta[r.id] = { description: r.description, owner, runner_label, runner_type, skip_dry_run };
         if (Array.isArray(r.tests)) {
           for (const t of r.tests) {
             const key = t.toLowerCase();
-            if (!map[key]) map[key] = { requirements: [], owner: r.owner };
+            if (!map[key]) map[key] = { requirements: [], owner };
             map[key].requirements.push(r.id);
           }
         }
@@ -102,7 +111,11 @@ export async function collectTestCases(files: string[], evidenceDir: string, os?
   return tests;
 }
 
-export function mapToRequirements(tests: TestCase[], mapping: Record<string, { requirements: string[]; owner?: string }>, meta: Record<string, { description?: string; owner?: string }>): RequirementGroup[] {
+export function mapToRequirements(
+  tests: TestCase[],
+  mapping: Record<string, { requirements: string[]; owner?: string }>,
+  meta: Record<string, { description?: string; owner?: string; runner_label?: string; runner_type?: string; skip_dry_run?: boolean }>
+): RequirementGroup[] {
   const groups: Map<string, RequirementGroup> = new Map();
   for (const test of tests) {
     const stripAnnotations = (s: string) => s.replace(/\[[^\]]+\]/g, '').trim();
@@ -122,7 +135,15 @@ export function mapToRequirements(tests: TestCase[], mapping: Record<string, { r
     const targetReqs = reqs.length ? reqs : ['Unmapped'];
     for (const reqId of targetReqs) {
       if (!groups.has(reqId)) {
-        groups.set(reqId, { id: reqId, description: meta[reqId]?.description, owner: meta[reqId]?.owner, tests: [] });
+        groups.set(reqId, {
+          id: reqId,
+          description: meta[reqId]?.description,
+          owner: meta[reqId]?.owner,
+          runner_label: meta[reqId]?.runner_label,
+          runner_type: meta[reqId]?.runner_type,
+          skip_dry_run: meta[reqId]?.skip_dry_run,
+          tests: [],
+        });
       }
       groups.get(reqId)!.tests.push(test);
     }

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -16,6 +16,7 @@ interface TestCase {
   owner?: string;
   evidence?: string;
   requirements: string[];
+  os?: string;
 }
 
 interface RequirementGroup {
@@ -67,6 +68,8 @@ export async function collectTestCases(files: string[], evidenceDir: string): Pr
   };
   for (const file of files) {
     const xml = await fs.readFile(file, 'utf8');
+    const osMatch = file.toLowerCase().match(/(windows|linux|macos)/);
+    const osType = osMatch ? osMatch[1] : 'unknown';
     const data = await parseStringPromise(xml, { explicitArray: true, mergeAttrs: true });
     const suites: any[] = [];
     if (data.testsuite) suites.push(data.testsuite);
@@ -85,7 +88,7 @@ export async function collectTestCases(files: string[], evidenceDir: string): Pr
           if (tc.failure || tc.error) status = 'Failed';
           else if (tc.skipped) status = 'Skipped';
           const duration = parseFloat(tc.time?.[0] ?? '0');
-          const test: TestCase = { id, name, className, status, duration, requirements: [] };
+          const test: TestCase = { id, name, className, status, duration, requirements: [], os: osType };
           const evidence = evidenceFiles.find((f) => f.startsWith(id) || f.startsWith(id + '.'));
           if (evidence) test.evidence = path.join('evidence', evidence);
           const ownerMatch = name.match(/\[Owner:([^\]]+)\]/i);
@@ -142,16 +145,30 @@ export function mapToRequirements(tests: TestCase[], mapping: Record<string, { r
   return sorted;
 }
 
-function buildSummary(groups: RequirementGroup[]) {
-  let passed = 0, failed = 0, skipped = 0, duration = 0;
+export function buildSummary(groups: RequirementGroup[]) {
+  const overall = { passed: 0, failed: 0, skipped: 0, duration: 0, rate: 0 };
+  const byOs: Record<string, { passed: number; failed: number; skipped: number; duration: number; rate: number }> = {};
   for (const g of groups) {
     for (const t of g.tests) {
-      duration += t.duration;
-      if (t.status === 'Passed') passed++; else if (t.status === 'Failed') failed++; else skipped++;
+      const os = t.os || 'unknown';
+      if (!byOs[os]) byOs[os] = { passed: 0, failed: 0, skipped: 0, duration: 0, rate: 0 };
+      overall.duration += t.duration;
+      byOs[os].duration += t.duration;
+      if (t.status === 'Passed') {
+        overall.passed++; byOs[os].passed++;
+      } else if (t.status === 'Failed') {
+        overall.failed++; byOs[os].failed++;
+      } else {
+        overall.skipped++; byOs[os].skipped++;
+      }
     }
   }
-  const rate = passed + failed === 0 ? 0 : (passed / (passed + failed)) * 100;
-  return { passed, failed, skipped, duration, rate };
+  overall.rate = overall.passed + overall.failed === 0 ? 0 : (overall.passed / (overall.passed + overall.failed)) * 100;
+  for (const os of Object.keys(byOs)) {
+    const t = byOs[os];
+    t.rate = t.passed + t.failed === 0 ? 0 : (t.passed / (t.passed + t.failed)) * 100;
+  }
+  return { overall, byOs };
 }
 
 export function groupToMarkdown(groups: RequirementGroup[], limit?: number) {

--- a/tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'AddTokenToLabview.SelfHosted.Workflow [REQ-008]' {
     It 'runs add-token-to-labview action on a self-hosted runner and uploads token artifact [REQ-008]' {

--- a/tests/pester/ApplyVipc.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/ApplyVipc.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'ApplyVipc.SelfHosted.DryRunTrue.Workflow [REQ-006]' {
     It 'runs apply-vipc action with dry_run true [REQ-006]' {

--- a/tests/pester/Build.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/Build.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'Build.SelfHosted.Workflow [REQ-009]' {
     It 'runs build action with required inputs [REQ-009]' {

--- a/tests/pester/BuildLvlibp.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/BuildLvlibp.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'BuildLvlibp.SelfHosted.Workflow [REQ-010]' {
     It 'runs build-lvlibp action and uploads lvlibp artifact [REQ-010]' {

--- a/tests/pester/BuildViPackage.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/BuildViPackage.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'BuildViPackage.SelfHosted.Workflow [REQ-011]' {
     It 'runs build-vi-package action and uploads vi package artifact [REQ-011]' {

--- a/tests/pester/CloseLabview.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/CloseLabview.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'CloseLabview.SelfHosted.Workflow [REQ-012]' {
     It 'runs close-labview action for 32-bit and 64-bit and uploads logs [REQ-012]' {

--- a/tests/pester/MissingInProject.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/MissingInProject.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'MissingInProject.SelfHosted.Workflow [REQ-014]' {
     It 'runs missing-in-project action on a self-hosted runner and uploads findings report [REQ-014]' {

--- a/tests/pester/ModifyVipbDisplayInfo.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/ModifyVipbDisplayInfo.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'ModifyVipbDisplayInfo.SelfHosted.Workflow [REQ-015]' {
     It 'runs modify-vipb-display-info action on a self-hosted runner and uploads VIPB artifact [REQ-015]' {

--- a/tests/pester/PrepareLabviewSource.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/PrepareLabviewSource.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'PrepareLabviewSource.SelfHosted.Workflow [REQ-011]' {
     It 'runs prepare-labview-source action and uploads prepared source artifact [REQ-011]' {

--- a/tests/pester/RenameFile.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RenameFile.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'RenameFile.SelfHosted.Workflow [REQ-011]' {
     It 'runs rename-file action on a self-hosted runner and uploads renamed file artifact [REQ-011]' {

--- a/tests/pester/RestoreSetupLvSource.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RestoreSetupLvSource.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'RestoreSetupLvSource.SelfHosted.Workflow [REQ-018]' {
     It 'runs restore-setup-lv-source action on a self-hosted runner and uploads restoration artifacts [REQ-018]' {

--- a/tests/pester/RevertDevelopmentMode.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RevertDevelopmentMode.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'RevertDevelopmentMode.SelfHosted.Workflow [REQ-019]' {
     It 'runs revert-development-mode action on a self-hosted runner and uploads configuration artifact [REQ-019]' {

--- a/tests/pester/RunUnitTests.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RunUnitTests.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'RunUnitTests.SelfHosted.Workflow [REQ-011]' {
     It 'runs run-unit-tests action and uploads unit-test results [REQ-011]' {

--- a/tests/pester/SetDevelopmentMode.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/SetDevelopmentMode.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'SetDevelopmentMode.SelfHosted.Workflow [REQ-021]' {
     It 'runs set-development-mode action on a self-hosted runner and uploads logs [REQ-021]' {


### PR DESCRIPTION
## Summary
- categorize test totals by OS in CI summary
- cover OS-split totals with unit test

## Testing
- `npm run check:node` *(fails: Node.js >=24 required)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required)*
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Install-Module -Name Pester,powershell-yaml -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a0e04a35588329a596eb217075bb24