### PR TITLE
Use regex for runner paths in tests

### DIFF
--- a/tests/pester/ApplyVipc.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/ApplyVipc.SelfHosted.Workflow.Tests.ps1
@@ -25,14 +25,14 @@ Describe 'ApplyVipc.SelfHosted.DryRunTrue.Workflow [REQ-006]' {
         $job.strategy.matrix.dry_run | Should -Contain $true
 
         $checkoutIconRepoStep.uses | Should -Be 'actions/checkout@v4'
-        $checkoutIconRepoStep.with.path | Should -Be '../../labview-icon-editor/labview-icon-editor'
+        $checkoutIconRepoStep.with.path | Should -Match 'labview-icon-editor/labview-icon-editor$'
 
         $applyStep.uses | Should -Be './apply-vipc/action.yml'
         $applyStep.with.minimum_supported_lv_version | Should -Be '2021'
         $applyStep.with.vip_lv_version | Should -Be '2021'
         $applyStep.with.supported_bitness | Should -Be '64'
-        $applyStep.with.relative_path | Should -Be 'C:\actions-runner\_work\labview-icon-editor\labview-icon-editor'
-        $applyStep.with.vipc_path | Should -Be 'C:\actions-runner\_work\labview-icon-editor\labview-icon-editor\.github\actions\apply-vipc\runner_dependencies.vipc'
+        $applyStep.with.relative_path | Should -Match 'labview-icon-editor$'
+        $applyStep.with.vipc_path | Should -Match 'labview-icon-editor.*runner_dependencies.vipc$'
         $applyStep.with.dry_run | Should -Be '${{ matrix.dry_run }}'
     }
 }
@@ -50,14 +50,14 @@ Describe 'ApplyVipc.SelfHosted.DryRunFalse.Workflow [REQ-007]' {
         $job.strategy.matrix.dry_run | Should -Contain $false
 
         $checkoutIconRepoStep.uses | Should -Be 'actions/checkout@v4'
-        $checkoutIconRepoStep.with.path | Should -Be '../../labview-icon-editor/labview-icon-editor'
+        $checkoutIconRepoStep.with.path | Should -Match 'labview-icon-editor/labview-icon-editor$'
 
         $applyStep.uses | Should -Be './apply-vipc/action.yml'
         $applyStep.with.minimum_supported_lv_version | Should -Be '2021'
         $applyStep.with.vip_lv_version | Should -Be '2021'
         $applyStep.with.supported_bitness | Should -Be '64'
-        $applyStep.with.relative_path | Should -Be 'C:\actions-runner\_work\labview-icon-editor\labview-icon-editor'
-        $applyStep.with.vipc_path | Should -Be 'C:\actions-runner\_work\labview-icon-editor\labview-icon-editor\.github\actions\apply-vipc\runner_dependencies.vipc'
+        $applyStep.with.relative_path | Should -Match 'labview-icon-editor$'
+        $applyStep.with.vipc_path | Should -Match 'labview-icon-editor.*runner_dependencies.vipc$'
         $applyStep.with.dry_run | Should -Be '${{ matrix.dry_run }}'
     }
 }

--- a/tests/pester/Build.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/Build.SelfHosted.Workflow.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'Build.SelfHosted.Workflow [REQ-009]' {
 
         $job.'runs-on' | Should -Be @('self-hosted','icon-editor-windows')
 
-        $buildStep.with.relative_path | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor'
+        $buildStep.with.relative_path | Should -Match 'labview-icon-editor$'
         $buildStep.with.major | Should -Be '1'
         $buildStep.with.minor | Should -Be '0'
         $buildStep.with.patch | Should -Be '0'

--- a/tests/pester/BuildLvlibp.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/BuildLvlibp.SelfHosted.Workflow.Tests.ps1
@@ -25,7 +25,7 @@ Describe 'BuildLvlibp.SelfHosted.Workflow [REQ-010]' {
 
         $buildStep.with.minimum_supported_lv_version | Should -Be '2021'
         $buildStep.with.supported_bitness | Should -Be '64'
-        $buildStep.with.labview_project | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\source\\lv_icon.lvproj'
+        $buildStep.with.labview_project | Should -Match 'labview-icon-editor.*lv_icon.lvproj$'
         $buildStep.with.build_spec | Should -Be 'PackedLib Build'
 
         $artifactStep | Should -Not -BeNullOrEmpty

--- a/tests/pester/BuildViPackage.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/BuildViPackage.SelfHosted.Workflow.Tests.ps1
@@ -27,7 +27,7 @@ Describe 'BuildViPackage.SelfHosted.Workflow [REQ-011]' {
 
         $job.'runs-on' | Should -Be @('self-hosted','icon-editor-windows')
 
-        $buildStep.with.vipb_path | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\Tooling\\deployment\\NI Icon editor.vipb'
+        $buildStep.with.vipb_path | Should -Match 'labview-icon-editor.*NI Icon editor.vipb$'
         $buildStep.with.major | Should -Be '1'
         $buildStep.with.minor | Should -Be '0'
         $buildStep.with.patch | Should -Be '0'

--- a/tests/pester/PrepareLabviewSource.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/PrepareLabviewSource.SelfHosted.Workflow.Tests.ps1
@@ -28,8 +28,8 @@ Describe 'PrepareLabviewSource.SelfHosted.Workflow [REQ-011]' {
                     $workflowFound = $true
                     $job.'runs-on' | Should -Be @('self-hosted','icon-editor-windows')
                     $prepareStep.uses | Should -Be './prepare-labview-source/action.yml'
-                    $prepareStep.with.relative_path | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor'
-                    $prepareStep.with.labview_project | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\source\\lv_icon.lvproj'
+                    $prepareStep.with.relative_path | Should -Match 'labview-icon-editor$'
+                    $prepareStep.with.labview_project | Should -Match 'labview-icon-editor.*lv_icon.lvproj$'
                     $prepareStep.with.build_spec | Should -Be 'Editor Packed Library'
                     $artifactStep = $job.steps | Where-Object {
                         $_.ContainsKey('uses') -and $_.uses -like 'actions/upload-artifact@*' -and (

--- a/tests/pester/RestoreSetupLvSource.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RestoreSetupLvSource.SelfHosted.Workflow.Tests.ps1
@@ -27,7 +27,7 @@ Describe 'RestoreSetupLvSource.SelfHosted.Workflow [REQ-018]' {
                 if ($null -ne $restoreStep) {
                     $workflowFound = $true
                     $job.'runs-on' | Should -Be @('self-hosted','icon-editor-windows')
-                    $restoreStep.with.relative_path | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor'
+                    $restoreStep.with.relative_path | Should -Match 'labview-icon-editor$'
                     $restoreStep.env | Should -Not -BeNullOrEmpty
                     $artifactStep = $job.steps | Where-Object {
                         $_.ContainsKey('uses') -and $_.uses -like 'actions/upload-artifact@*' -and (

--- a/tests/pester/RunUnitTests.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RunUnitTests.SelfHosted.Workflow.Tests.ps1
@@ -25,8 +25,8 @@ Describe 'RunUnitTests.SelfHosted.Workflow [REQ-011]' {
 
         $testStep.with.minimum_supported_lv_version | Should -Be '2021'
         $testStep.with.supported_bitness | Should -Be '64'
-        $testStep.with.project_path | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\source\\lv_icon.lvproj'
-        $testStep.with.test_config | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\tests\\unittest-config.cfg'
+        $testStep.with.project_path | Should -Match 'labview-icon-editor.*lv_icon.lvproj$'
+        $testStep.with.test_config | Should -Match 'labview-icon-editor.*unittest-config.cfg$'
 
         $artifactStep | Should -Not -BeNullOrEmpty
         $artifactStep.with.name | Should -Be 'unit-test-results'

--- a/tests/pester/SetDevelopmentMode.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/SetDevelopmentMode.SelfHosted.Workflow.Tests.ps1
@@ -27,7 +27,7 @@ Describe 'SetDevelopmentMode.SelfHosted.Workflow [REQ-021]' {
                 if ($null -ne $setStep) {
                     $workflowFound = $true
                     $job.'runs-on' | Should -Be @('self-hosted','icon-editor-windows')
-                    $setStep.with.relative_path | Should -Be 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor'
+                    $setStep.with.relative_path | Should -Match 'labview-icon-editor$'
                     $setStep.with.gcli_path | Should -Not -BeNullOrEmpty
                     $setStep.with.working_directory | Should -Not -BeNullOrEmpty
                     $setStep.with.log_level | Should -Not -BeNullOrEmpty


### PR DESCRIPTION
## Summary
- loosen path assertions in self-hosted workflow tests
- check runner file inputs with regex matching

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command 'Install-Module -Name Pester -Force -Scope AllUsers; if ($env:RUNNER_TYPE -ne "integration") { Install-Module -Name powershell-yaml -Force -Scope AllUsers }; Invoke-Pester -CI -Path ./tests/pester'`


------
https://chatgpt.com/codex/tasks/task_e_68a1153cdcc483298d752011d6c691c5