### PR TITLE
Remove test ID column from CI summary

### DIFF
--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -80,7 +80,7 @@ test('collectTestCases uses evidence property and falls back to directory scan',
   await fs.rm(dir, { recursive: true, force: true });
 });
 
-test('groupToMarkdown assigns numeric identifiers', () => {
+test('groupToMarkdown omits numeric identifiers', () => {
   const groups = [{
     id: 'REQ-XYZ',
     tests: [
@@ -89,9 +89,10 @@ test('groupToMarkdown assigns numeric identifiers', () => {
     ],
   }];
   const md = groupToMarkdown(groups);
-  assert.match(md, /\| ID \| Requirement \| Test ID \| Status \|/);
-  assert.match(md, /\| 0 \| REQ-XYZ \| alpha \| Passed \|/);
-  assert.match(md, /\| 1 \| REQ-XYZ \| beta \| Failed \|/);
+  assert.doesNotMatch(md, /\| ID \|/);
+  assert.match(md, /\| Requirement \| Test ID \| Status \| Duration \(s\) \| Owner \| Evidence \|/);
+  assert.match(md, /\| REQ-XYZ \| alpha \| Passed \|/);
+  assert.match(md, /\| REQ-XYZ \| beta \| Failed \|/);
 });
 
 test('buildSummary splits totals by OS', () => {

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -235,19 +235,23 @@ export function requirementsSummaryToMarkdown(groups: RequirementGroup[]) {
 
 export function groupToMarkdown(groups: RequirementGroup[], limit?: number) {
   const lines: string[] = [];
-  let count = 0;
+  let remaining = limit ?? Infinity;
   for (const g of groups) {
     const total = g.tests.length;
     const passedCount = g.tests.filter((t) => t.status === 'Passed').length;
     const pct = total === 0 ? 0 : Math.round((passedCount / total) * 100);
     const header = `${g.id} (${pct}% passed)`;
-    const table = ['| ID | Requirement | Test ID | Status | Duration (s) | Owner | Evidence |',
-      '| --- | --- | --- | --- | --- | --- | --- |'];
+    const table = [
+      '| Requirement | Test ID | Status | Duration (s) | Owner | Evidence |',
+      '| --- | --- | --- | --- | --- | --- |',
+    ];
     for (const t of g.tests) {
-      if (limit && count >= limit) break;
+      if (remaining <= 0) break;
       const evidence = t.evidence ? `[link](${t.evidence})` : '';
-      table.push(`| ${count} | ${g.id} | ${t.name} | ${t.status} | ${t.duration.toFixed(3)} | ${t.owner ?? g.owner ?? ''} | ${evidence} |`);
-      count++;
+      table.push(
+        `| ${g.id} | ${t.name} | ${t.status} | ${t.duration.toFixed(3)} | ${t.owner ?? g.owner ?? ''} | ${evidence} |`,
+      );
+      remaining--;
     }
     const content = table.join('\n');
     if (g.tests.length > 5) {
@@ -255,9 +259,9 @@ export function groupToMarkdown(groups: RequirementGroup[], limit?: number) {
     } else {
       lines.push(`#### ${header}\n\n${content}`);
     }
-    if (limit && count >= limit) break;
+    if (remaining <= 0) break;
   }
-  if (limit && count >= limit) lines.push('\n_Truncated. See traceability.md for full details._');
+  if (limit && remaining <= 0) lines.push('\n_Truncated. See traceability.md for full details._');
   return lines.join('\n\n');
 }
 


### PR DESCRIPTION
## Summary
- drop numeric identifiers and ID column from groupToMarkdown table
- update tests to match new summary output

## Testing
- `npm run check:node` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm test` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `/root/.local/share/mise/installs/go/1.24.3/bin/actionlint`
- `pwsh -NoLogo -Command "Install-Module -Name Pester -Force -Scope AllUsers; if ($env:RUNNER_TYPE -ne 'integration') { Install-Module -Name powershell-yaml -Force -Scope AllUsers }; Invoke-Pester -CI -Path ./tests/pester"` *(terminated: command exceeded time limit)*

------
https://chatgpt.com/codex/tasks/task_e_68a13a8984c48329944079cfe60f2ab3