### PR TITLE
fix: drop fs.R_OK in yarn lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,6 @@ If npm prints `npm warn Unknown env config "http-proxy"`, remove the
 `npm_config_http_proxy` environment variable or replace it with
 `npm_config_proxy`/`npm_config_https_proxy`.
 
-Node.js 24+ removes legacy constants like `fs.R_OK`. The scripts in this
-repository use `fs.constants.R_OK` to remain compatible with newer Node
-releases.
+Node.js 24+ removes legacy constants like `fs.R_OK`. Scripts and patches in
+this repository rely on `fs.constants.R_OK` to remain compatible with newer
+Node releases.

--- a/patches/@yarnpkg+lockfile+1.1.0.patch
+++ b/patches/@yarnpkg+lockfile+1.1.0.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/@yarnpkg/lockfile/index.js b/node_modules/@yarnpkg/lockfile/index.js
+index 67cab24..c634614 100644
+--- a/node_modules/@yarnpkg/lockfile/index.js
++++ b/node_modules/@yarnpkg/lockfile/index.js
+@@ -1287,11 +1287,7 @@ function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj;
+ 
+ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+ 
+-const constants = exports.constants = typeof (_fs || _load_fs()).default.constants !== 'undefined' ? (_fs || _load_fs()).default.constants : {
+-  R_OK: (_fs || _load_fs()).default.R_OK,
+-  W_OK: (_fs || _load_fs()).default.W_OK,
+-  X_OK: (_fs || _load_fs()).default.X_OK
+-};
++const constants = exports.constants = (_fs || _load_fs()).default.constants;
+ 
+ const lockQueue = exports.lockQueue = new (_blockingQueue || _load_blockingQueue()).default('fs lock');
+ 


### PR DESCRIPTION
## Summary
- patch `@yarnpkg/lockfile` to use `fs.constants` instead of deprecated `fs.R_OK`
- clarify troubleshooting notes about Node 24 constant removal

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npx --yes markdownlint-cli README.md docs/**/*.md scripts/**/*.md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force; Install-Module -Name Pester -Force -Scope AllUsers; if ($env:RUNNER_TYPE -ne 'integration') { Install-Module -Name powershell-yaml -Force -Scope AllUsers }; Invoke-Pester -CI -Path ./tests/pester"` *(failed: NuGet provider not found and powershell-yaml module missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a12b30e55c832997798a6dfbfcbdac