### PR TITLE
Fix setup info formatting in ps-ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           "was captured from the set up job." | Out-File -FilePath $file -Encoding utf8
           foreach ($k in $data.Keys) {
             if ($data[$k]) {
-              "$k: $($data[$k])" | Out-File -FilePath $file -Encoding utf8 -Append
+              "${k}: $($data[$k])" | Out-File -FilePath $file -Encoding utf8 -Append
             }
           }
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- ensure `Capture setup info` uses proper PowerShell string interpolation in `ps-ci` job

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command '$PSVersionTable.PSVersion'`
- `pwsh -NoLogo -Command "Install-Module -Name Pester,powershell-yaml -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a0e613fd808329947d13455cc31414