### PR TITLE
Use script to print Pester traceability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,10 +143,7 @@ jobs:
           REQ_MAPPING_FILE: requirements.json
           DISPATCHER_REGISTRY: dispatchers.json
           EVIDENCE_DIR: test-screenshots
-      - name: Print test traceability matrix
-        run: |
-          cat "artifacts/${RUNNER_OS,,}/traceability.md" >> "$GITHUB_STEP_SUMMARY"
-          cat "artifacts/${RUNNER_OS,,}/traceability.md"
+      - run: node scripts/print-pester-traceability.ts >> "$GITHUB_STEP_SUMMARY"
       - name: Include setup information
         run: |
           echo '## ubuntu-24.04' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- generate Pester traceability summary directly with `scripts/print-pester-traceability.ts`

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a142bac48483299569846fea73879c