### PR TITLE
Support integration runner metadata in requirements

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,31 +1,40 @@
 # Requirements
 
-This project tracks high‑level requirements and maps each one to the Pester test
-files that verify it. The authoritative mapping is stored in
-[`requirements.json`](../requirements.json) at the repository root; the table below
-provides a human‑readable summary for quick reference.
+This project tracks high‑level requirements and maps each one to the Pester test files that verify it. The authoritative mapping is stored in [`requirements.json`](../requirements.json); the table below provides a human‑readable summary for quick reference.
 
-| ID | Description | Tests |
-|----|-------------|-------|
-| REQ-001 | Dispatcher discovers available actions, describes them, and validates arguments. | `tests/pester/Dispatcher.Tests.ps1` |
-| REQ-002 | Dispatcher dry‑run mode prints descriptions and warns on unknown arguments without executing actions. | `tests/pester/Dispatcher.DryRun.Tests.ps1` |
-| REQ-003 | Actions correctly resolve and pass RelativePath arguments without warnings. | `tests/pester/RelativePath.Actions.Tests.ps1` |
-| REQ-004 | Every action script exists at the expected path. | `tests/pester/ScriptPath.Tests.ps1` |
-| REQ-005 | Dispatcher fails when RelativePath is missing or invalid. | `tests/pester/Dispatcher.InvalidPaths.Tests.ps1` |
+| ID | Description | Tests | Runner | Runner Type | Skip Dry Run |
+|----|-------------|-------|--------|-------------|--------------|
+| REQ-001 | Dispatcher discovers available actions, describes them, and validates arguments. | `tests/pester/Dispatcher.Tests.ps1` |  |  |  |
+| REQ-002 | Dispatcher dry-run mode prints descriptions and warns on unknown arguments without executing actions. | `tests/pester/Dispatcher.DryRun.Tests.ps1` |  |  |  |
+| REQ-003 | Actions correctly resolve and pass RelativePath arguments without warnings. | `tests/pester/RelativePath.Actions.Tests.ps1` |  |  |  |
+| REQ-004 | Every action script exists at the expected path. | `tests/pester/ScriptPath.Tests.ps1` |  |  |  |
+| REQ-005 | Dispatcher fails when RelativePath is missing or invalid. | `tests/pester/Dispatcher.InvalidPaths.Tests.ps1` |  |  |  |
+| REQ-006 | Workflow checks out the LabVIEW icon editor repository and tests the composite action defined in apply-vipc/action.yml with minimum_supported_lv_version '2021', vip_lv_version '2021', supported_bitness '64', relative_path 'C:\actions-runner\_work\labview-icon-editor\labview-icon-editor', and vipc_path 'C:\actions-runner\_work\labview-icon-editor\labview-icon-editor\.github\actions\apply-vipc\runner_dependencies.vipc' on a self-hosted Windows runner labeled icon-editor-windows with dry_run true. | `tests/pester/ApplyVipc.SelfHosted.DryRunTrue.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-007 | Workflow checks out the LabVIEW icon editor repository and tests the composite action defined in apply-vipc/action.yml with minimum_supported_lv_version '2021', vip_lv_version '2021', supported_bitness '64', relative_path 'C:\actions-runner\_work\labview-icon-editor\labview-icon-editor', and vipc_path 'C:\actions-runner\_work\labview-icon-editor\labview-icon-editor\.github\actions\apply-vipc\runner_dependencies.vipc' on a self-hosted Windows runner labeled icon-editor-windows with dry_run false. | `tests/pester/ApplyVipc.SelfHosted.DryRunFalse.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-008 | Workflow tests the composite action defined in add-token-to-labview/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/AddTokenToLabview.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-009 | Workflow tests the composite action defined in build/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/Build.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-010 | Workflow tests the composite action defined in build-lvlibp/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/BuildLvlibp.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-011 | Workflow tests the composite action defined in build-vi-package/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/BuildViPackage.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-012 | Workflow clones an external repository and operates on it without modification using the composite action defined in close-labview/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/CloseLabview.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-013 | Workflow tests the composite action defined in generate-release-notes/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/GenerateReleaseNotes.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-014 | Workflow tests the composite action defined in missing-in-project/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/MissingInProject.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-015 | Workflow tests the composite action defined in modify-vipb-display-info/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/ModifyVipbDisplayInfo.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-016 | Workflow tests the composite action defined in prepare-labview-source/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/PrepareLabviewSource.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-017 | Workflow tests the composite action defined in rename-file/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/RenameFile.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-018 | Workflow tests the composite action defined in restore-setup-lv-source/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/RestoreSetupLvSource.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-019 | Workflow tests the composite action defined in revert-development-mode/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/RevertDevelopmentMode.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-020 | Workflow tests the composite action defined in run-unit-tests/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/RunUnitTests.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-021 | Workflow tests the composite action defined in set-development-mode/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/SetDevelopmentMode.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-022 | Workflow tests the composite action defined in setup-mkdocs/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/SetupMkdocs.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
 
-Each test file is annotated with its corresponding requirement ID to maintain
-traceability between requirements and test coverage.
+Each test file is annotated with its corresponding requirement ID to maintain traceability between requirements and test coverage.
 
-During CI runs, `scripts/generate-ci-summary.ts` writes requirement artifacts
-to an OS‑specific directory under `artifacts/`, such as
-`artifacts/windows/traceability.md` or `artifacts/linux/traceability.md`, using the `RUNNER_OS` environment variable.
+During CI runs, `scripts/generate-ci-summary.ts` writes requirement artifacts to an OS‑specific directory under `artifacts/`, such as `artifacts/windows/traceability.md` or `artifacts/linux/traceability.md`, using the `RUNNER_OS` environment variable.
 
-Each directory also includes a `summary.md` file with per‑OS totals. A typical
-summary might look like this:
+Each directory also includes a `summary.md` file with per‑OS totals. A typical summary might look like this:
 
 | OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |
 | --- | --- | --- | --- | --- | --- |
 | overall | 10 | 0 | 2 | 12.34 | 100.00 |
 | windows | 5 | 0 | 1 | 6.17 | 100.00 |
 | linux | 5 | 0 | 1 | 6.17 | 100.00 |
-

--- a/requirements.json
+++ b/requirements.json
@@ -1,4 +1,12 @@
 {
+  "runners": {
+    "icon-editor-windows": {
+      "owner": "icon-editor-windows",
+      "runner_label": "icon-editor-windows",
+      "runner_type": "integration",
+      "skip_dry_run": true
+    }
+  },
   "requirements": [
     {
       "id": "REQ-001",
@@ -38,8 +46,7 @@
     {
       "id": "REQ-006",
       "description": "Workflow checks out the LabVIEW icon editor repository and tests the composite action defined in apply-vipc/action.yml with minimum_supported_lv_version '2021', vip_lv_version '2021', supported_bitness '64', relative_path 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor', and vipc_path 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\.github\\actions\\apply-vipc\\runner_dependencies.vipc' on a self-hosted Windows runner labeled icon-editor-windows with dry_run true.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "ApplyVipc.SelfHosted.DryRunTrue.Workflow"
       ]
@@ -47,8 +54,7 @@
     {
       "id": "REQ-007",
       "description": "Workflow checks out the LabVIEW icon editor repository and tests the composite action defined in apply-vipc/action.yml with minimum_supported_lv_version '2021', vip_lv_version '2021', supported_bitness '64', relative_path 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor', and vipc_path 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\.github\\actions\\apply-vipc\\runner_dependencies.vipc' on a self-hosted Windows runner labeled icon-editor-windows with dry_run false.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "ApplyVipc.SelfHosted.DryRunFalse.Workflow"
       ]
@@ -56,8 +62,7 @@
     {
       "id": "REQ-008",
       "description": "Workflow tests the composite action defined in add-token-to-labview/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "AddTokenToLabview.SelfHosted.Workflow"
       ]
@@ -65,8 +70,7 @@
     {
       "id": "REQ-009",
       "description": "Workflow tests the composite action defined in build/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "Build.SelfHosted.Workflow"
       ]
@@ -74,8 +78,7 @@
     {
       "id": "REQ-010",
       "description": "Workflow tests the composite action defined in build-lvlibp/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "BuildLvlibp.SelfHosted.Workflow"
       ]
@@ -83,8 +86,7 @@
     {
       "id": "REQ-011",
       "description": "Workflow tests the composite action defined in build-vi-package/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "BuildViPackage.SelfHosted.Workflow"
       ]
@@ -92,8 +94,7 @@
     {
       "id": "REQ-012",
       "description": "Workflow clones an external repository and operates on it without modification using the composite action defined in close-labview/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "CloseLabview.SelfHosted.Workflow"
       ]
@@ -101,8 +102,7 @@
     {
       "id": "REQ-013",
       "description": "Workflow tests the composite action defined in generate-release-notes/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "GenerateReleaseNotes.SelfHosted.Workflow"
       ]
@@ -110,8 +110,7 @@
     {
       "id": "REQ-014",
       "description": "Workflow tests the composite action defined in missing-in-project/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "MissingInProject.SelfHosted.Workflow"
       ]
@@ -119,8 +118,7 @@
     {
       "id": "REQ-015",
       "description": "Workflow tests the composite action defined in modify-vipb-display-info/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "ModifyVipbDisplayInfo.SelfHosted.Workflow"
       ]
@@ -128,8 +126,7 @@
     {
       "id": "REQ-016",
       "description": "Workflow tests the composite action defined in prepare-labview-source/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "PrepareLabviewSource.SelfHosted.Workflow"
       ]
@@ -137,8 +134,7 @@
     {
       "id": "REQ-017",
       "description": "Workflow tests the composite action defined in rename-file/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "RenameFile.SelfHosted.Workflow"
       ]
@@ -146,8 +142,7 @@
     {
       "id": "REQ-018",
       "description": "Workflow tests the composite action defined in restore-setup-lv-source/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "RestoreSetupLvSource.SelfHosted.Workflow"
       ]
@@ -155,8 +150,7 @@
     {
       "id": "REQ-019",
       "description": "Workflow tests the composite action defined in revert-development-mode/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "RevertDevelopmentMode.SelfHosted.Workflow"
       ]
@@ -164,8 +158,7 @@
     {
       "id": "REQ-020",
       "description": "Workflow tests the composite action defined in run-unit-tests/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "RunUnitTests.SelfHosted.Workflow"
       ]
@@ -173,8 +166,7 @@
     {
       "id": "REQ-021",
       "description": "Workflow tests the composite action defined in set-development-mode/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "SetDevelopmentMode.SelfHosted.Workflow"
       ]
@@ -182,8 +174,7 @@
     {
       "id": "REQ-022",
       "description": "Workflow tests the composite action defined in setup-mkdocs/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
-      "owner": "icon-editor-windows",
-      "runner_label": "icon-editor-windows",
+      "runner": "icon-editor-windows",
       "tests": [
         "SetupMkdocs.SelfHosted.Workflow"
       ]

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -23,6 +23,9 @@ interface RequirementGroup {
   id: string;
   description?: string;
   owner?: string;
+  runner_label?: string;
+  runner_type?: string;
+  skip_dry_run?: boolean;
   tests: TestCase[];
 }
 
@@ -38,15 +41,21 @@ export async function loadRequirements(mappingFile: string) {
   try {
     const raw = await fs.readFile(mappingFile, 'utf8');
     const parsed = JSON.parse(raw);
+    const defaults: Record<string, any> = parsed.runners || parsed.defaults || {};
     const map: Record<string, { requirements: string[]; owner?: string }> = {};
-    const meta: Record<string, { description?: string; owner?: string }> = {};
+    const meta: Record<string, { description?: string; owner?: string; runner_label?: string; runner_type?: string; skip_dry_run?: boolean }> = {};
     if (Array.isArray(parsed.requirements)) {
       for (const r of parsed.requirements) {
-        meta[r.id] = { description: r.description, owner: r.owner };
+        const def = (r.runner && defaults[r.runner]) || {};
+        const owner = r.owner ?? def.owner;
+        const runner_label = r.runner_label ?? def.runner_label;
+        const runner_type = r.runner_type ?? def.runner_type;
+        const skip_dry_run = r.skip_dry_run ?? def.skip_dry_run;
+        meta[r.id] = { description: r.description, owner, runner_label, runner_type, skip_dry_run };
         if (Array.isArray(r.tests)) {
           for (const t of r.tests) {
             const key = t.toLowerCase();
-            if (!map[key]) map[key] = { requirements: [], owner: r.owner };
+            if (!map[key]) map[key] = { requirements: [], owner };
             map[key].requirements.push(r.id);
           }
         }
@@ -102,7 +111,11 @@ export async function collectTestCases(files: string[], evidenceDir: string, os?
   return tests;
 }
 
-export function mapToRequirements(tests: TestCase[], mapping: Record<string, { requirements: string[]; owner?: string }>, meta: Record<string, { description?: string; owner?: string }>): RequirementGroup[] {
+export function mapToRequirements(
+  tests: TestCase[],
+  mapping: Record<string, { requirements: string[]; owner?: string }>,
+  meta: Record<string, { description?: string; owner?: string; runner_label?: string; runner_type?: string; skip_dry_run?: boolean }>
+): RequirementGroup[] {
   const groups: Map<string, RequirementGroup> = new Map();
   for (const test of tests) {
     const stripAnnotations = (s: string) => s.replace(/\[[^\]]+\]/g, '').trim();
@@ -122,7 +135,15 @@ export function mapToRequirements(tests: TestCase[], mapping: Record<string, { r
     const targetReqs = reqs.length ? reqs : ['Unmapped'];
     for (const reqId of targetReqs) {
       if (!groups.has(reqId)) {
-        groups.set(reqId, { id: reqId, description: meta[reqId]?.description, owner: meta[reqId]?.owner, tests: [] });
+        groups.set(reqId, {
+          id: reqId,
+          description: meta[reqId]?.description,
+          owner: meta[reqId]?.owner,
+          runner_label: meta[reqId]?.runner_label,
+          runner_type: meta[reqId]?.runner_type,
+          skip_dry_run: meta[reqId]?.skip_dry_run,
+          tests: [],
+        });
       }
       groups.get(reqId)!.tests.push(test);
     }


### PR DESCRIPTION
## Summary
- add `runner_type` and `skip_dry_run` support to requirements schema and deduplicate runner metadata via defaults
- mark `icon-editor-windows` entries as integration tests that skip dry runs
- document updated schema and runner behavior

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `npx --yes actionlint` *(fails: could not determine executable to run)*
- `pwsh --version`
- `pwsh -NoLogo -Command "Install-Module -Name Pester,powershell-yaml -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a0fa855f3c8329beccd68eb77bd2a3