### PR TITLE
chore: broaden JUnit glob and configure test results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
       - run: npm run test:ci
       - run: npm run derive:registry
       - run: npm run generate:summary
+        env:
+          TEST_RESULTS_GLOB: test-results/*junit*.xml
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -132,7 +134,7 @@ jobs:
       - run: npm run generate:summary
         env:
           TEST_RESULTS_GLOBS: |
-            downloaded/test-results/**/*.xml
+            downloaded/test-results/**/*junit*.xml
             downloaded/pester-junit-*/pester-junit.xml
           REQ_MAPPING_FILE: requirements.json
           DISPATCHER_REGISTRY: dispatchers.json

--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -16,6 +16,7 @@ test('generate-ci-summary features', async () => {
   assert.match(content, /TEST_RESULTS_GLOBS/);
   assert.match(content, /<redacted>/);
   assert.match(content, /<details><summary>/);
+  assert.match(content, /\*\*\/\*junit\*\.xml/);
 });
 
 test('writeErrorSummary skips summary file for non-Error throws', async () => {

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -334,7 +334,7 @@ async function main() {
     }
     junitFiles = Array.from(found);
   } else {
-    const single = process.env.TEST_RESULTS_GLOB || '**/junit*.xml';
+    const single = process.env.TEST_RESULTS_GLOB || '**/*junit*.xml';
     junitFiles = await glob(single, { nodir: true });
   }
   let tests: TestCase[] = [];


### PR DESCRIPTION
## Summary
- detect `*junit*.xml` reports by default
- verify new glob in tests
- configure workflows to pass test result globs explicitly

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "Set-PSRepository -Name PSGallery -InstallationPolicy Trusted; Install-Module -Name Pester -Force -Scope AllUsers; if ($env:RUNNER_TYPE -ne 'integration') { Install-Module -Name powershell-yaml -Force -Scope AllUsers }; Invoke-Pester -CI -Path ./tests/pester"`

------
https://chatgpt.com/codex/tasks/task_e_68a11bb0dcf08329adf146d396dca605