### PR TITLE
Add JUnit parsing requirements and tests

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -26,6 +26,16 @@ This project tracks high‑level requirements and maps each one to the Pester te
 | REQ-020 | Workflow tests the composite action defined in run-unit-tests/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/RunUnitTests.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
 | REQ-021 | Workflow tests the composite action defined in set-development-mode/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/SetDevelopmentMode.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
 | REQ-022 | Workflow tests the composite action defined in setup-mkdocs/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/SetupMkdocs.SelfHosted.Workflow.ps1` | icon-editor-windows | integration | true |
+| REQ-023 | Parser ingests JUnit XML artifacts starting at the testsuites root and iterating through nested suites and testcases. | `scripts/__tests__/junit-parser.test.js` |  |  |  |
+| REQ-024 | Top-level testsuites attributes name, tests, errors, failures, disabled, and time are captured for summary reporting. | `scripts/__tests__/junit-parser.test.js` |  |  |  |
+| REQ-025 | Each testsuite records attributes including name, tests, errors, failures, hostname, id, skipped, disabled, package, and time. | `scripts/__tests__/junit-parser.test.js` |  |  |  |
+| REQ-026 | Suite properties are extracted as name/value pairs for environment details. | `scripts/__tests__/junit-parser.test.js` |  |  |  |
+| REQ-027 | Testcase attributes name, status, classname, assertions, time, and any skip message are preserved. | `scripts/__tests__/junit-parser.test.js` |  |  |  |
+| REQ-028 | Requirement identifiers embedded in testcase names are detected and associated with the test. | `scripts/__tests__/junit-parser.test.js` |  |  |  |
+| REQ-029 | Test results are aggregated by requirement and by suite to count passed, failed, and skipped cases. | `scripts/__tests__/junit-parser.test.js` |  |  |  |
+| REQ-030 | Traceability matrix links requirement IDs to testcases with status, execution time, host properties, and skipped reasons. | `scripts/__tests__/junit-parser.test.js` |  |  |  |
+| REQ-031 | Parsing logic validates presence of required fields and reports missing or malformed data. | `scripts/__tests__/junit-parser.test.js` |  |  |  |
+| REQ-032 | Parser tolerates and retains unknown attributes for future extensibility. | `scripts/__tests__/junit-parser.test.js` |  |  |  |
 
 Each test file is annotated with its corresponding requirement ID to maintain traceability between requirements and test coverage.
 

--- a/requirements.json
+++ b/requirements.json
@@ -178,6 +178,76 @@
       "tests": [
         "SetupMkdocs.SelfHosted.Workflow"
       ]
+    },
+    {
+      "id": "REQ-023",
+      "description": "Parser ingests JUnit XML artifacts starting at the testsuites root and iterating through nested suites and testcases.",
+      "tests": [
+        "scripts/__tests__/junit-parser.test.js"
+      ]
+    },
+    {
+      "id": "REQ-024",
+      "description": "Top-level testsuites attributes name, tests, errors, failures, disabled, and time are captured for summary reporting.",
+      "tests": [
+        "scripts/__tests__/junit-parser.test.js"
+      ]
+    },
+    {
+      "id": "REQ-025",
+      "description": "Each testsuite records attributes including name, tests, errors, failures, hostname, id, skipped, disabled, package, and time.",
+      "tests": [
+        "scripts/__tests__/junit-parser.test.js"
+      ]
+    },
+    {
+      "id": "REQ-026",
+      "description": "Suite properties are extracted as name/value pairs for environment details.",
+      "tests": [
+        "scripts/__tests__/junit-parser.test.js"
+      ]
+    },
+    {
+      "id": "REQ-027",
+      "description": "Testcase attributes name, status, classname, assertions, time, and any skip message are preserved.",
+      "tests": [
+        "scripts/__tests__/junit-parser.test.js"
+      ]
+    },
+    {
+      "id": "REQ-028",
+      "description": "Requirement identifiers embedded in testcase names are detected and associated with the test.",
+      "tests": [
+        "scripts/__tests__/junit-parser.test.js"
+      ]
+    },
+    {
+      "id": "REQ-029",
+      "description": "Test results are aggregated by requirement and by suite to count passed, failed, and skipped cases.",
+      "tests": [
+        "scripts/__tests__/junit-parser.test.js"
+      ]
+    },
+    {
+      "id": "REQ-030",
+      "description": "Traceability matrix links requirement IDs to testcases with status, execution time, host properties, and skipped reasons.",
+      "tests": [
+        "scripts/__tests__/junit-parser.test.js"
+      ]
+    },
+    {
+      "id": "REQ-031",
+      "description": "Parsing logic validates presence of required fields and reports missing or malformed data.",
+      "tests": [
+        "scripts/__tests__/junit-parser.test.js"
+      ]
+    },
+    {
+      "id": "REQ-032",
+      "description": "Parser tolerates and retains unknown attributes for future extensibility.",
+      "tests": [
+        "scripts/__tests__/junit-parser.test.js"
+      ]
     }
   ]
 }

--- a/scripts/__tests__/junit-parser.test.js
+++ b/scripts/__tests__/junit-parser.test.js
@@ -1,0 +1,88 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseJUnit, summarize, buildTraceability, validate } from '../junit-parser.ts';
+
+const xml = `<?xml version="1.0" encoding="utf-8"?>
+<testsuites name="Root" tests="2" errors="1" failures="0" disabled="0" time="1.23">
+  <testsuite name="SuiteA" tests="1" errors="0" failures="0" skipped="0" disabled="0" hostname="hostA" id="0" package="pkgA" time="0.5">
+    <properties>
+      <property name="machine-name" value="hostA" />
+      <property name="os-version" value="Ubuntu" />
+    </properties>
+    <testcase name="pass case [REQ-028]" classname="ClsA" assertions="1" time="0.1" extra="1" />
+  </testsuite>
+  <testsuite name="SuiteB" tests="1" errors="0" failures="0" skipped="1" disabled="0" hostname="hostB" id="1" package="pkgB" time="0.7">
+    <properties>
+      <property name="machine-name" value="hostB" />
+    </properties>
+    <testcase name="skip case [REQ-028]" classname="ClsB" assertions="1" time="0.2">
+      <skipped message="no reason" />
+    </testcase>
+  </testsuite>
+</testsuites>`;
+
+const xmlMissing = `<testsuites><testsuite><testcase /></testsuite></testsuites>`;
+
+const xmlExtra = `<testsuites name="X" tests="0" errors="0" failures="0" disabled="0" time="0"><testsuite name="S" tests="0" errors="0" failures="0" skipped="0" disabled="0" hostname="h" id="1" package="p" time="0"><testcase name="t" foo="bar" time="0"/></testsuite></testsuites>`;
+
+test('[REQ-023] parses nested JUnit structures', async () => {
+  const report = await parseJUnit(xml);
+  assert.strictEqual(report.suites.length, 2);
+  assert.strictEqual(report.suites[0].testcases.length, 1);
+});
+
+test('[REQ-024] captures root testsuites attributes', async () => {
+  const report = await parseJUnit(xml);
+  assert.strictEqual(report.attributes.name, 'Root');
+  assert.strictEqual(report.attributes.tests, '2');
+  assert.strictEqual(report.attributes.errors, '1');
+});
+
+test('[REQ-025] captures testsuite attributes', async () => {
+  const report = await parseJUnit(xml);
+  assert.strictEqual(report.suites[0].attributes.hostname, 'hostA');
+  assert.strictEqual(report.suites[1].attributes.skipped, '1');
+});
+
+test('[REQ-026] captures suite properties', async () => {
+  const report = await parseJUnit(xml);
+  assert.strictEqual(report.suites[0].properties['os-version'], 'Ubuntu');
+});
+
+test('[REQ-027] captures testcase attributes and skipped message', async () => {
+  const report = await parseJUnit(xml);
+  const tc = report.suites[1].testcases[0];
+  assert.strictEqual(tc.classname, 'ClsB');
+  assert.strictEqual(tc.skippedMessage, 'no reason');
+});
+
+test('[REQ-028] extracts requirement identifiers', async () => {
+  const report = await parseJUnit(xml);
+  const ids = report.suites.flatMap((s) => s.testcases.flatMap((t) => t.requirements));
+  assert.deepStrictEqual(ids, ['REQ-028', 'REQ-028']);
+});
+
+test('[REQ-029] aggregates status by requirement and suite', async () => {
+  const report = await parseJUnit(xml);
+  const sums = summarize(report);
+  assert.strictEqual(sums.byRequirement['REQ-028'].skipped, 1);
+  assert.strictEqual(sums.bySuite['SuiteA'].passed, 1);
+});
+
+test('[REQ-030] builds traceability matrix with skipped reasons', async () => {
+  const report = await parseJUnit(xml);
+  const matrix = buildTraceability(report);
+  const skipped = matrix.find((m) => m.status === 'Skipped');
+  assert.ok(skipped && skipped.skippedMessage === 'no reason');
+});
+
+test('[REQ-031] validates missing fields', async () => {
+  const report = await parseJUnit(xmlMissing);
+  const warnings = validate(report);
+  assert.ok(warnings.length > 0);
+});
+
+test('[REQ-032] preserves unknown attributes', async () => {
+  const report = await parseJUnit(xmlExtra);
+  assert.strictEqual(report.suites[0].testcases[0].attributes.foo, 'bar');
+});

--- a/scripts/junit-parser.ts
+++ b/scripts/junit-parser.ts
@@ -1,0 +1,136 @@
+import { parseStringPromise } from 'xml2js';
+
+export interface JUnitTestCase {
+  name: string;
+  status: 'Passed' | 'Failed' | 'Skipped';
+  classname?: string;
+  assertions?: string;
+  time: number;
+  skippedMessage?: string;
+  requirements: string[];
+  attributes: Record<string, string>;
+}
+
+export interface JUnitTestSuite {
+  attributes: Record<string, string>;
+  properties: Record<string, string>;
+  testcases: JUnitTestCase[];
+}
+
+export interface JUnitReport {
+  attributes: Record<string, string>;
+  suites: JUnitTestSuite[];
+}
+
+function extractAttributes(obj: any): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  for (const [k, v] of Object.entries(obj ?? {})) {
+    if (typeof v === 'string') attrs[k] = v;
+  }
+  return attrs;
+}
+
+export async function parseJUnit(xml: string): Promise<JUnitReport> {
+  const parsed = await parseStringPromise(xml, { explicitArray: false, mergeAttrs: true });
+  const root = parsed.testsuites ?? parsed.testsuite;
+  const reportAttrs = extractAttributes(root);
+  const rawSuites = root.testsuite
+    ? Array.isArray(root.testsuite)
+      ? root.testsuite
+      : [root.testsuite]
+    : root.testcase
+    ? [root]
+    : [];
+  const suites: JUnitTestSuite[] = rawSuites.map((s: any) => {
+    const suiteAttrs = extractAttributes(s);
+    const props: Record<string, string> = {};
+    const properties = s.properties?.property;
+    const list = Array.isArray(properties) ? properties : properties ? [properties] : [];
+    for (const p of list) {
+      if (p.name && (p.value || p._)) {
+        props[p.name] = p.value ?? p._ ?? '';
+      }
+    }
+    const rawCases = s.testcase ? (Array.isArray(s.testcase) ? s.testcase : [s.testcase]) : [];
+    const testcases: JUnitTestCase[] = rawCases.map((tc: any) => {
+      const tcAttrs = extractAttributes(tc);
+      const name = tc.name ?? 'unknown';
+      const classname = tc.classname;
+      const assertions = tc.assertions;
+      const time = parseFloat(tc.time ?? '0');
+      let status: 'Passed' | 'Failed' | 'Skipped' = 'Passed';
+      if (tc.failure || tc.error) status = 'Failed';
+      else if (tc.skipped) status = 'Skipped';
+      const skippedMessage = tc.skipped?.message ?? tc.skipped?._;
+      const reqMatches = [...name.matchAll(/\[(REQ-\d+)\]/gi)].map((m) => m[1].toUpperCase());
+      const requirements = Array.from(new Set(reqMatches));
+      return { name, status, classname, assertions, time, skippedMessage, requirements, attributes: tcAttrs };
+    });
+    return { attributes: suiteAttrs, properties: props, testcases };
+  });
+  return { attributes: reportAttrs, suites };
+}
+
+export function summarize(report: JUnitReport) {
+  const byRequirement: Record<string, { passed: number; failed: number; skipped: number }> = {};
+  const bySuite: Record<string, { passed: number; failed: number; skipped: number }> = {};
+  for (const suite of report.suites) {
+    const sName = suite.attributes.name || 'unknown';
+    if (!bySuite[sName]) bySuite[sName] = { passed: 0, failed: 0, skipped: 0 };
+    for (const tc of suite.testcases) {
+      if (!bySuite[sName]) bySuite[sName] = { passed: 0, failed: 0, skipped: 0 };
+      bySuite[sName][tc.status.toLowerCase() as 'passed' | 'failed' | 'skipped']++;
+      for (const r of tc.requirements) {
+        if (!byRequirement[r]) byRequirement[r] = { passed: 0, failed: 0, skipped: 0 };
+        byRequirement[r][tc.status.toLowerCase() as 'passed' | 'failed' | 'skipped']++;
+      }
+    }
+  }
+  return { byRequirement, bySuite };
+}
+
+export function buildTraceability(report: JUnitReport) {
+  const rows: {
+    requirement: string;
+    testcase: string;
+    status: string;
+    time: number;
+    host?: string;
+    skippedMessage?: string;
+  }[] = [];
+  for (const suite of report.suites) {
+    const host = suite.properties['machine-name'];
+    for (const tc of suite.testcases) {
+      for (const req of tc.requirements) {
+        rows.push({
+          requirement: req,
+          testcase: tc.name,
+          status: tc.status,
+          time: tc.time,
+          host,
+          skippedMessage: tc.skippedMessage,
+        });
+      }
+    }
+  }
+  return rows;
+}
+
+export function validate(report: JUnitReport) {
+  const warnings: string[] = [];
+  const requiredRoot = ['name', 'tests', 'errors', 'failures', 'disabled', 'time'];
+  for (const f of requiredRoot) {
+    if (!(f in report.attributes)) warnings.push(`missing testsuites attribute: ${f}`);
+  }
+  for (const suite of report.suites) {
+    const reqSuite = ['name', 'tests', 'errors', 'failures', 'hostname', 'id', 'skipped', 'disabled', 'package', 'time'];
+    for (const f of reqSuite) {
+      if (!(f in suite.attributes)) warnings.push(`missing testsuite attribute: ${f}`);
+    }
+    for (const tc of suite.testcases) {
+      if (!tc.name) warnings.push('missing testcase name');
+      if (typeof tc.time !== 'number') warnings.push('missing testcase time');
+    }
+  }
+  return warnings;
+}


### PR DESCRIPTION
## Summary
- document new requirements for parsing JUnit artifacts and add parser utility
- provide tests validating JUnit parsing, aggregation, and traceability features
- update requirements documentation to include new parser requirements

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "Install-Module -Name Pester -Force -Scope AllUsers; if ($env:RUNNER_TYPE -ne 'integration') { Install-Module -Name powershell-yaml -Force -Scope AllUsers }; Invoke-Pester -CI -Path ./tests/pester"`

------
https://chatgpt.com/codex/tasks/task_e_68a135d3623c8329b7cbd8f2f9817cdc