### PR TITLE
Group workflow artifacts by OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,17 @@ jobs:
         if: always()
         with:
           name: traceability
-          path: artifacts/traceability.*
+          path: artifacts/${{ toLower(runner.os) }}/traceability.*
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: action-docs
-          path: artifacts/action-docs.*
+          path: artifacts/${{ toLower(runner.os) }}/action-docs.*
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: evidence
-          path: artifacts/evidence/**
+          path: artifacts/${{ toLower(runner.os) }}/evidence/**
           if-no-files-found: ignore
 
   ps-ci:


### PR DESCRIPTION
## Summary
- scope workflow artifact paths by OS for traceability, action-docs, and evidence

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `pwsh --version`
- `pwsh -NoLogo -Command "Install-Module -Name Pester,powershell-yaml -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a0efcbb0188329ab794f88740eaf2e