### PR TITLE
Add Pester traceability reporting script

### DIFF
--- a/scripts/print-pester-traceability.ts
+++ b/scripts/print-pester-traceability.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env tsx
+import path from 'path';
+import { glob } from 'glob';
+import { collectTestCases } from './generate-ci-summary.ts';
+
+async function main() {
+  const junitFiles = await glob('downloaded/pester-junit-*/pester-junit.xml');
+  const tests = [];
+  for (const file of junitFiles) {
+    const dir = path.dirname(file);
+    const ts = await collectTestCases([file], dir, process.env.RUNNER_OS);
+    tests.push(...ts);
+  }
+  const groups: Map<string, typeof tests> = new Map();
+  for (const t of tests) {
+    const owner = t.owner || 'Unassigned';
+    if (!groups.has(owner)) groups.set(owner, []);
+    groups.get(owner)!.push(t);
+  }
+  const lines: string[] = [];
+  const sortedOwners = Array.from(groups.keys()).sort();
+  for (const owner of sortedOwners) {
+    const tlist = groups.get(owner)!;
+    const table = ['| Test | Requirements | Status | Evidence |', '| --- | --- | --- | --- |'];
+    for (const t of tlist) {
+      const reqs = t.requirements.join(', ');
+      const evidence = t.evidence ? `[link](${t.evidence})` : '';
+      table.push(`| ${t.name} | ${reqs} | ${t.status} | ${evidence} |`);
+    }
+    const content = table.join('\n');
+    lines.push(`<details><summary>${owner}</summary>\n\n${content}\n\n</details>`);
+  }
+  console.log(lines.join('\n\n'));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `print-pester-traceability.ts` to summarize Pester JUnit results by owner

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "Install-Module -Name Pester -Force -Scope AllUsers; if (\$env:RUNNER_TYPE -ne 'integration') { Install-Module -Name powershell-yaml -Force -Scope AllUsers }; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a1405afe248329a5f1ad39a3f00580