### PR TITLE
feat: infer test owner from junit properties

### DIFF
--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -45,6 +45,23 @@ test('associates classname with requirement', async () => {
   await fs.rm(dir, { recursive: true, force: true });
 });
 
+test('collectTestCases uses machine-name property for owner', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'owner-'));
+  const xmlProp = `<testsuite><testcase name="foo" time="0"><properties><property name="machine-name" value="ci-bot"/></properties></testcase></testsuite>`;
+  const propPath = path.join(dir, 'junit1.xml');
+  await fs.writeFile(propPath, xmlProp);
+  const testsProp = await collectTestCases([propPath], dir, 'linux');
+  assert.strictEqual(testsProp[0].owner, 'ci-bot');
+
+  const xmlFallback = `<testsuite><testcase name="[Owner:alice] bar" time="0"/></testsuite>`;
+  const fallbackPath = path.join(dir, 'junit2.xml');
+  await fs.writeFile(fallbackPath, xmlFallback);
+  const testsFallback = await collectTestCases([fallbackPath], dir, 'linux');
+  assert.strictEqual(testsFallback[0].owner, 'alice');
+
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
 test('groupToMarkdown assigns numeric identifiers', () => {
   const groups = [{
     id: 'REQ-XYZ',

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -94,8 +94,16 @@ export async function collectTestCases(files: string[], evidenceDir: string, os?
           const test: TestCase = { id, name, className, status, duration, requirements: [], os: osType };
           const evidence = evidenceFiles.find((f) => f.startsWith(id) || f.startsWith(id + '.'));
           if (evidence) test.evidence = path.join('evidence', evidence);
-          const ownerMatch = name.match(/\[Owner:([^\]]+)\]/i);
-          if (ownerMatch) test.owner = ownerMatch[1];
+          const props = tc.properties?.[0]?.property;
+          if (Array.isArray(props)) {
+            const machine = props.find((p: any) => p.name?.[0] === 'machine-name');
+            const ownerVal = machine?.value?.[0] ?? machine?._;
+            if (ownerVal) test.owner = ownerVal;
+          }
+          if (!test.owner) {
+            const ownerMatch = name.match(/\[Owner:([^\]]+)\]/i);
+            if (ownerMatch) test.owner = ownerMatch[1];
+          }
           const reqMatches = [...name.matchAll(/\[(REQ-\d+)\]/gi)].map((m) => m[1].toUpperCase());
           const uniqueReqMatches = new Set(reqMatches);
           if (uniqueReqMatches.size) test.requirements.push(...uniqueReqMatches);


### PR DESCRIPTION
## Summary
- derive test owner from JUnit `machine-name` property
- test coverage for property-based and annotated owners

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "ConvertFrom-Yaml 'a: 1' | Out-Null"`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester" > pester.log && tail -n 20 pester.log`

------
https://chatgpt.com/codex/tasks/task_e_68a11f5a5c8083298c655bfeeb3364c5