### PR TITLE
feat: add per-os test summary

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -20,3 +20,12 @@ During CI runs, `scripts/generate-ci-summary.ts` writes requirement artifacts
 to an OS‑specific directory under `artifacts/`, such as
 `artifacts/windows/traceability.md` or `artifacts/linux/traceability.md`, using the `RUNNER_OS` environment variable.
 
+Each directory also includes a `summary.md` file with per‑OS totals. A typical
+summary might look like this:
+
+| OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
+| --- | --- | --- | --- | --- | --- |
+| overall | 10 | 0 | 2 | 12.34 | 100.00 |
+| windows | 5 | 0 | 1 | 6.17 | 100.00 |
+| linux | 5 | 0 | 1 | 6.17 | 100.00 |
+

--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -95,6 +95,8 @@ test('writes outputs to OS-specific directory', async () => {
   const outDir = path.join('artifacts', 'windows');
   const exists = await fs.stat(path.join(outDir, 'traceability.json')).then(() => true, () => false);
   assert.strictEqual(exists, true);
+  const summary = await fs.readFile(path.join(outDir, 'summary.md'), 'utf8');
+  assert.match(summary, /\| windows \| 1 \| 0 \| 0 \|/);
 
   await fs.rm(tmp, { recursive: true, force: true });
   await fs.rm('artifacts', { recursive: true, force: true });

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -300,6 +300,18 @@ async function main() {
 
   const matrixMd = groupToMarkdown(groups);
 
+  const summaryLines = [
+    '### Test Summary',
+    '| OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |',
+    '| --- | --- | --- | --- | --- | --- |',
+    `| overall | ${totals.overall.passed} | ${totals.overall.failed} | ${totals.overall.skipped} | ${totals.overall.duration.toFixed(2)} | ${totals.overall.rate.toFixed(2)} |`,
+  ];
+  for (const os of Object.keys(totals.byOs).sort()) {
+    const t = totals.byOs[os];
+    summaryLines.push(`| ${os} | ${t.passed} | ${t.failed} | ${t.skipped} | ${t.duration.toFixed(2)} | ${t.rate.toFixed(2)} |`);
+  }
+  const summaryMd = summaryLines.join('\n');
+
   const wrapperFiles = await glob('*/action.yml', { nodir: true });
   const wrapperDirs = wrapperFiles.map(f => path.dirname(f)).sort();
   console.log('Discovered wrapper directories:', wrapperDirs.join(', '));
@@ -307,6 +319,7 @@ async function main() {
 
   await fs.writeFile(path.join(outDir, 'traceability.json'), JSON.stringify({ requirements: groups, totals }, null, 2));
   await fs.writeFile(path.join(outDir, 'traceability.md'), redact(`### Test Traceability Matrix\n\n${matrixMd}`));
+  await fs.writeFile(path.join(outDir, 'summary.md'), redact(summaryMd));
   await fs.writeFile(path.join(outDir, 'action-docs.json'), JSON.stringify(docs, null, 2));
   await fs.writeFile(path.join(outDir, 'action-docs.md'), redact(markdown));
 


### PR DESCRIPTION
## Summary
- include per-OS test totals in new `summary.md` artifact
- test generation to ensure OS-specific summaries are written
- document per-OS summary format in requirements guide

## Testing
- `npm run check:node` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `npx --yes actionlint` *(fails: could not determine executable to run)*
- `pwsh -NoLogo -Command "Install-Module -Name Pester,powershell-yaml -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"` *(fails: pwsh: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f89e84c483299d3713891f289cbf