### PR TITLE
chore: fix error handler import

### DIFF
--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -6,7 +6,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import { glob } from 'glob';
 import { parseStringPromise } from 'xml2js';
 import yaml from 'js-yaml';
-import { writeErrorSummary } from './error-handler';
+import { writeErrorSummary } from './error-handler.ts';
 
 interface TestCase {
   id: string;


### PR DESCRIPTION
## Summary
- fix incorrect error-handler import path in generate-ci-summary

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command 'Install-Module -Name Pester -Force -Scope AllUsers; if ($env:RUNNER_TYPE -ne "integration") { Install-Module -Name powershell-yaml -Force -Scope AllUsers }; Invoke-Pester -CI -Path ./tests/pester'`
- `npm run generate:summary`


------
https://chatgpt.com/codex/tasks/task_e_68a149f816b4832986c3a9d27b093662