### PR TITLE
Use TestMetadata in AddTokenToLabview Pester test

### DIFF
--- a/tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1
@@ -13,8 +13,15 @@ if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
 }
 
 Describe 'AddTokenToLabview.SelfHosted.Workflow' {
-    BeforeEach { Add-TestResult -Property @{ Owner = "DevTools"; Evidence = "tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1" } }
-    It 'runs add-token-to-labview action on a self-hosted runner and uploads token artifact' -Tag 'REQ-008' {
+    $meta = @{
+        requirement = 'REQ-008'
+        Owner       = 'DevTools'
+        Evidence    = 'tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1'
+    }
+
+    It 'runs add-token-to-labview action on a self-hosted runner and uploads token artifact' \
+        -Tag 'REQ-008' \
+        -TestMetadata $meta {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfDir = Join-Path $repoRoot '.github/workflows'
         $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'


### PR DESCRIPTION
## Summary
- attach requirement, owner, and evidence to AddTokenToLabview test with `-TestMetadata`
- remove dependency on `Add-TestResult`

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "Import-Module Pester; Import-Module powershell-yaml; Invoke-Pester -CI -Path ./tests/pester"` *(fails: The term 'Add-TestResult' is not recognized as a name of a cmdlet)*

------
https://chatgpt.com/codex/tasks/task_e_68a15d4b6bac8329a63e7a2d5db2c6ff