### PR TITLE
test: cover pester traceability output

### DIFF
--- a/scripts/__tests__/fixtures/downloaded/pester-junit-sample/pester-junit.xml
+++ b/scripts/__tests__/fixtures/downloaded/pester-junit-sample/pester-junit.xml
@@ -1,0 +1,17 @@
+<testsuite>
+  <testcase name="[REQ-123][Owner:alice] Alpha" time="0">
+    <properties>
+      <property name="evidence" value="http://example.com/alpha.log"/>
+    </properties>
+  </testcase>
+  <testcase name="[REQ-456][Owner:bob] Beta" time="0">
+    <properties>
+      <property name="evidence" value="http://example.com/beta.log"/>
+    </properties>
+  </testcase>
+  <testcase name="[REQ-789][Owner:alice] Gamma" time="0">
+    <properties>
+      <property name="evidence" value="http://example.com/gamma.log"/>
+    </properties>
+  </testcase>
+</testsuite>

--- a/scripts/__tests__/print-pester-traceability.test.js
+++ b/scripts/__tests__/print-pester-traceability.test.js
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import path from 'node:path';
+
+const execFileP = promisify(execFile);
+
+const fixtureDir = fileURLToPath(new URL('./fixtures', import.meta.url));
+const rootDir = fileURLToPath(new URL('../..', import.meta.url));
+
+test('groups owners and includes requirements and evidence', async () => {
+  const env = { ...process.env, RUNNER_OS: 'Linux' };
+  const tsxPath = path.join(rootDir, 'node_modules/.bin/tsx');
+  const scriptPath = '../../print-pester-traceability.ts';
+  const { stdout } = await execFileP(tsxPath, [scriptPath], { cwd: fixtureDir, env });
+
+  // ensure details sections for each owner
+  assert.match(stdout, /<details><summary>alice<\/summary>/);
+  assert.match(stdout, /<details><summary>bob<\/summary>/);
+
+  // owners grouped correctly
+  const aliceSection = stdout.match(/<details><summary>alice<\/summary>[\s\S]*?<\/details>/)[0];
+  const bobSection = stdout.match(/<details><summary>bob<\/summary>[\s\S]*?<\/details>/)[0];
+  assert(aliceSection.includes('Alpha') && aliceSection.includes('Gamma'));
+  assert(!aliceSection.includes('Beta'));
+  assert(bobSection.includes('Beta'));
+  assert(!bobSection.includes('Alpha') && !bobSection.includes('Gamma'));
+
+  // requirement IDs and evidence links
+  assert.match(aliceSection, /Alpha \| REQ-123 \| Passed \| \[link\]\(http:\/\/example.com\/alpha.log\)/);
+  assert.match(aliceSection, /Gamma \| REQ-789 \| Passed \| \[link\]\(http:\/\/example.com\/gamma.log\)/);
+  assert.match(bobSection, /Beta \| REQ-456 \| Passed \| \[link\]\(http:\/\/example.com\/beta.log\)/);
+});


### PR DESCRIPTION
## Summary
- test grouping of owners, requirement IDs, and evidence in Pester traceability output

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "Install-Module -Name Pester -Force -Scope AllUsers; if (\$env:RUNNER_TYPE -ne 'integration') { Install-Module -Name powershell-yaml -Force -Scope AllUsers }; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a14530a96483299eda597215bdee97