### PR TITLE
Require icon-editor-windows label for AddTokenToLabview test

### DIFF
--- a/tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1
@@ -12,6 +12,11 @@ if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
     }
 }
 
+if (-not ($env:RUNNER_LABELS -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ -eq 'icon-editor-windows' })) {
+    Set-ItResult -Skipped -Because 'requires runner label icon-editor-windows'
+    return
+}
+
 Describe 'AddTokenToLabview.SelfHosted.Workflow' {
     $meta = @{
         requirement = 'REQ-008'


### PR DESCRIPTION
## Summary
- skip AddTokenToLabview self-hosted workflow test unless runner has icon-editor-windows label

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -File run_pester.ps1` *(fails: is skipped, because requires runner label icon-editor-windows)*

------
https://chatgpt.com/codex/tasks/task_e_68a168265b9083298d348eef1ffe268f