### PR TITLE
Tag Pester tests with requirement IDs and parse from JUnit properties

### DIFF
--- a/scripts/__tests__/fixtures/downloaded/pester-junit-sample/pester-junit.xml
+++ b/scripts/__tests__/fixtures/downloaded/pester-junit-sample/pester-junit.xml
@@ -1,17 +1,20 @@
 <testsuite>
-  <testcase name="[REQ-123][Owner:alice] Alpha" time="0">
+  <testcase name="[Owner:alice] Alpha" time="0">
     <properties>
       <property name="evidence" value="http://example.com/alpha.log"/>
+      <property name="requirement" value="REQ-123"/>
     </properties>
   </testcase>
-  <testcase name="[REQ-456][Owner:bob] Beta" time="0">
+  <testcase name="[Owner:bob] Beta" time="0">
     <properties>
       <property name="evidence" value="http://example.com/beta.log"/>
+      <property name="requirement" value="REQ-456"/>
     </properties>
   </testcase>
-  <testcase name="[REQ-789][Owner:alice] Gamma" time="0">
+  <testcase name="[Owner:alice] Gamma" time="0">
     <properties>
       <property name="evidence" value="http://example.com/gamma.log"/>
+      <property name="requirement" value="REQ-789"/>
     </properties>
   </testcase>
 </testsuite>

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -103,6 +103,12 @@ export async function collectTestCases(files: string[], evidenceDir: string, os?
             );
             const evidenceVal = evidenceProp?.value?.[0] ?? evidenceProp?._;
             if (evidenceVal) test.evidence = evidenceVal;
+            for (const p of props) {
+              if (p.name?.[0] === 'requirement') {
+                const val = p.value?.[0] ?? p._;
+                if (typeof val === 'string') test.requirements.push(val.toUpperCase());
+              }
+            }
           }
           if (!test.evidence) {
             const evidence = evidenceFiles.find((f) => f.startsWith(id) || f.startsWith(id + '.'));
@@ -112,9 +118,6 @@ export async function collectTestCases(files: string[], evidenceDir: string, os?
             const ownerMatch = name.match(/\[Owner:([^\]]+)\]/i);
             if (ownerMatch) test.owner = ownerMatch[1];
           }
-          const reqMatches = [...name.matchAll(/\[(REQ-\d+)\]/gi)].map((m) => m[1].toUpperCase());
-          const uniqueReqMatches = new Set(reqMatches);
-          if (uniqueReqMatches.size) test.requirements.push(...uniqueReqMatches);
           tests.push(test);
         }
       }

--- a/scripts/run-pester-tests/RunPesterTests.ps1
+++ b/scripts/run-pester-tests/RunPesterTests.ps1
@@ -17,6 +17,30 @@ $pesterDir = Join-Path $repoRoot 'tests' 'pester'
 
 # Run Pester and capture results
 $pesterResult = Invoke-Pester -Path $pesterDir -PassThru
+
+# Export JUnit report with requirement properties derived from tags
+$junitPath = Join-Path $repoRoot 'pester-junit.xml'
+$pesterResult | Export-JUnitReport -Path $junitPath
+[xml]$junitXml = Get-Content -Path $junitPath
+foreach ($t in $pesterResult.Tests) {
+    $name = ($t.Path -join '.')
+    $case = $junitXml.SelectSingleNode("//testcase[@name='${name}']")
+    if (-not $case) { continue }
+    foreach ($tag in @($t.Tag)) {
+        if ($tag -match '^REQ-\d+$') {
+            $props = $case.SelectSingleNode('properties')
+            if (-not $props) {
+                $props = $junitXml.CreateElement('properties')
+                $null = $case.AppendChild($props)
+            }
+            $prop = $junitXml.CreateElement('property')
+            $prop.SetAttribute('name', 'requirement')
+            $prop.SetAttribute('value', $tag.ToUpper())
+            $null = $props.AppendChild($prop)
+        }
+    }
+}
+$junitXml.Save($junitPath)
 $tests = $null
 if ($pesterResult.PSObject.Properties['TestResult']) {
     $tests = $pesterResult.TestResult

--- a/tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1
@@ -12,8 +12,8 @@ if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
     }
 }
 
-Describe 'AddTokenToLabview.SelfHosted.Workflow [REQ-008]' {
-    It 'runs add-token-to-labview action on a self-hosted runner and uploads token artifact [REQ-008]' {
+Describe 'AddTokenToLabview.SelfHosted.Workflow' {
+    It 'runs add-token-to-labview action on a self-hosted runner and uploads token artifact' -Tag 'REQ-008' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfDir = Join-Path $repoRoot '.github/workflows'
         $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'

--- a/tests/pester/ApplyVipc.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/ApplyVipc.SelfHosted.Workflow.Tests.ps1
@@ -12,8 +12,8 @@ if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
     }
 }
 
-Describe 'ApplyVipc.SelfHosted.DryRunTrue.Workflow [REQ-006]' {
-    It 'runs apply-vipc action with dry_run true [REQ-006]' {
+Describe 'ApplyVipc.SelfHosted.DryRunTrue.Workflow' {
+    It 'runs apply-vipc action with dry_run true' -Tag 'REQ-006' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/apply-vipc-self-hosted.yml'
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml
@@ -37,8 +37,8 @@ Describe 'ApplyVipc.SelfHosted.DryRunTrue.Workflow [REQ-006]' {
     }
 }
 
-Describe 'ApplyVipc.SelfHosted.DryRunFalse.Workflow [REQ-007]' {
-    It 'runs apply-vipc action with dry_run false [REQ-007]' {
+Describe 'ApplyVipc.SelfHosted.DryRunFalse.Workflow' {
+    It 'runs apply-vipc action with dry_run false' -Tag 'REQ-007' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/apply-vipc-self-hosted.yml'
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml

--- a/tests/pester/Build.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/Build.SelfHosted.Workflow.Tests.ps1
@@ -12,8 +12,8 @@ if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
     }
 }
 
-Describe 'Build.SelfHosted.Workflow [REQ-009]' {
-    It 'runs build action with required inputs [REQ-009]' {
+Describe 'Build.SelfHosted.Workflow' {
+    It 'runs build action with required inputs' -Tag 'REQ-009' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/build-self-hosted.yml'
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml

--- a/tests/pester/BuildLvlibp.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/BuildLvlibp.SelfHosted.Workflow.Tests.ps1
@@ -12,8 +12,8 @@ if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
     }
 }
 
-Describe 'BuildLvlibp.SelfHosted.Workflow [REQ-010]' {
-    It 'runs build-lvlibp action and uploads lvlibp artifact [REQ-010]' {
+Describe 'BuildLvlibp.SelfHosted.Workflow' {
+    It 'runs build-lvlibp action and uploads lvlibp artifact' -Tag 'REQ-010' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/build-lvlibp-self-hosted.yml'
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml

--- a/tests/pester/BuildViPackage.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/BuildViPackage.SelfHosted.Workflow.Tests.ps1
@@ -12,8 +12,8 @@ if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
     }
 }
 
-Describe 'BuildViPackage.SelfHosted.Workflow [REQ-011]' {
-    It 'runs build-vi-package action and uploads vi package artifact [REQ-011]' {
+Describe 'BuildViPackage.SelfHosted.Workflow' {
+    It 'runs build-vi-package action and uploads vi package artifact' -Tag 'REQ-011' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/build-vi-package-self-hosted.yml'
         if (-not (Test-Path $workflowPath)) {

--- a/tests/pester/CloseLabview.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/CloseLabview.SelfHosted.Workflow.Tests.ps1
@@ -12,8 +12,8 @@ if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
     }
 }
 
-Describe 'CloseLabview.SelfHosted.Workflow [REQ-012]' {
-    It 'runs close-labview action for 32-bit and 64-bit and uploads logs [REQ-012]' {
+Describe 'CloseLabview.SelfHosted.Workflow' {
+    It 'runs close-labview action for 32-bit and 64-bit and uploads logs' -Tag 'REQ-012' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfFile = Join-Path $repoRoot '.github/workflows/close-labview-external.yml'
 

--- a/tests/pester/Dispatcher.DryRun.Tests.ps1
+++ b/tests/pester/Dispatcher.DryRun.Tests.ps1
@@ -10,7 +10,7 @@ $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
 $global:dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
 Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
 
-Describe 'Unified Dispatcher — DryRun behavior for all actions [REQ-002]' {
+Describe 'Unified Dispatcher — DryRun behavior for all actions' {
   $script:args = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
   $extra = @{
        VIP_LVVersion             = '2021'
@@ -42,14 +42,14 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions [REQ-002]' {
     Where-Object { $_ -match '^\s+- ' } |
     ForEach-Object { @{ Action = $_.Trim().Substring(2); ArgsJson = $script:argsJson } }
 
-  It "describes <Action> [REQ-002]" -ForEach $actions {
+  It "describes <Action>" -Tag 'REQ-002' -ForEach $actions {
     param($Action, $ArgsJson)
     Write-Host "Testing $Action with ArgsJson $ArgsJson"
     pwsh -NoProfile -File $global:dispatcher -Describe $Action -ArgsJson $ArgsJson *> $null
     $LASTEXITCODE | Should -Be 0
   }
 
-  It "prints description before dry-run <Action> [REQ-002]" -ForEach $actions {
+  It "prints description before dry-run <Action>" -Tag 'REQ-002' -ForEach $actions {
     param($Action, $ArgsJson)
     Write-Host "Testing $Action with ArgsJson $ArgsJson"
     $describeOut = & $global:dispatcher -Describe $Action -ArgsJson $ArgsJson 6>&1 | Out-String
@@ -58,7 +58,7 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions [REQ-002]' {
     $describeOut | Should -Match "$Action parameters:"
   }
 
-  It "dry-runs <Action> and warns on unknown args [REQ-002]" -ForEach $actions {
+  It "dry-runs <Action> and warns on unknown args" -Tag 'REQ-002' -ForEach $actions {
     param($Action, $ArgsJson)
     Write-Host "Testing $Action with ArgsJson $ArgsJson"
     $out = & $global:dispatcher -ActionName $Action -ArgsJson $ArgsJson -DryRun *>&1 | Out-String

--- a/tests/pester/Dispatcher.InvalidPaths.Tests.ps1
+++ b/tests/pester/Dispatcher.InvalidPaths.Tests.ps1
@@ -9,15 +9,15 @@ $repoRoot   = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
 $global:dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
 Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
 
-Describe 'Invalid RelativePath handling [REQ-005]' {
-    It 'fails when RelativePath does not exist [REQ-005]' {
+Describe 'Invalid RelativePath handling' {
+    It 'fails when RelativePath does not exist' -Tag 'REQ-005' {
         $json = @{ RelativePath = 'NoSuchDir' } | ConvertTo-Json -Compress
         $out = pwsh -NonInteractive -NoProfile -File $global:dispatcher -ActionName set-development-mode -ArgsJson $json *>&1 | Out-String
         $LASTEXITCODE | Should -Not -Be 0
         $out | Should -Match 'An unexpected error occurred during script execution'
     }
 
-    It 'fails when RelativePath is missing [REQ-005]' {
+    It 'fails when RelativePath is missing' -Tag 'REQ-005' {
         $out = pwsh -NonInteractive -NoProfile -File $global:dispatcher -ActionName set-development-mode -ArgsJson '{}' *>&1 | Out-String
         $LASTEXITCODE | Should -Not -Be 0
         $out | Should -Match 'missing mandatory'

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -11,8 +11,8 @@ $global:dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
 Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
 
 
-Describe 'Unified Dispatcher — discovery and validation [REQ-001]' {
-  It 'lists available actions [REQ-001]' {
+Describe 'Unified Dispatcher — discovery and validation' {
+  It 'lists available actions' -Tag 'REQ-001' {
     $json = Get-LabVIEWIconEditorArgsJson
     $out = pwsh -NoProfile -File $global:dispatcher -ListActions -ArgsJson $json | Out-String
     $out | Should -Match 'apply-vipc'
@@ -20,7 +20,7 @@ Describe 'Unified Dispatcher — discovery and validation [REQ-001]' {
     $out | Should -Match 'missing-in-project'
     $out | Should -Match 'run-unit-tests'
   }
-  It 'describes a known action (build-lvlibp) [REQ-001]' {
+  It 'describes a known action (build-lvlibp)' -Tag 'REQ-001' {
     $json = Get-LabVIEWIconEditorArgsJson
     $out = pwsh -NoProfile -File $global:dispatcher -Describe build-lvlibp -ArgsJson $json | Out-String
     $out | Should -Match 'Major'
@@ -30,23 +30,23 @@ Describe 'Unified Dispatcher — discovery and validation [REQ-001]' {
     $out | Should -Match 'Commit'
   }
 
-  It 'fails gracefully on unknown action [REQ-001]' {
+  It 'fails gracefully on unknown action' -Tag 'REQ-001' {
     $json = Get-LabVIEWIconEditorArgsJson
     pwsh -NoProfile -File $global:dispatcher -ActionName no-such-action -ArgsJson $json *>$null
     $LASTEXITCODE | Should -Be 1
   }
 }
 
-Describe 'ArgsJson path handling [REQ-001]' {
-  It 'handles Windows paths without manual escaping [REQ-001]' {
+Describe 'ArgsJson path handling' {
+  It 'handles Windows paths without manual escaping' -Tag 'REQ-001' {
     $json = Get-LabVIEWIconEditorArgsJson
     & $global:dispatcher -ActionName set-development-mode -ArgsJson $json -DryRun *> $null
     $LASTEXITCODE | Should -Be 0
   }
 }
 
-Describe 'ArgsFile handling [REQ-001]' {
-  It 'merges file arguments with inline overrides [REQ-001]' {
+Describe 'ArgsFile handling' {
+  It 'merges file arguments with inline overrides' -Tag 'REQ-001' {
     $jsonFile = Join-Path $TestDrive 'args.json'
     @{ MinimumSupportedLVVersion = '2021'; SupportedBitness = '32' } | ConvertTo-Json -Compress | Set-Content -Path $jsonFile
 
@@ -59,8 +59,8 @@ Describe 'ArgsFile handling [REQ-001]' {
 }
 
 
-Describe 'Filter-Args helper [REQ-001]' {
-  It 'returns UnknownParams when requested [REQ-001]' {
+Describe 'Filter-Args helper' {
+  It 'returns UnknownParams when requested' -Tag 'REQ-001' {
     $ast = [System.Management.Automation.Language.Parser]::ParseFile($global:dispatcher, [ref]$null, [ref]$null)
     $funcAst = $ast.Find({ param($a) $a -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $a.Name -eq 'Filter-Args' }, $true)
     Invoke-Expression $funcAst.Extent.Text
@@ -72,8 +72,8 @@ Describe 'Filter-Args helper [REQ-001]' {
   }
 }
 
-  Describe 'close-labview parameter aliases [REQ-001]' {
-    It 'accepts camelCase args [REQ-001]' {
+  Describe 'close-labview parameter aliases' {
+    It 'accepts camelCase args' -Tag 'REQ-001' {
       $base = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
       $json = @{
         MinimumSupportedLVVersion = $base.MinimumSupportedLVVersion
@@ -83,7 +83,7 @@ Describe 'Filter-Args helper [REQ-001]' {
       $LASTEXITCODE | Should -Be 0
     }
 
-    It 'accepts snake_case args without warnings [REQ-001]' {
+    It 'accepts snake_case args without warnings' -Tag 'REQ-001' {
       $base = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
       $json = @{
         minimum_supported_lv_version = $base.MinimumSupportedLVVersion

--- a/tests/pester/MissingInProject.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/MissingInProject.SelfHosted.Workflow.Tests.ps1
@@ -12,8 +12,8 @@ if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
     }
 }
 
-Describe 'MissingInProject.SelfHosted.Workflow [REQ-014]' {
-    It 'runs missing-in-project action on a self-hosted runner and uploads findings report [REQ-014]' {
+Describe 'MissingInProject.SelfHosted.Workflow' {
+    It 'runs missing-in-project action on a self-hosted runner and uploads findings report' -Tag 'REQ-014' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfDir = Join-Path $repoRoot '.github/workflows'
         $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'

--- a/tests/pester/ModifyVipbDisplayInfo.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/ModifyVipbDisplayInfo.SelfHosted.Workflow.Tests.ps1
@@ -12,8 +12,8 @@ if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
     }
 }
 
-Describe 'ModifyVipbDisplayInfo.SelfHosted.Workflow [REQ-015]' {
-    It 'runs modify-vipb-display-info action on a self-hosted runner and uploads VIPB artifact [REQ-015]' {
+Describe 'ModifyVipbDisplayInfo.SelfHosted.Workflow' {
+    It 'runs modify-vipb-display-info action on a self-hosted runner and uploads VIPB artifact' -Tag 'REQ-015' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfDir = Join-Path $repoRoot '.github/workflows'
         $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'

--- a/tests/pester/PrepareLabviewSource.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/PrepareLabviewSource.SelfHosted.Workflow.Tests.ps1
@@ -12,8 +12,8 @@ if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
     }
 }
 
-Describe 'PrepareLabviewSource.SelfHosted.Workflow [REQ-011]' {
-    It 'runs prepare-labview-source action and uploads prepared source artifact [REQ-011]' {
+Describe 'PrepareLabviewSource.SelfHosted.Workflow' {
+    It 'runs prepare-labview-source action and uploads prepared source artifact' -Tag 'REQ-011' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfDir = Join-Path $repoRoot '.github/workflows'
         $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'

--- a/tests/pester/RelativePath.Actions.Tests.ps1
+++ b/tests/pester/RelativePath.Actions.Tests.ps1
@@ -9,8 +9,8 @@ $repoRoot   = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
 $dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
 Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
 
-Describe 'add-token-to-labview resolves RelativePath [REQ-003]' {
-    It 'dry-runs without warnings [REQ-003]' {
+Describe 'add-token-to-labview resolves RelativePath' {
+    It 'dry-runs without warnings' -Tag 'REQ-003' {
         $json = Get-LabVIEWIconEditorArgsJson
         $expected = ($json | ConvertFrom-Json).RelativePath
         $out = & $dispatcher -ActionName add-token-to-labview -ArgsJson $json -DryRun *>&1 | Out-String
@@ -22,8 +22,8 @@ Describe 'add-token-to-labview resolves RelativePath [REQ-003]' {
     }
 }
 
-Describe 'apply-vipc resolves RelativePath [REQ-003]' {
-    It 'dry-runs without warnings [REQ-003]' {
+Describe 'apply-vipc resolves RelativePath' {
+    It 'dry-runs without warnings' -Tag 'REQ-003' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ MinimumSupportedLVVersion = $b.MinimumSupportedLVVersion; SupportedBitness = $b.SupportedBitness; RelativePath = $b.RelativePath; VIP_LVVersion = '2021'; VIPCPath = 'dummy.vipc' } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName apply-vipc -ArgsJson $args -DryRun *>&1 | Out-String
@@ -35,8 +35,8 @@ Describe 'apply-vipc resolves RelativePath [REQ-003]' {
     }
 }
 
-Describe 'build-vi-package resolves RelativePath [REQ-003]' {
-    It 'dry-runs without warnings [REQ-003]' {
+Describe 'build-vi-package resolves RelativePath' {
+    It 'dry-runs without warnings' -Tag 'REQ-003' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ MinimumSupportedLVVersion=$b.MinimumSupportedLVVersion; SupportedBitness=$b.SupportedBitness; LabVIEWMinorRevision='2021'; RelativePath=$b.RelativePath; VIPBPath='dummy.vipb'; Major=1; Minor=0; Patch=0; Build=1; Commit='deadbeef'; DisplayInformationJSON='{}'; ReleaseNotesFile='notes.md' } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName build-vi-package -ArgsJson $args -DryRun *>&1 | Out-String
@@ -48,8 +48,8 @@ Describe 'build-vi-package resolves RelativePath [REQ-003]' {
     }
 }
 
-Describe 'build resolves RelativePath [REQ-003]' {
-    It 'dry-runs without warnings [REQ-003]' {
+Describe 'build resolves RelativePath' {
+    It 'dry-runs without warnings' -Tag 'REQ-003' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ RelativePath=$b.RelativePath; Major=1; Minor=0; Patch=0; Build=1; Commit='deadbeef'; LabVIEWMinorRevision='2021'; CompanyName='Company'; AuthorName='Author' } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName build -ArgsJson $args -DryRun *>&1 | Out-String
@@ -61,8 +61,8 @@ Describe 'build resolves RelativePath [REQ-003]' {
     }
 }
 
-Describe 'build-lvlibp resolves RelativePath [REQ-003]' {
-    It 'dry-runs without warnings [REQ-003]' {
+Describe 'build-lvlibp resolves RelativePath' {
+    It 'dry-runs without warnings' -Tag 'REQ-003' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ MinimumSupportedLVVersion=$b.MinimumSupportedLVVersion; SupportedBitness=$b.SupportedBitness; RelativePath=$b.RelativePath; LabVIEW_Project='My.lvproj'; Build_Spec='MyBuild'; Major=1; Minor=0; Patch=0; Build=1; Commit='deadbeef' } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName build-lvlibp -ArgsJson $args -DryRun *>&1 | Out-String
@@ -74,8 +74,8 @@ Describe 'build-lvlibp resolves RelativePath [REQ-003]' {
     }
 }
 
-Describe 'modify-vipb-display-info resolves RelativePath [REQ-003]' {
-    It 'dry-runs without warnings [REQ-003]' {
+Describe 'modify-vipb-display-info resolves RelativePath' {
+    It 'dry-runs without warnings' -Tag 'REQ-003' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ SupportedBitness=$b.SupportedBitness; RelativePath=$b.RelativePath; VIPBPath='dummy.vipb'; MinimumSupportedLVVersion=$b.MinimumSupportedLVVersion; LabVIEWMinorRevision='2021'; Major=1; Minor=0; Patch=0; Build=1; Commit='deadbeef'; DisplayInformationJSON='{}'; ReleaseNotesFile='notes.md' } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName modify-vipb-display-info -ArgsJson $args -DryRun *>&1 | Out-String
@@ -87,8 +87,8 @@ Describe 'modify-vipb-display-info resolves RelativePath [REQ-003]' {
     }
 }
 
-Describe 'prepare-labview-source resolves RelativePath [REQ-003]' {
-    It 'dry-runs without warnings [REQ-003]' {
+Describe 'prepare-labview-source resolves RelativePath' {
+    It 'dry-runs without warnings' -Tag 'REQ-003' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ MinimumSupportedLVVersion=$b.MinimumSupportedLVVersion; SupportedBitness=$b.SupportedBitness; RelativePath=$b.RelativePath; LabVIEW_Project='My.lvproj'; Build_Spec='MyBuild' } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName prepare-labview-source -ArgsJson $args -DryRun *>&1 | Out-String
@@ -100,8 +100,8 @@ Describe 'prepare-labview-source resolves RelativePath [REQ-003]' {
     }
 }
 
-Describe 'restore-setup-lv-source resolves RelativePath [REQ-003]' {
-    It 'dry-runs without warnings [REQ-003]' {
+Describe 'restore-setup-lv-source resolves RelativePath' {
+    It 'dry-runs without warnings' -Tag 'REQ-003' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ MinimumSupportedLVVersion=$b.MinimumSupportedLVVersion; SupportedBitness=$b.SupportedBitness; RelativePath=$b.RelativePath; LabVIEW_Project='My.lvproj'; Build_Spec='MyBuild' } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName restore-setup-lv-source -ArgsJson $args -DryRun *>&1 | Out-String
@@ -113,8 +113,8 @@ Describe 'restore-setup-lv-source resolves RelativePath [REQ-003]' {
     }
 }
 
-Describe 'revert-development-mode resolves RelativePath [REQ-003]' {
-    It 'dry-runs without warnings [REQ-003]' {
+Describe 'revert-development-mode resolves RelativePath' {
+    It 'dry-runs without warnings' -Tag 'REQ-003' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ RelativePath=$b.RelativePath } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName revert-development-mode -ArgsJson $args -DryRun *>&1 | Out-String
@@ -126,8 +126,8 @@ Describe 'revert-development-mode resolves RelativePath [REQ-003]' {
     }
 }
 
-Describe 'set-development-mode resolves RelativePath [REQ-003]' {
-    It 'dry-runs without warnings [REQ-003]' {
+Describe 'set-development-mode resolves RelativePath' {
+    It 'dry-runs without warnings' -Tag 'REQ-003' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ RelativePath=$b.RelativePath } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName set-development-mode -ArgsJson $args -DryRun *>&1 | Out-String

--- a/tests/pester/RenameFile.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RenameFile.SelfHosted.Workflow.Tests.ps1
@@ -12,8 +12,8 @@ if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
     }
 }
 
-Describe 'RenameFile.SelfHosted.Workflow [REQ-011]' {
-    It 'runs rename-file action on a self-hosted runner and uploads renamed file artifact [REQ-011]' {
+Describe 'RenameFile.SelfHosted.Workflow' {
+    It 'runs rename-file action on a self-hosted runner and uploads renamed file artifact' -Tag 'REQ-011' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfDir = Join-Path $repoRoot '.github/workflows'
         $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'

--- a/tests/pester/RestoreSetupLvSource.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RestoreSetupLvSource.SelfHosted.Workflow.Tests.ps1
@@ -12,8 +12,8 @@ if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
     }
 }
 
-Describe 'RestoreSetupLvSource.SelfHosted.Workflow [REQ-018]' {
-    It 'runs restore-setup-lv-source action on a self-hosted runner and uploads restoration artifacts [REQ-018]' {
+Describe 'RestoreSetupLvSource.SelfHosted.Workflow' {
+    It 'runs restore-setup-lv-source action on a self-hosted runner and uploads restoration artifacts' -Tag 'REQ-018' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfDir = Join-Path $repoRoot '.github/workflows'
         $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'

--- a/tests/pester/RevertDevelopmentMode.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RevertDevelopmentMode.SelfHosted.Workflow.Tests.ps1
@@ -12,8 +12,8 @@ if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
     }
 }
 
-Describe 'RevertDevelopmentMode.SelfHosted.Workflow [REQ-019]' {
-    It 'runs revert-development-mode action on a self-hosted runner and uploads configuration artifact [REQ-019]' {
+Describe 'RevertDevelopmentMode.SelfHosted.Workflow' {
+    It 'runs revert-development-mode action on a self-hosted runner and uploads configuration artifact' -Tag 'REQ-019' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfDir = Join-Path $repoRoot '.github/workflows'
         $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'

--- a/tests/pester/RunUnitTests.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RunUnitTests.SelfHosted.Workflow.Tests.ps1
@@ -12,8 +12,8 @@ if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
     }
 }
 
-Describe 'RunUnitTests.SelfHosted.Workflow [REQ-011]' {
-    It 'runs run-unit-tests action and uploads unit-test results [REQ-011]' {
+Describe 'RunUnitTests.SelfHosted.Workflow' {
+    It 'runs run-unit-tests action and uploads unit-test results' -Tag 'REQ-011' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/run-unit-tests-self-hosted.yml'
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml

--- a/tests/pester/ScriptPath.Tests.ps1
+++ b/tests/pester/ScriptPath.Tests.ps1
@@ -29,8 +29,8 @@ $cases = foreach ($name in $actionNames) {
     }
 }
 
-Describe 'Action script paths [REQ-004]' {
-    It 'has script for <Name> [REQ-004]' -TestCases $cases {
+Describe 'Action script paths' {
+    It 'has script for <Name>' -Tag 'REQ-004' -TestCases $cases {
         param($Name, $Path)
         Test-Path $Path | Should -BeTrue
     }

--- a/tests/pester/SetDevelopmentMode.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/SetDevelopmentMode.SelfHosted.Workflow.Tests.ps1
@@ -12,8 +12,8 @@ if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
     }
 }
 
-Describe 'SetDevelopmentMode.SelfHosted.Workflow [REQ-021]' {
-    It 'runs set-development-mode action on a self-hosted runner and uploads logs [REQ-021]' {
+Describe 'SetDevelopmentMode.SelfHosted.Workflow' {
+    It 'runs set-development-mode action on a self-hosted runner and uploads logs' -Tag 'REQ-021' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfDir = Join-Path $repoRoot '.github/workflows'
         $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'


### PR DESCRIPTION
## Summary
- tag all Pester test cases with their requirement ID
- include requirement properties when exporting Pester JUnit reports
- read requirement IDs from JUnit testcase properties instead of names

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "Install-Module -Name Pester -Force -Scope AllUsers; if ($env:RUNNER_TYPE -ne 'integration') { Install-Module -Name powershell-yaml -Force -Scope AllUsers }; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a151f1a96483299fd487a863129076