### PR TITLE
ci: add actionlint check and fix workflow

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - icon-editor-windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,17 @@ jobs:
         if: always()
         with:
           name: traceability
-          path: artifacts/${{ toLower(runner.os) }}/traceability.*
+          path: artifacts/${{ runner.os == 'Windows' && 'windows' || runner.os == 'macOS' && 'macos' || 'linux' }}/traceability.*
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: action-docs
-          path: artifacts/${{ toLower(runner.os) }}/action-docs.*
+          path: artifacts/${{ runner.os == 'Windows' && 'windows' || runner.os == 'macOS' && 'macos' || 'linux' }}/action-docs.*
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: evidence
-          path: artifacts/${{ toLower(runner.os) }}/evidence/**
+          path: artifacts/${{ runner.os == 'Windows' && 'windows' || runner.os == 'macOS' && 'macos' || 'linux' }}/evidence/**
           if-no-files-found: ignore
 
   ps-ci:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Run `npm test`.
 - Run `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md` to lint Markdown files.
 - Run `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')` to verify links.
+- Run `npx --yes actionlint` to validate GitHub Actions workflows.
 - Ensure PowerShell 7.5.2 is installed.
 - Run `pwsh -NoLogo -Command "Install-Module -Name Pester,powershell-yaml -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"`.
 


### PR DESCRIPTION
## Summary
- require actionlint to guard workflows
- fix CI artifact paths and allow custom runner labels

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `./actionlint`
- `pwsh --version`
- `pwsh -NoLogo -Command "Install-Module -Name Pester,powershell-yaml -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a0f26172308329b440cc895ae34ba6