### PR TITLE
Add requirement summary markdown report

### DIFF
--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -134,6 +134,11 @@ test('writes outputs to OS-specific directory', async () => {
   assert.strictEqual(exists, true);
   const summary = await fs.readFile(path.join(outDir, 'summary.md'), 'utf8');
   assert.match(summary, /\| windows \| 1 \| 0 \| 0 \|/);
+  const reqSummary = await fs.readFile(path.join(outDir, 'requirements-summary.md'), 'utf8');
+  assert.match(reqSummary, /### Requirement Summary/);
+  assert.match(reqSummary, /Unmapped/);
+  assert.match(reqSummary, /### Requirement Testcases/);
+  assert.match(reqSummary, /\| Unmapped \| foo \| Passed \|/);
 
   await fs.rm(tmp, { recursive: true, force: true });
   await fs.rm('artifacts', { recursive: true, force: true });

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -236,6 +236,20 @@ export function requirementsSummaryToMarkdown(groups: RequirementGroup[]) {
   return lines.join('\n');
 }
 
+export function requirementTestsToMarkdown(groups: RequirementGroup[]) {
+  const lines = [
+    '### Requirement Testcases',
+    '| Requirement ID | Test ID | Status |',
+    '| --- | --- | --- |',
+  ];
+  for (const g of groups) {
+    for (const t of g.tests) {
+      lines.push(`| ${g.id} | ${t.name} | ${t.status} |`);
+    }
+  }
+  return lines.join('\n');
+}
+
 export function groupToMarkdown(groups: RequirementGroup[], limit?: number) {
   const lines: string[] = [];
   let remaining = limit ?? Infinity;
@@ -376,6 +390,7 @@ async function main() {
   const matrixMd = groupToMarkdown(groups);
   const summaryMd = summaryToMarkdown(totals);
   const requirementsMd = requirementsSummaryToMarkdown(groups);
+  const requirementsTestsMd = requirementTestsToMarkdown(groups);
 
   const wrapperFiles = await glob('*/action.yml', { nodir: true });
   const wrapperDirs = wrapperFiles.map(f => path.dirname(f)).sort();
@@ -386,6 +401,8 @@ async function main() {
   await fs.writeFile(path.join(outDir, 'traceability.md'), redact(`### Test Traceability Matrix\n\n${matrixMd}`));
   const combinedSummary = `${summaryMd}\n\n${requirementsMd}\n\n_For detailed per-test information, see [traceability.md](traceability.md)._`;
   await fs.writeFile(path.join(outDir, 'summary.md'), redact(combinedSummary));
+  const reqSummary = `${requirementsMd}\n\n${requirementsTestsMd}`;
+  await fs.writeFile(path.join(outDir, 'requirements-summary.md'), redact(reqSummary));
   await fs.writeFile(path.join(outDir, 'action-docs.json'), JSON.stringify(docs, null, 2));
   await fs.writeFile(path.join(outDir, 'action-docs.md'), redact(markdown));
 


### PR DESCRIPTION
## Summary
- generate requirements-summary.md detailing per-requirement pass/fail/skip counts
- list each requirement's test cases with their final status

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "Install-Module -Name Pester -Force -Scope AllUsers; if ($env:RUNNER_TYPE -ne 'integration') { Install-Module -Name powershell-yaml -Force -Scope AllUsers }; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a1567ae448832993ed9bb2283faa72