### PR TITLE
feat: partition CI summaries by runner type

### DIFF
--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -101,3 +101,43 @@ test('writes outputs to OS-specific directory', async () => {
   await fs.rm(tmp, { recursive: true, force: true });
   await fs.rm('artifacts', { recursive: true, force: true });
 });
+
+test('partitions requirement groups by runner_type', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'partition-'));
+  const junitPath = path.join(dir, 'junit.xml');
+  const xml = '<testsuite><testcase name="alpha" time="0"/><testcase name="beta" time="0"/></testsuite>';
+  await fs.writeFile(junitPath, xml);
+  const req = {
+    runners: { integ: { runner_type: 'integration' } },
+    requirements: [
+      { id: 'REQ-1', tests: ['alpha'] },
+      { id: 'REQ-2', runner: 'integ', tests: ['beta'] },
+    ],
+  };
+  const reqPath = path.join(dir, 'req.json');
+  await fs.writeFile(reqPath, JSON.stringify(req));
+
+  await fs.rm('artifacts', { recursive: true, force: true });
+
+  const env = {
+    ...process.env,
+    TEST_RESULTS_GLOB: junitPath,
+    EVIDENCE_DIR: dir,
+    REQ_MAPPING_FILE: reqPath,
+    RUNNER_OS: 'Linux',
+  };
+
+  await execFileP('node_modules/.bin/tsx', ['scripts/generate-ci-summary.ts'], { env });
+
+  const outDir = path.join('artifacts', 'linux');
+  const std = await fs.readFile(path.join(outDir, 'summary-standard.md'), 'utf8');
+  assert.match(std, /REQ-1/);
+  const integ = await fs.readFile(path.join(outDir, 'summary-integration.md'), 'utf8');
+  assert.match(integ, /REQ-2/);
+  const traceStdExists = await fs.stat(path.join(outDir, 'traceability-standard.md')).then(() => true, () => false);
+  const traceIntegExists = await fs.stat(path.join(outDir, 'traceability-integration.md')).then(() => true, () => false);
+  assert.strictEqual(traceStdExists && traceIntegExists, true);
+
+  await fs.rm(dir, { recursive: true, force: true });
+  await fs.rm('artifacts', { recursive: true, force: true });
+});

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -186,6 +186,20 @@ export function buildSummary(groups: RequirementGroup[]) {
   return { overall, byOs };
 }
 
+export function summaryToMarkdown(totals: { overall: { passed: number; failed: number; skipped: number; duration: number; rate: number }; byOs: Record<string, { passed: number; failed: number; skipped: number; duration: number; rate: number }> }) {
+  const lines = [
+    '### Test Summary',
+    '| OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |',
+    '| --- | --- | --- | --- | --- | --- |',
+    `| overall | ${totals.overall.passed} | ${totals.overall.failed} | ${totals.overall.skipped} | ${totals.overall.duration.toFixed(2)} | ${totals.overall.rate.toFixed(2)} |`,
+  ];
+  for (const os of Object.keys(totals.byOs).sort()) {
+    const t = totals.byOs[os];
+    lines.push(`| ${os} | ${t.passed} | ${t.failed} | ${t.skipped} | ${t.duration.toFixed(2)} | ${t.rate.toFixed(2)} |`);
+  }
+  return lines.join('\n');
+}
+
 export function groupToMarkdown(groups: RequirementGroup[], limit?: number) {
   const lines: string[] = [];
   let count = 0;
@@ -320,18 +334,7 @@ async function main() {
   await fs.mkdir(outDir, { recursive: true });
 
   const matrixMd = groupToMarkdown(groups);
-
-  const summaryLines = [
-    '### Test Summary',
-    '| OS | Passed | Failed | Skipped | Duration (s) | Pass Rate (%) |',
-    '| --- | --- | --- | --- | --- | --- |',
-    `| overall | ${totals.overall.passed} | ${totals.overall.failed} | ${totals.overall.skipped} | ${totals.overall.duration.toFixed(2)} | ${totals.overall.rate.toFixed(2)} |`,
-  ];
-  for (const os of Object.keys(totals.byOs).sort()) {
-    const t = totals.byOs[os];
-    summaryLines.push(`| ${os} | ${t.passed} | ${t.failed} | ${t.skipped} | ${t.duration.toFixed(2)} | ${t.rate.toFixed(2)} |`);
-  }
-  const summaryMd = summaryLines.join('\n');
+  const summaryMd = summaryToMarkdown(totals);
 
   const wrapperFiles = await glob('*/action.yml', { nodir: true });
   const wrapperDirs = wrapperFiles.map(f => path.dirname(f)).sort();
@@ -343,6 +346,24 @@ async function main() {
   await fs.writeFile(path.join(outDir, 'summary.md'), redact(summaryMd));
   await fs.writeFile(path.join(outDir, 'action-docs.json'), JSON.stringify(docs, null, 2));
   await fs.writeFile(path.join(outDir, 'action-docs.md'), redact(markdown));
+
+  const partitions: Record<string, RequirementGroup[]> = {};
+  for (const g of groups) {
+    const type = g.runner_type ?? 'standard';
+    if (!partitions[type]) partitions[type] = [];
+    partitions[type].push(g);
+  }
+
+  for (const [type, list] of Object.entries(partitions)) {
+    const partTotals = buildSummary(list);
+    const partSummary = summaryToMarkdown(partTotals);
+    const partMatrix = groupToMarkdown(list);
+    await fs.writeFile(path.join(outDir, `summary-${type}.md`), redact(`${partSummary}\n\n${partMatrix}`));
+    await fs.writeFile(
+      path.join(outDir, `traceability-${type}.md`),
+      redact(`### Test Traceability Matrix\n\n${partMatrix}`),
+    );
+  }
 
   try {
     await fs.access(evidenceDir);


### PR DESCRIPTION
## Summary
- partition test requirements by `runner_type` to build per-runner summaries and traceability docs
- generate `summary-<type>.md` and `traceability-<type>.md` alongside overall outputs
- add tests for runner type partitioning

## Testing
- `npm run check:node` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `npx --yes actionlint` *(fails: could not determine executable to run)*
- `pwsh --version`
- `pwsh -NoLogo -Command "Install-Module -Name Pester -Force -Scope AllUsers; if ($env:RUNNER_TYPE -ne 'integration') { Install-Module -Name powershell-yaml -Force -Scope AllUsers }; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a1020b3e8c8329a00b9da80978c148