### PR TITLE
Use OS-specific traceability summary path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,8 @@ jobs:
           EVIDENCE_DIR: test-screenshots
       - name: Print test traceability matrix
         run: |
-          cat artifacts/traceability.md >> "$GITHUB_STEP_SUMMARY"
-          cat artifacts/traceability.md
+          cat "artifacts/${RUNNER_OS,,}/traceability.md" >> "$GITHUB_STEP_SUMMARY"
+          cat "artifacts/${RUNNER_OS,,}/traceability.md"
       - name: Include setup information
         run: |
           echo '## ubuntu-24.04' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- use OS-aware path for traceability matrix in CI workflow

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh -NoLogo -Command "Install-Module -Name Pester,powershell-yaml -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a0ec8623dc8329acce9b097f3df3ff