### PR TITLE
Include module scripts in dispatcher registry

### DIFF
--- a/dispatchers.json
+++ b/dispatchers.json
@@ -1,1 +1,62 @@
-{}
+{
+  "InvokeAddTokenToLabVIEW": {
+    "description": "",
+    "parameters": {}
+  },
+  "InvokeApplyVIPC": {
+    "description": "",
+    "parameters": {}
+  },
+  "InvokeBuild": {
+    "description": "",
+    "parameters": {}
+  },
+  "InvokeBuildLvlibp": {
+    "description": "",
+    "parameters": {}
+  },
+  "InvokeBuildViPackage": {
+    "description": "",
+    "parameters": {}
+  },
+  "InvokeCloseLabVIEW": {
+    "description": "",
+    "parameters": {}
+  },
+  "InvokeGenerateReleaseNotes": {
+    "description": "",
+    "parameters": {}
+  },
+  "InvokeMissingInProject": {
+    "description": "",
+    "parameters": {}
+  },
+  "InvokeModifyVIPBDisplayInfo": {
+    "description": "",
+    "parameters": {}
+  },
+  "InvokePrepareLabVIEWSource": {
+    "description": "",
+    "parameters": {}
+  },
+  "InvokeRenameFile": {
+    "description": "",
+    "parameters": {}
+  },
+  "InvokeRestoreSetupLVSource": {
+    "description": "",
+    "parameters": {}
+  },
+  "InvokeRevertDevelopmentMode": {
+    "description": "",
+    "parameters": {}
+  },
+  "InvokeRunUnitTests": {
+    "description": "",
+    "parameters": {}
+  },
+  "InvokeSetDevelopmentMode": {
+    "description": "",
+    "parameters": {}
+  }
+}

--- a/scripts/derive-dispatcher-registry.ts
+++ b/scripts/derive-dispatcher-registry.ts
@@ -51,7 +51,7 @@ function extractDescription(content: string, index: number): string {
 }
 
 async function main() {
-  const files = await glob('actions/*.ps1');
+  const files = await glob('actions/*.{ps1,psm1}');
   const registry: Record<string, FuncInfo> = {};
   for (const file of files) {
     const content = await fs.readFile(file, 'utf8');


### PR DESCRIPTION
## Summary
- expand dispatcher registry glob to include PowerShell module files
- regenerate dispatcher mapping

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "Install-Module -Name Pester -Force -Scope AllUsers; if ($env:RUNNER_TYPE -ne 'integration') { Install-Module -Name powershell-yaml -Force -Scope AllUsers }; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a1100c7adc8329ac68f63bddb3cced