### PR TITLE
feat: separate artifacts by os

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ npm install
 npm test
 ```
 
-For CI, `npm run test:ci` emits a JUnit XML report that [scripts/generate-ci-summary.ts](scripts/generate-ci-summary.ts) parses to build requirement traceability files.
+For CI, `npm run test:ci` emits a JUnit XML report that [scripts/generate-ci-summary.ts](scripts/generate-ci-summary.ts) parses to build requirement traceability files in OS‑specific subdirectories (e.g., `artifacts/windows`, `artifacts/linux`).
 
 Pester tests cover the dispatcher and helper modules. See [docs/testing-pester.md](docs/testing-pester.md) for guidelines on using the canonical argument helper and adding new tests. Run them with:
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -16,6 +16,7 @@ provides a human‑readable summary for quick reference.
 Each test file is annotated with its corresponding requirement ID to maintain
 traceability between requirements and test coverage.
 
-During CI runs, `scripts/generate-ci-summary.ts` produces the `traceability.md`
-artifact, which contains the full requirement traceability matrix.
+During CI runs, `scripts/generate-ci-summary.ts` writes requirement artifacts
+to an OS‑specific directory under `artifacts/`, such as
+`artifacts/windows/traceability.md` or `artifacts/linux/traceability.md`.
 

--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -4,6 +4,8 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
 import { fileURLToPath } from 'node:url';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { collectTestCases, loadRequirements, mapToRequirements, groupToMarkdown, buildSummary } from '../generate-ci-summary.ts';
 import { writeErrorSummary } from '../error-handler.ts';
 
@@ -70,4 +72,30 @@ test('buildSummary splits totals by OS', () => {
   assert.strictEqual(summary.byOs.windows.passed, 1);
   assert.strictEqual(summary.byOs.linux.failed, 1);
   assert.strictEqual(summary.byOs.linux.skipped, 1);
+});
+
+const execFileP = promisify(execFile);
+
+test('writes outputs to OS-specific directory', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'summary-'));
+  const junitPath = path.join(tmp, 'junit.xml');
+  await fs.writeFile(junitPath, '<testsuite><testcase name="foo" time="0"/></testsuite>');
+
+  await fs.rm('artifacts', { recursive: true, force: true });
+
+  const env = {
+    ...process.env,
+    TEST_RESULTS_GLOB: junitPath,
+    EVIDENCE_DIR: tmp,
+    RUNNER_OS: 'Windows',
+  };
+
+  await execFileP('node_modules/.bin/tsx', ['scripts/generate-ci-summary.ts'], { env });
+
+  const outDir = path.join('artifacts', 'windows');
+  const exists = await fs.stat(path.join(outDir, 'traceability.json')).then(() => true, () => false);
+  assert.strictEqual(exists, true);
+
+  await fs.rm(tmp, { recursive: true, force: true });
+  await fs.rm('artifacts', { recursive: true, force: true });
 });

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -300,7 +300,9 @@ async function main() {
   const groups = mapToRequirements(tests, map, meta);
   const totals = buildSummary(groups);
 
-  await fs.mkdir('artifacts', { recursive: true });
+  const osDir = (process.env.RUNNER_OS ?? 'unknown').toLowerCase();
+  const outDir = path.join('artifacts', osDir);
+  await fs.mkdir(outDir, { recursive: true });
 
   const matrixMd = groupToMarkdown(groups);
 
@@ -309,14 +311,14 @@ async function main() {
   console.log('Discovered wrapper directories:', wrapperDirs.join(', '));
   const { docs, markdown } = await generateActionDocs(dispatcherRegistryFile, wrapperDirs);
 
-  await fs.writeFile(path.join('artifacts','traceability.json'), JSON.stringify({ requirements: groups, totals }, null, 2));
-  await fs.writeFile(path.join('artifacts','traceability.md'), redact(`### Test Traceability Matrix\n\n${matrixMd}`));
-  await fs.writeFile(path.join('artifacts','action-docs.json'), JSON.stringify(docs, null, 2));
-  await fs.writeFile(path.join('artifacts','action-docs.md'), redact(markdown));
+  await fs.writeFile(path.join(outDir, 'traceability.json'), JSON.stringify({ requirements: groups, totals }, null, 2));
+  await fs.writeFile(path.join(outDir, 'traceability.md'), redact(`### Test Traceability Matrix\n\n${matrixMd}`));
+  await fs.writeFile(path.join(outDir, 'action-docs.json'), JSON.stringify(docs, null, 2));
+  await fs.writeFile(path.join(outDir, 'action-docs.md'), redact(markdown));
 
   try {
     await fs.access(evidenceDir);
-    await fs.cp(evidenceDir, path.join('artifacts','evidence'), { recursive: true });
+    await fs.cp(evidenceDir, path.join(outDir, 'evidence'), { recursive: true });
   } catch {
     // ignore missing evidence
   }


### PR DESCRIPTION
## Summary
- partition CI summary artifacts by runner OS
- test artifact path resolution per OS
- document OS-specific artifact directories

## Testing
- `PATH=/usr/local/bin:$PATH npm run check:node`
- `PATH=/usr/local/bin:$PATH npm install`
- `PATH=/usr/local/bin:$PATH npm test`
- `PATH=/usr/local/bin:$PATH npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `PATH=/usr/local/bin:$PATH npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Install-Module -Name Pester,powershell-yaml -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a0e94edbf48329906ec2d62d5bb4e8