### PR TITLE
Remove unsupported Pester TestMetadata parameter

### DIFF
--- a/tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1
@@ -24,9 +24,7 @@ Describe 'AddTokenToLabview.SelfHosted.Workflow' {
         Evidence    = 'tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1'
     }
 
-    It 'runs add-token-to-labview action on a self-hosted runner and uploads token artifact' \
-        -Tag 'REQ-008' \
-        -TestMetadata $meta {
+    It 'runs add-token-to-labview action on a self-hosted runner and uploads token artifact' -Tag 'REQ-008' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfDir = Join-Path $repoRoot '.github/workflows'
         $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'

--- a/tests/pester/ApplyVipc.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/ApplyVipc.SelfHosted.Workflow.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'ApplyVipc.SelfHosted.DryRunTrue.Workflow' {
         Evidence    = 'tests/pester/ApplyVipc.SelfHosted.Workflow.Tests.ps1'
     }
 
-    It 'runs apply-vipc action with dry_run true' -Tag 'REQ-006' -TestMetadata $meta {
+    It 'runs apply-vipc action with dry_run true' -Tag 'REQ-006' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/apply-vipc-self-hosted.yml'
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml
@@ -50,7 +50,7 @@ Describe 'ApplyVipc.SelfHosted.DryRunFalse.Workflow' {
         Evidence    = 'tests/pester/ApplyVipc.SelfHosted.Workflow.Tests.ps1'
     }
 
-    It 'runs apply-vipc action with dry_run false' -Tag 'REQ-007' -TestMetadata $meta {
+    It 'runs apply-vipc action with dry_run false' -Tag 'REQ-007' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/apply-vipc-self-hosted.yml'
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml

--- a/tests/pester/Build.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/Build.SelfHosted.Workflow.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'Build.SelfHosted.Workflow' {
         Evidence    = 'tests/pester/Build.SelfHosted.Workflow.Tests.ps1'
     }
 
-    It 'runs build action with required inputs' -Tag 'REQ-009' -TestMetadata $meta {
+    It 'runs build action with required inputs' -Tag 'REQ-009' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/build-self-hosted.yml'
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml

--- a/tests/pester/BuildLvlibp.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/BuildLvlibp.SelfHosted.Workflow.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'BuildLvlibp.SelfHosted.Workflow' {
         Evidence    = 'tests/pester/BuildLvlibp.SelfHosted.Workflow.Tests.ps1'
     }
 
-    It 'runs build-lvlibp action and uploads lvlibp artifact' -Tag 'REQ-010' -TestMetadata $meta {
+    It 'runs build-lvlibp action and uploads lvlibp artifact' -Tag 'REQ-010' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/build-lvlibp-self-hosted.yml'
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml

--- a/tests/pester/BuildViPackage.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/BuildViPackage.SelfHosted.Workflow.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'BuildViPackage.SelfHosted.Workflow' {
         Evidence    = 'tests/pester/BuildViPackage.SelfHosted.Workflow.Tests.ps1'
     }
 
-    It 'runs build-vi-package action and uploads vi package artifact' -Tag 'REQ-011' -TestMetadata $meta {
+    It 'runs build-vi-package action and uploads vi package artifact' -Tag 'REQ-011' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/build-vi-package-self-hosted.yml'
         if (-not (Test-Path $workflowPath)) {

--- a/tests/pester/CloseLabview.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/CloseLabview.SelfHosted.Workflow.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'CloseLabview.SelfHosted.Workflow' {
         Evidence    = 'tests/pester/CloseLabview.SelfHosted.Workflow.Tests.ps1'
     }
 
-    It 'runs close-labview action for 32-bit and 64-bit and uploads logs' -Tag 'REQ-012' -TestMetadata $meta {
+    It 'runs close-labview action for 32-bit and 64-bit and uploads logs' -Tag 'REQ-012' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfFile = Join-Path $repoRoot '.github/workflows/close-labview-external.yml'
 

--- a/tests/pester/Dispatcher.ArgsInputs.Tests.ps1
+++ b/tests/pester/Dispatcher.ArgsInputs.Tests.ps1
@@ -5,7 +5,7 @@ Describe 'Dispatcher Args Inputs' {
         Evidence    = 'tests/pester/Dispatcher.ArgsInputs.Tests.ps1'
     }
 
-    It 'dummy test' -Tag 'REQ-000' -TestMetadata $meta {
+    It 'dummy test' -Tag 'REQ-000' {
         $true | Should -BeTrue
     }
 }

--- a/tests/pester/Dispatcher.DryRun.Tests.ps1
+++ b/tests/pester/Dispatcher.DryRun.Tests.ps1
@@ -47,14 +47,14 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions' {
     Where-Object { $_ -match '^\s+- ' } |
     ForEach-Object { @{ Action = $_.Trim().Substring(2); ArgsJson = $script:argsJson } }
 
-  It "describes <Action>" -Tag 'REQ-002' -ForEach $actions -TestMetadata $meta {
+  It "describes <Action>" -Tag 'REQ-002' -ForEach $actions {
     param($Action, $ArgsJson)
     Write-Host "Testing $Action with ArgsJson $ArgsJson"
     pwsh -NoProfile -File $global:dispatcher -Describe $Action -ArgsJson $ArgsJson *> $null
     $LASTEXITCODE | Should -Be 0
   }
 
-  It "prints description before dry-run <Action>" -Tag 'REQ-002' -ForEach $actions -TestMetadata $meta {
+  It "prints description before dry-run <Action>" -Tag 'REQ-002' -ForEach $actions {
     param($Action, $ArgsJson)
     Write-Host "Testing $Action with ArgsJson $ArgsJson"
     $describeOut = & $global:dispatcher -Describe $Action -ArgsJson $ArgsJson 6>&1 | Out-String
@@ -63,7 +63,7 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions' {
     $describeOut | Should -Match "$Action parameters:"
   }
 
-  It "dry-runs <Action> and warns on unknown args" -Tag 'REQ-002' -ForEach $actions -TestMetadata $meta {
+  It "dry-runs <Action> and warns on unknown args" -Tag 'REQ-002' -ForEach $actions {
     param($Action, $ArgsJson)
     Write-Host "Testing $Action with ArgsJson $ArgsJson"
     $out = & $global:dispatcher -ActionName $Action -ArgsJson $ArgsJson -DryRun *>&1 | Out-String

--- a/tests/pester/Dispatcher.InvalidPaths.Tests.ps1
+++ b/tests/pester/Dispatcher.InvalidPaths.Tests.ps1
@@ -16,14 +16,14 @@ Describe 'Invalid RelativePath handling' {
         Evidence    = 'tests/pester/Dispatcher.InvalidPaths.Tests.ps1'
     }
 
-    It 'fails when RelativePath does not exist' -Tag 'REQ-005' -TestMetadata $meta {
+    It 'fails when RelativePath does not exist' -Tag 'REQ-005' {
         $json = @{ RelativePath = 'NoSuchDir' } | ConvertTo-Json -Compress
         $out = pwsh -NonInteractive -NoProfile -File $global:dispatcher -ActionName set-development-mode -ArgsJson $json *>&1 | Out-String
         $LASTEXITCODE | Should -Not -Be 0
         $out | Should -Match 'An unexpected error occurred during script execution'
     }
 
-    It 'fails when RelativePath is missing' -Tag 'REQ-005' -TestMetadata $meta {
+    It 'fails when RelativePath is missing' -Tag 'REQ-005' {
         $out = pwsh -NonInteractive -NoProfile -File $global:dispatcher -ActionName set-development-mode -ArgsJson '{}' *>&1 | Out-String
         $LASTEXITCODE | Should -Not -Be 0
         $out | Should -Match 'missing mandatory'

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -17,7 +17,7 @@ $meta = @{
 }
 
 Describe 'Unified Dispatcher — discovery and validation' {
-  It 'lists available actions' -Tag 'REQ-001' -TestMetadata $meta {
+  It 'lists available actions' -Tag 'REQ-001' {
     $json = Get-LabVIEWIconEditorArgsJson
     $out = pwsh -NoProfile -File $global:dispatcher -ListActions -ArgsJson $json | Out-String
     $out | Should -Match 'apply-vipc'
@@ -25,7 +25,7 @@ Describe 'Unified Dispatcher — discovery and validation' {
     $out | Should -Match 'missing-in-project'
     $out | Should -Match 'run-unit-tests'
   }
-  It 'describes a known action (build-lvlibp)' -Tag 'REQ-001' -TestMetadata $meta {
+  It 'describes a known action (build-lvlibp)' -Tag 'REQ-001' {
     $json = Get-LabVIEWIconEditorArgsJson
     $out = pwsh -NoProfile -File $global:dispatcher -Describe build-lvlibp -ArgsJson $json | Out-String
     $out | Should -Match 'Major'
@@ -35,7 +35,7 @@ Describe 'Unified Dispatcher — discovery and validation' {
     $out | Should -Match 'Commit'
   }
 
-  It 'fails gracefully on unknown action' -Tag 'REQ-001' -TestMetadata $meta {
+  It 'fails gracefully on unknown action' -Tag 'REQ-001' {
     $json = Get-LabVIEWIconEditorArgsJson
     pwsh -NoProfile -File $global:dispatcher -ActionName no-such-action -ArgsJson $json *>$null
     $LASTEXITCODE | Should -Be 1
@@ -43,7 +43,7 @@ Describe 'Unified Dispatcher — discovery and validation' {
 }
 
 Describe 'ArgsJson path handling' {
-  It 'handles Windows paths without manual escaping' -Tag 'REQ-001' -TestMetadata $meta {
+  It 'handles Windows paths without manual escaping' -Tag 'REQ-001' {
     $json = Get-LabVIEWIconEditorArgsJson
     & $global:dispatcher -ActionName set-development-mode -ArgsJson $json -DryRun *> $null
     $LASTEXITCODE | Should -Be 0
@@ -51,7 +51,7 @@ Describe 'ArgsJson path handling' {
 }
 
 Describe 'ArgsFile handling' {
-  It 'merges file arguments with inline overrides' -Tag 'REQ-001' -TestMetadata $meta {
+  It 'merges file arguments with inline overrides' -Tag 'REQ-001' {
     $jsonFile = Join-Path $TestDrive 'args.json'
     @{ MinimumSupportedLVVersion = '2021'; SupportedBitness = '32' } | ConvertTo-Json -Compress | Set-Content -Path $jsonFile
 
@@ -65,7 +65,7 @@ Describe 'ArgsFile handling' {
 
 
 Describe 'Filter-Args helper' {
-  It 'returns UnknownParams when requested' -Tag 'REQ-001' -TestMetadata $meta {
+  It 'returns UnknownParams when requested' -Tag 'REQ-001' {
     $ast = [System.Management.Automation.Language.Parser]::ParseFile($global:dispatcher, [ref]$null, [ref]$null)
     $funcAst = $ast.Find({ param($a) $a -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $a.Name -eq 'Filter-Args' }, $true)
     Invoke-Expression $funcAst.Extent.Text
@@ -78,7 +78,7 @@ Describe 'Filter-Args helper' {
 }
 
   Describe 'close-labview parameter aliases' {
-    It 'accepts camelCase args' -Tag 'REQ-001' -TestMetadata $meta {
+    It 'accepts camelCase args' -Tag 'REQ-001' {
       $base = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
       $json = @{
         MinimumSupportedLVVersion = $base.MinimumSupportedLVVersion
@@ -88,7 +88,7 @@ Describe 'Filter-Args helper' {
       $LASTEXITCODE | Should -Be 0
     }
 
-    It 'accepts snake_case args without warnings' -Tag 'REQ-001' -TestMetadata $meta {
+    It 'accepts snake_case args without warnings' -Tag 'REQ-001' {
       $base = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
       $json = @{
         minimum_supported_lv_version = $base.MinimumSupportedLVVersion

--- a/tests/pester/MissingInProject.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/MissingInProject.SelfHosted.Workflow.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'MissingInProject.SelfHosted.Workflow' {
         Evidence    = 'tests/pester/MissingInProject.SelfHosted.Workflow.Tests.ps1'
     }
 
-    It 'runs missing-in-project action on a self-hosted runner and uploads findings report' -Tag 'REQ-014' -TestMetadata $meta {
+    It 'runs missing-in-project action on a self-hosted runner and uploads findings report' -Tag 'REQ-014' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfDir = Join-Path $repoRoot '.github/workflows'
         $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'

--- a/tests/pester/ModifyVipbDisplayInfo.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/ModifyVipbDisplayInfo.SelfHosted.Workflow.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'ModifyVipbDisplayInfo.SelfHosted.Workflow' {
         Evidence    = 'tests/pester/ModifyVipbDisplayInfo.SelfHosted.Workflow.Tests.ps1'
     }
 
-    It 'runs modify-vipb-display-info action on a self-hosted runner and uploads VIPB artifact' -Tag 'REQ-015' -TestMetadata $meta {
+    It 'runs modify-vipb-display-info action on a self-hosted runner and uploads VIPB artifact' -Tag 'REQ-015' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfDir = Join-Path $repoRoot '.github/workflows'
         $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'

--- a/tests/pester/PathRestoration.Actions.Tests.ps1
+++ b/tests/pester/PathRestoration.Actions.Tests.ps1
@@ -40,7 +40,7 @@ Describe 'Adapters restore PATH' -Skip {
 
     foreach ($case in $cases) {
         $caseCopy = $case
-        It "restores PATH after $($caseCopy.Func)" -TestMetadata $meta {
+        It "restores PATH after $($caseCopy.Func)" {
             $originalPath = $env:PATH
             & $caseCopy.Func @($caseCopy.Args) -DryRun -gcliPath $script:gcliPath | Out-Null
             $env:PATH | Should -Be $originalPath

--- a/tests/pester/PrepareLabviewSource.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/PrepareLabviewSource.SelfHosted.Workflow.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'PrepareLabviewSource.SelfHosted.Workflow' {
         Evidence    = 'tests/pester/PrepareLabviewSource.SelfHosted.Workflow.Tests.ps1'
     }
 
-    It 'runs prepare-labview-source action and uploads prepared source artifact' -Tag 'REQ-011' -TestMetadata $meta {
+    It 'runs prepare-labview-source action and uploads prepared source artifact' -Tag 'REQ-011' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfDir = Join-Path $repoRoot '.github/workflows'
         $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'

--- a/tests/pester/RelativePath.Actions.Tests.ps1
+++ b/tests/pester/RelativePath.Actions.Tests.ps1
@@ -16,7 +16,7 @@ $meta = @{
 }
 
 Describe 'add-token-to-labview resolves RelativePath' {
-    It 'dry-runs without warnings' -Tag 'REQ-003' -TestMetadata $meta {
+    It 'dry-runs without warnings' -Tag 'REQ-003' {
         $json = Get-LabVIEWIconEditorArgsJson
         $expected = ($json | ConvertFrom-Json).RelativePath
         $out = & $dispatcher -ActionName add-token-to-labview -ArgsJson $json -DryRun *>&1 | Out-String
@@ -29,7 +29,7 @@ Describe 'add-token-to-labview resolves RelativePath' {
 }
 
 Describe 'apply-vipc resolves RelativePath' {
-    It 'dry-runs without warnings'  -Tag 'REQ-003' -TestMetadata $meta {
+    It 'dry-runs without warnings'  -Tag 'REQ-003' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ MinimumSupportedLVVersion = $b.MinimumSupportedLVVersion; SupportedBitness = $b.SupportedBitness; RelativePath = $b.RelativePath; VIP_LVVersion = '2021'; VIPCPath = 'dummy.vipc' } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName apply-vipc -ArgsJson $args -DryRun *>&1 | Out-String
@@ -42,7 +42,7 @@ Describe 'apply-vipc resolves RelativePath' {
 }
 
 Describe 'build-vi-package resolves RelativePath' {
-    It 'dry-runs without warnings'  -Tag 'REQ-003' -TestMetadata $meta {
+    It 'dry-runs without warnings'  -Tag 'REQ-003' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ MinimumSupportedLVVersion=$b.MinimumSupportedLVVersion; SupportedBitness=$b.SupportedBitness; LabVIEWMinorRevision='2021'; RelativePath=$b.RelativePath; VIPBPath='dummy.vipb'; Major=1; Minor=0; Patch=0; Build=1; Commit='deadbeef'; DisplayInformationJSON='{}'; ReleaseNotesFile='notes.md' } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName build-vi-package -ArgsJson $args -DryRun *>&1 | Out-String
@@ -55,7 +55,7 @@ Describe 'build-vi-package resolves RelativePath' {
 }
 
 Describe 'build resolves RelativePath' {
-    It 'dry-runs without warnings'  -Tag 'REQ-003' -TestMetadata $meta {
+    It 'dry-runs without warnings'  -Tag 'REQ-003' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ RelativePath=$b.RelativePath; Major=1; Minor=0; Patch=0; Build=1; Commit='deadbeef'; LabVIEWMinorRevision='2021'; CompanyName='Company'; AuthorName='Author' } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName build -ArgsJson $args -DryRun *>&1 | Out-String
@@ -68,7 +68,7 @@ Describe 'build resolves RelativePath' {
 }
 
 Describe 'build-lvlibp resolves RelativePath' {
-    It 'dry-runs without warnings'  -Tag 'REQ-003' -TestMetadata $meta {
+    It 'dry-runs without warnings'  -Tag 'REQ-003' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ MinimumSupportedLVVersion=$b.MinimumSupportedLVVersion; SupportedBitness=$b.SupportedBitness; RelativePath=$b.RelativePath; LabVIEW_Project='My.lvproj'; Build_Spec='MyBuild'; Major=1; Minor=0; Patch=0; Build=1; Commit='deadbeef' } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName build-lvlibp -ArgsJson $args -DryRun *>&1 | Out-String
@@ -81,7 +81,7 @@ Describe 'build-lvlibp resolves RelativePath' {
 }
 
 Describe 'modify-vipb-display-info resolves RelativePath' {
-    It 'dry-runs without warnings'  -Tag 'REQ-003' -TestMetadata $meta {
+    It 'dry-runs without warnings'  -Tag 'REQ-003' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ SupportedBitness=$b.SupportedBitness; RelativePath=$b.RelativePath; VIPBPath='dummy.vipb'; MinimumSupportedLVVersion=$b.MinimumSupportedLVVersion; LabVIEWMinorRevision='2021'; Major=1; Minor=0; Patch=0; Build=1; Commit='deadbeef'; DisplayInformationJSON='{}'; ReleaseNotesFile='notes.md' } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName modify-vipb-display-info -ArgsJson $args -DryRun *>&1 | Out-String
@@ -94,7 +94,7 @@ Describe 'modify-vipb-display-info resolves RelativePath' {
 }
 
 Describe 'prepare-labview-source resolves RelativePath' {
-    It 'dry-runs without warnings'  -Tag 'REQ-003' -TestMetadata $meta {
+    It 'dry-runs without warnings'  -Tag 'REQ-003' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ MinimumSupportedLVVersion=$b.MinimumSupportedLVVersion; SupportedBitness=$b.SupportedBitness; RelativePath=$b.RelativePath; LabVIEW_Project='My.lvproj'; Build_Spec='MyBuild' } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName prepare-labview-source -ArgsJson $args -DryRun *>&1 | Out-String
@@ -107,7 +107,7 @@ Describe 'prepare-labview-source resolves RelativePath' {
 }
 
 Describe 'restore-setup-lv-source resolves RelativePath' {
-    It 'dry-runs without warnings'  -Tag 'REQ-003' -TestMetadata $meta {
+    It 'dry-runs without warnings'  -Tag 'REQ-003' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ MinimumSupportedLVVersion=$b.MinimumSupportedLVVersion; SupportedBitness=$b.SupportedBitness; RelativePath=$b.RelativePath; LabVIEW_Project='My.lvproj'; Build_Spec='MyBuild' } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName restore-setup-lv-source -ArgsJson $args -DryRun *>&1 | Out-String
@@ -120,7 +120,7 @@ Describe 'restore-setup-lv-source resolves RelativePath' {
 }
 
 Describe 'revert-development-mode resolves RelativePath' {
-    It 'dry-runs without warnings'  -Tag 'REQ-003' -TestMetadata $meta {
+    It 'dry-runs without warnings'  -Tag 'REQ-003' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ RelativePath=$b.RelativePath } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName revert-development-mode -ArgsJson $args -DryRun *>&1 | Out-String
@@ -133,7 +133,7 @@ Describe 'revert-development-mode resolves RelativePath' {
 }
 
 Describe 'set-development-mode resolves RelativePath' {
-    It 'dry-runs without warnings'  -Tag 'REQ-003' -TestMetadata $meta {
+    It 'dry-runs without warnings'  -Tag 'REQ-003' {
         $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
         $args = @{ RelativePath=$b.RelativePath } | ConvertTo-Json -Compress
         $out = & $dispatcher -ActionName set-development-mode -ArgsJson $args -DryRun *>&1 | Out-String

--- a/tests/pester/RenameFile.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RenameFile.SelfHosted.Workflow.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'RenameFile.SelfHosted.Workflow' {
         Evidence    = 'tests/pester/RenameFile.SelfHosted.Workflow.Tests.ps1'
     }
 
-    It 'runs rename-file action on a self-hosted runner and uploads renamed file artifact' -Tag 'REQ-011' -TestMetadata $meta {
+    It 'runs rename-file action on a self-hosted runner and uploads renamed file artifact' -Tag 'REQ-011' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfDir = Join-Path $repoRoot '.github/workflows'
         $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'

--- a/tests/pester/RestoreSetupLvSource.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RestoreSetupLvSource.SelfHosted.Workflow.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'RestoreSetupLvSource.SelfHosted.Workflow' {
         Evidence    = 'tests/pester/RestoreSetupLvSource.SelfHosted.Workflow.Tests.ps1'
     }
 
-    It 'runs restore-setup-lv-source action on a self-hosted runner and uploads restoration artifacts' -Tag 'REQ-018' -TestMetadata $meta {
+    It 'runs restore-setup-lv-source action on a self-hosted runner and uploads restoration artifacts' -Tag 'REQ-018' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfDir = Join-Path $repoRoot '.github/workflows'
         $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'

--- a/tests/pester/RevertDevelopmentMode.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RevertDevelopmentMode.SelfHosted.Workflow.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'RevertDevelopmentMode.SelfHosted.Workflow' {
         Evidence    = 'tests/pester/RevertDevelopmentMode.SelfHosted.Workflow.Tests.ps1'
     }
 
-    It 'runs revert-development-mode action on a self-hosted runner and uploads configuration artifact' -Tag 'REQ-019' -TestMetadata $meta {
+    It 'runs revert-development-mode action on a self-hosted runner and uploads configuration artifact' -Tag 'REQ-019' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfDir = Join-Path $repoRoot '.github/workflows'
         $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'

--- a/tests/pester/RunUnitTests.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RunUnitTests.SelfHosted.Workflow.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'RunUnitTests.SelfHosted.Workflow' {
         Evidence    = 'tests/pester/RunUnitTests.SelfHosted.Workflow.Tests.ps1'
     }
 
-    It 'runs run-unit-tests action and uploads unit-test results' -Tag 'REQ-011' -TestMetadata $meta {
+    It 'runs run-unit-tests action and uploads unit-test results' -Tag 'REQ-011' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $workflowPath = Join-Path $repoRoot '.github/workflows/run-unit-tests-self-hosted.yml'
         $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml

--- a/tests/pester/ScriptPath.Tests.ps1
+++ b/tests/pester/ScriptPath.Tests.ps1
@@ -36,7 +36,7 @@ Describe 'Action script paths' {
         Evidence    = 'tests/pester/ScriptPath.Tests.ps1'
     }
 
-    It 'has script for <Name>' -Tag 'REQ-004' -TestCases $cases -TestMetadata $meta {
+    It 'has script for <Name>' -Tag 'REQ-004' -TestCases $cases {
         param($Name, $Path)
         Test-Path $Path | Should -BeTrue
     }

--- a/tests/pester/SetDevelopmentMode.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/SetDevelopmentMode.SelfHosted.Workflow.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'SetDevelopmentMode.SelfHosted.Workflow' {
         Evidence    = 'tests/pester/SetDevelopmentMode.SelfHosted.Workflow.Tests.ps1'
     }
 
-    It 'runs set-development-mode action on a self-hosted runner and uploads logs' -Tag 'REQ-021' -TestMetadata $meta {
+    It 'runs set-development-mode action on a self-hosted runner and uploads logs' -Tag 'REQ-021' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfDir = Join-Path $repoRoot '.github/workflows'
         $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'


### PR DESCRIPTION
## Summary
- drop deprecated `-TestMetadata` from Pester tests
- clean up AddTokenToLabview test definition

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `RUNNER_LABELS=icon-editor-windows pwsh -NoLogo -Command "Install-Module -Name Pester -Force -Scope AllUsers; if (\$env:RUNNER_TYPE -ne 'integration') { Install-Module -Name powershell-yaml -Force -Scope AllUsers }; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a17b205c14832986c42ae509666564