### PR TITLE
refactor(ci summary): link traceability artifacts

### DIFF
--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -168,12 +168,13 @@ test('partitions requirement groups by runner_type', async () => {
 
   const outDir = path.join('artifacts', 'linux');
   const std = await fs.readFile(path.join(outDir, 'summary-standard.md'), 'utf8');
-  assert.match(std, /REQ-1/);
+  assert.match(std, /traceability-standard.md/);
   const integ = await fs.readFile(path.join(outDir, 'summary-integration.md'), 'utf8');
-  assert.match(integ, /REQ-2/);
-  const traceStdExists = await fs.stat(path.join(outDir, 'traceability-standard.md')).then(() => true, () => false);
-  const traceIntegExists = await fs.stat(path.join(outDir, 'traceability-integration.md')).then(() => true, () => false);
-  assert.strictEqual(traceStdExists && traceIntegExists, true);
+  assert.match(integ, /traceability-integration.md/);
+  const traceStd = await fs.readFile(path.join(outDir, 'traceability-standard.md'), 'utf8');
+  assert.match(traceStd, /REQ-1/);
+  const traceInteg = await fs.readFile(path.join(outDir, 'traceability-integration.md'), 'utf8');
+  assert.match(traceInteg, /REQ-2/);
 
   await fs.rm(dir, { recursive: true, force: true });
   await fs.rm('artifacts', { recursive: true, force: true });

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -396,11 +396,15 @@ async function main() {
   for (const [type, list] of Object.entries(partitions)) {
     const partTotals = buildSummary(list);
     const partSummary = summaryToMarkdown(partTotals);
-    const partMatrix = groupToMarkdown(list);
-    await fs.writeFile(path.join(outDir, `summary-${type}.md`), redact(`${partSummary}\n\n${partMatrix}`));
+    await fs.writeFile(
+      path.join(outDir, `summary-${type}.md`),
+      redact(
+        `${partSummary}\n\n_For detailed per-test information, see [traceability-${type}.md](traceability-${type}.md)._`,
+      ),
+    );
     await fs.writeFile(
       path.join(outDir, `traceability-${type}.md`),
-      redact(`### Test Traceability Matrix\n\n${partMatrix}`),
+      redact(`### Test Traceability Matrix\n\n${groupToMarkdown(list)}`),
     );
   }
 


### PR DESCRIPTION
## Summary
- stop inlining partition traceability matrices into `summary-*.md`
- test partition summaries for traceability links

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "Install-Module -Name Pester -Force -Scope AllUsers; if ($env:RUNNER_TYPE -ne 'integration') { Install-Module -Name powershell-yaml -Force -Scope AllUsers }; Invoke-Pester -CI -Path ./tests/pester"`

------
https://chatgpt.com/codex/tasks/task_e_68a13cb80b948329aa70b94e828c3f8e