### PR TITLE
Support evidence property in test collection

### DIFF
--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -62,6 +62,24 @@ test('collectTestCases uses machine-name property for owner', async () => {
   await fs.rm(dir, { recursive: true, force: true });
 });
 
+test('collectTestCases uses evidence property and falls back to directory scan', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'evidence-'));
+  const xmlProp = `<testsuite><testcase name="alpha" time="0"><properties><property name="evidence" value="http://ci/example.log"/></properties></testcase></testsuite>`;
+  const propPath = path.join(dir, 'junit1.xml');
+  await fs.writeFile(propPath, xmlProp);
+  const xmlFallback = `<testsuite><testcase name="beta" time="0"/></testsuite>`;
+  const fallbackPath = path.join(dir, 'junit2.xml');
+  await fs.writeFile(fallbackPath, xmlFallback);
+  await fs.writeFile(path.join(dir, 'beta.txt'), 'x');
+
+  const testsProp = await collectTestCases([propPath], dir, 'linux');
+  assert.strictEqual(testsProp[0].evidence, 'http://ci/example.log');
+  const testsFallback = await collectTestCases([fallbackPath], dir, 'linux');
+  assert.strictEqual(testsFallback[0].evidence, path.join('evidence', 'beta.txt'));
+
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
 test('groupToMarkdown assigns numeric identifiers', () => {
   const groups = [{
     id: 'REQ-XYZ',

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -92,13 +92,20 @@ export async function collectTestCases(files: string[], evidenceDir: string, os?
           else if (tc.skipped) status = 'Skipped';
           const duration = parseFloat(tc.time?.[0] ?? '0');
           const test: TestCase = { id, name, className, status, duration, requirements: [], os: osType };
-          const evidence = evidenceFiles.find((f) => f.startsWith(id) || f.startsWith(id + '.'));
-          if (evidence) test.evidence = path.join('evidence', evidence);
           const props = tc.properties?.[0]?.property;
           if (Array.isArray(props)) {
             const machine = props.find((p: any) => p.name?.[0] === 'machine-name');
             const ownerVal = machine?.value?.[0] ?? machine?._;
             if (ownerVal) test.owner = ownerVal;
+            const evidenceProp = props.find((p: any) =>
+              ['evidence', 'attachment', 'ci_link'].includes(p.name?.[0])
+            );
+            const evidenceVal = evidenceProp?.value?.[0] ?? evidenceProp?._;
+            if (evidenceVal) test.evidence = evidenceVal;
+          }
+          if (!test.evidence) {
+            const evidence = evidenceFiles.find((f) => f.startsWith(id) || f.startsWith(id + '.'));
+            if (evidence) test.evidence = path.join('evidence', evidence);
           }
           if (!test.owner) {
             const ownerMatch = name.match(/\[Owner:([^\]]+)\]/i);


### PR DESCRIPTION
## Summary
- extract `evidence`, `attachment`, or `ci_link` test case properties when collecting tests
- fallback to existing evidence directory scan when property absent
- add tests to verify evidence property and directory fallback

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "Install-Module -Name Pester -Force -Scope AllUsers; if (\$env:RUNNER_TYPE -ne 'integration') { Install-Module -Name powershell-yaml -Force -Scope AllUsers }; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a1270f126c832991c2c2bd9c849f1e