### PR TITLE
refactor: pass os to collect test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ npm install
 npm test
 ```
 
-For CI, `npm run test:ci` emits a JUnit XML report that [scripts/generate-ci-summary.ts](scripts/generate-ci-summary.ts) parses to build requirement traceability files in OS‑specific subdirectories (e.g., `artifacts/windows`, `artifacts/linux`).
+For CI, `npm run test:ci` emits a JUnit XML report that [scripts/generate-ci-summary.ts](scripts/generate-ci-summary.ts) parses to build requirement traceability files in OS‑specific subdirectories (e.g., `artifacts/windows`, `artifacts/linux`) based on the `RUNNER_OS` environment variable.
 
 Pester tests cover the dispatcher and helper modules. See [docs/testing-pester.md](docs/testing-pester.md) for guidelines on using the canonical argument helper and adding new tests. Run them with:
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -18,5 +18,5 @@ traceability between requirements and test coverage.
 
 During CI runs, `scripts/generate-ci-summary.ts` writes requirement artifacts
 to an OS‑specific directory under `artifacts/`, such as
-`artifacts/windows/traceability.md` or `artifacts/linux/traceability.md`.
+`artifacts/windows/traceability.md` or `artifacts/linux/traceability.md`, using the `RUNNER_OS` environment variable.
 

--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -35,7 +35,7 @@ test('associates classname with requirement', async () => {
   const xml = `<testsuite><testcase classname="Dispatcher.Tests" name="sample" time="0.1"/></testsuite>`;
   const xmlPath = path.join(dir, 'junit.xml');
   await fs.writeFile(xmlPath, xml);
-  const tests = await collectTestCases([xmlPath], dir);
+  const tests = await collectTestCases([xmlPath], dir, 'linux');
   const reqPath = fileURLToPath(new URL('../../requirements.json', import.meta.url));
   const { map, meta } = await loadRequirements(reqPath);
   const groups = mapToRequirements(tests, map, meta);

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -58,18 +58,12 @@ export async function loadRequirements(mappingFile: string) {
   }
 }
 
-export async function collectTestCases(files: string[], evidenceDir: string): Promise<TestCase[]> {
+export async function collectTestCases(files: string[], evidenceDir: string, os?: string): Promise<TestCase[]> {
   const evidenceFiles = await fs.readdir(evidenceDir).catch(() => []);
   const tests: TestCase[] = [];
-  const statusMap: Record<string, 'Passed' | 'Failed' | 'Skipped'> = {
-    passed: 'Passed',
-    failed: 'Failed',
-    skipped: 'Skipped',
-  };
+  const osType = (os ?? process.env.RUNNER_OS ?? 'unknown').toLowerCase();
   for (const file of files) {
     const xml = await fs.readFile(file, 'utf8');
-    const osMatch = file.toLowerCase().match(/(windows|linux|macos)/);
-    const osType = osMatch ? osMatch[1] : 'unknown';
     const data = await parseStringPromise(xml, { explicitArray: true, mergeAttrs: true });
     const suites: any[] = [];
     if (data.testsuite) suites.push(data.testsuite);
@@ -275,6 +269,7 @@ async function main() {
   const mappingFile = process.env.REQ_MAPPING_FILE || 'requirements.json';
   const dispatcherRegistryFile = process.env.DISPATCHER_REGISTRY || 'dispatchers.json';
   const evidenceDir = process.env.EVIDENCE_DIR || 'test-screenshots';
+  const osType = (process.env.RUNNER_OS ?? 'unknown').toLowerCase();
 
   let junitFiles: string[] = [];
   const plural = process.env.TEST_RESULTS_GLOBS;
@@ -294,14 +289,13 @@ async function main() {
   if (junitFiles.length === 0) {
     console.warn('No JUnit files found; writing empty summary.');
   } else {
-    tests = await collectTestCases(junitFiles, evidenceDir);
+    tests = await collectTestCases(junitFiles, evidenceDir, osType);
   }
   const { map, meta } = await loadRequirements(mappingFile);
   const groups = mapToRequirements(tests, map, meta);
   const totals = buildSummary(groups);
 
-  const osDir = (process.env.RUNNER_OS ?? 'unknown').toLowerCase();
-  const outDir = path.join('artifacts', osDir);
+  const outDir = path.join('artifacts', osType);
   await fs.mkdir(outDir, { recursive: true });
 
   const matrixMd = groupToMarkdown(groups);


### PR DESCRIPTION
## Summary
- allow collectTestCases to accept explicit OS instead of inferring from file name
- use RUNNER_OS when generating CI summary
- document RUNNER_OS usage for OS-specific artifacts

## Testing
- `npm run check:node` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `npx --yes actionlint` *(fails: could not determine executable to run)*
- `pwsh --version`
- `pwsh -NoLogo -Command "Install-Module -Name Pester,powershell-yaml -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a0f6fb00ac8329997afa0071eec99b