### PR TITLE
Skip powershell-yaml for integration runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,13 @@ jobs:
         include:
           - os: ubuntu-24.04
             runs-on: ubuntu-24.04
+            runner_type: default
           - os: icon-editor-windows
             runs-on: [self-hosted, icon-editor-windows]
+            runner_type: integration
     runs-on: ${{ matrix.runs-on }}
+    env:
+      RUNNER_TYPE: ${{ matrix.runner_type }}
     steps:
       - uses: actions/checkout@v4
       - name: Capture setup info
@@ -79,8 +83,15 @@ jobs:
             Install-Module -Name Pester -MinimumVersion 5.0.0 -Scope CurrentUser -Force -SkipPublisherCheck
           }
       - name: Install powershell-yaml
+        if: matrix.runner_type != 'integration'
         shell: pwsh
         run: Install-Module -Name powershell-yaml -Scope CurrentUser -Force
+      - name: Validate native YAML parsing
+        if: matrix.runner_type == 'integration'
+        shell: pwsh
+        run: |
+          $parsed = ConvertFrom-Yaml 'a: 1'
+          if ($parsed.a -ne 1) { throw 'YAML parsing failed' }
       - name: Run Pester
         shell: pwsh
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,8 @@
 - Run `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')` to verify links.
 - Run `npx --yes actionlint` to validate GitHub Actions workflows.
 - Ensure PowerShell 7.5.2 is installed.
-- Run `pwsh -NoLogo -Command "Install-Module -Name Pester,powershell-yaml -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"`.
+- Run `pwsh -NoLogo -Command "Install-Module -Name Pester -Force -Scope AllUsers; if ($env:RUNNER_TYPE -ne 'integration') { Install-Module -Name powershell-yaml -Force -Scope AllUsers }; Invoke-Pester -CI -Path ./tests/pester"`.
+- If `$env:RUNNER_TYPE` is `integration`, verify native YAML parsing with `pwsh -NoLogo -Command "ConvertFrom-Yaml 'a: 1' | Out-Null"` before running Pester.
 
 All tests above are mandatory; they must pass before committing.
 

--- a/tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'AddTokenToLabview.SelfHosted.Workflow [REQ-008]' {
     It 'runs add-token-to-labview action on a self-hosted runner and uploads token artifact [REQ-008]' {

--- a/tests/pester/ApplyVipc.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/ApplyVipc.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'ApplyVipc.SelfHosted.DryRunTrue.Workflow [REQ-006]' {
     It 'runs apply-vipc action with dry_run true [REQ-006]' {

--- a/tests/pester/Build.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/Build.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'Build.SelfHosted.Workflow [REQ-009]' {
     It 'runs build action with required inputs [REQ-009]' {

--- a/tests/pester/BuildLvlibp.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/BuildLvlibp.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'BuildLvlibp.SelfHosted.Workflow [REQ-010]' {
     It 'runs build-lvlibp action and uploads lvlibp artifact [REQ-010]' {

--- a/tests/pester/BuildViPackage.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/BuildViPackage.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'BuildViPackage.SelfHosted.Workflow [REQ-011]' {
     It 'runs build-vi-package action and uploads vi package artifact [REQ-011]' {

--- a/tests/pester/CloseLabview.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/CloseLabview.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'CloseLabview.SelfHosted.Workflow [REQ-012]' {
     It 'runs close-labview action for 32-bit and 64-bit and uploads logs [REQ-012]' {

--- a/tests/pester/MissingInProject.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/MissingInProject.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'MissingInProject.SelfHosted.Workflow [REQ-014]' {
     It 'runs missing-in-project action on a self-hosted runner and uploads findings report [REQ-014]' {

--- a/tests/pester/ModifyVipbDisplayInfo.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/ModifyVipbDisplayInfo.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'ModifyVipbDisplayInfo.SelfHosted.Workflow [REQ-015]' {
     It 'runs modify-vipb-display-info action on a self-hosted runner and uploads VIPB artifact [REQ-015]' {

--- a/tests/pester/PrepareLabviewSource.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/PrepareLabviewSource.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'PrepareLabviewSource.SelfHosted.Workflow [REQ-011]' {
     It 'runs prepare-labview-source action and uploads prepared source artifact [REQ-011]' {

--- a/tests/pester/RenameFile.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RenameFile.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'RenameFile.SelfHosted.Workflow [REQ-011]' {
     It 'runs rename-file action on a self-hosted runner and uploads renamed file artifact [REQ-011]' {

--- a/tests/pester/RestoreSetupLvSource.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RestoreSetupLvSource.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'RestoreSetupLvSource.SelfHosted.Workflow [REQ-018]' {
     It 'runs restore-setup-lv-source action on a self-hosted runner and uploads restoration artifacts [REQ-018]' {

--- a/tests/pester/RevertDevelopmentMode.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RevertDevelopmentMode.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'RevertDevelopmentMode.SelfHosted.Workflow [REQ-019]' {
     It 'runs revert-development-mode action on a self-hosted runner and uploads configuration artifact [REQ-019]' {

--- a/tests/pester/RunUnitTests.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RunUnitTests.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'RunUnitTests.SelfHosted.Workflow [REQ-011]' {
     It 'runs run-unit-tests action and uploads unit-test results [REQ-011]' {

--- a/tests/pester/SetDevelopmentMode.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/SetDevelopmentMode.SelfHosted.Workflow.Tests.ps1
@@ -2,7 +2,9 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-Import-Module powershell-yaml
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    Import-Module powershell-yaml
+}
 
 Describe 'SetDevelopmentMode.SelfHosted.Workflow [REQ-021]' {
     It 'runs set-development-mode action on a self-hosted runner and uploads logs [REQ-021]' {


### PR DESCRIPTION
## Summary
- avoid installing powershell-yaml when the runner type is integration
- document conditional powershell-yaml usage in AGENTS.md
- load powershell-yaml in tests only when native ConvertFrom-Yaml is missing

## Testing
- `PATH=/usr/bin:$PATH npm run check:node`
- `PATH=/usr/bin:$PATH npm install`
- `PATH=/usr/bin:$PATH npm test`
- `PATH=/usr/bin:$PATH npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `PATH=/usr/bin:$PATH npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `/tmp/actionlint -version`
- `/tmp/actionlint`
- `pwsh -NoLogo -Command 'Install-Module -Name Pester -Force -Scope AllUsers; if ($env:RUNNER_TYPE -ne "integration") { Install-Module -Name powershell-yaml -Force -Scope AllUsers }; Invoke-Pester -CI -Path ./tests/pester'`


------
https://chatgpt.com/codex/tasks/task_e_68a0fd6dd7108329b7a79f9cafd3a08b