### PR TITLE
feat: infer test owner from machine name

### DIFF
--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -45,6 +45,26 @@ test('associates classname with requirement', async () => {
   await fs.rm(dir, { recursive: true, force: true });
 });
 
+test('extracts owner from machine-name property', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'owner-prop-'));
+  const xml = `<testsuite><testcase name="alpha" time="0"><properties><property name="machine-name" value="dave"/></properties></testcase></testsuite>`;
+  const xmlPath = path.join(dir, 'junit.xml');
+  await fs.writeFile(xmlPath, xml);
+  const tests = await collectTestCases([xmlPath], dir, 'linux');
+  assert.strictEqual(tests[0].owner, 'dave');
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+test('falls back to [Owner:...] annotation', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'owner-annot-'));
+  const xml = `<testsuite><testcase name="beta [Owner:carol]" time="0"/></testsuite>`;
+  const xmlPath = path.join(dir, 'junit.xml');
+  await fs.writeFile(xmlPath, xml);
+  const tests = await collectTestCases([xmlPath], dir, 'linux');
+  assert.strictEqual(tests[0].owner, 'carol');
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
 test('groupToMarkdown assigns numeric identifiers', () => {
   const groups = [{
     id: 'REQ-XYZ',

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -94,8 +94,13 @@ export async function collectTestCases(files: string[], evidenceDir: string, os?
           const test: TestCase = { id, name, className, status, duration, requirements: [], os: osType };
           const evidence = evidenceFiles.find((f) => f.startsWith(id) || f.startsWith(id + '.'));
           if (evidence) test.evidence = path.join('evidence', evidence);
-          const ownerMatch = name.match(/\[Owner:([^\]]+)\]/i);
-          if (ownerMatch) test.owner = ownerMatch[1];
+          const machineName = tc.properties?.[0]?.property?.find((p: any) => p.name?.[0] === 'machine-name')?.value?.[0];
+          if (machineName) {
+            test.owner = machineName;
+          } else {
+            const ownerMatch = name.match(/\[Owner:([^\]]+)\]/i);
+            if (ownerMatch) test.owner = ownerMatch[1];
+          }
           const reqMatches = [...name.matchAll(/\[(REQ-\d+)\]/gi)].map((m) => m[1].toUpperCase());
           const uniqueReqMatches = new Set(reqMatches);
           if (uniqueReqMatches.size) test.requirements.push(...uniqueReqMatches);


### PR DESCRIPTION
## Summary
- derive test owner from `machine-name` JUnit property
- test fallback to `[Owner:...]` annotation

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "Set-PSRepository -Name PSGallery -InstallationPolicy Trusted; Install-Module -Name Pester -Force -Scope AllUsers; if ($env:RUNNER_TYPE -ne 'integration') { Install-Module -Name powershell-yaml -Force -Scope AllUsers }; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a11f5a5c8083298c655bfeeb3364c5