### PR TITLE
feat: add Add-TestResult fallback

### DIFF
--- a/tests/pester/Helper/ArgsJson.psm1
+++ b/tests/pester/Helper/ArgsJson.psm1
@@ -25,3 +25,19 @@ function Get-LabVIEWIconEditorArgsJson {
 }
 
 Export-ModuleMember -Function Get-LabVIEWIconEditorArgsJson
+
+if (-not (Get-Command -Name Add-TestResult -ErrorAction SilentlyContinue)) {
+    function Add-TestResult {
+        [CmdletBinding()]
+        param(
+            [hashtable]$Property
+        )
+
+        # Pester versions prior to 5 do not include Add-TestResult.
+        # Provide a no-op implementation so tests can record metadata
+        # without failing when the command is missing.
+        return
+    }
+
+    Export-ModuleMember -Function Add-TestResult -Alias *
+}


### PR DESCRIPTION
## Summary
- add Add-TestResult shim so tests don't fail when command is missing

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "Install-Module -Name Pester -Force -Scope AllUsers; if (\$env:RUNNER_TYPE -ne 'integration') { Install-Module -Name powershell-yaml -Force -Scope AllUsers }; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a173e5ca5c8329a401394d54069466