### PR TITLE
Stub Add-TestResult to unblock Pester tests

### DIFF
--- a/tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1
@@ -1,4 +1,5 @@
 #requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
@@ -12,11 +13,12 @@ if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
     }
 }
 
-if (-not ($env:RUNNER_LABELS -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ -eq 'icon-editor-windows' })) {
-    Set-ItResult -Skipped -Because 'requires runner label icon-editor-windows'
-    return
-}
 
+$missingLabel = -not ($env:RUNNER_LABELS -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ -eq 'icon-editor-windows' })
+
+if ($missingLabel) {
+    Describe 'AddTokenToLabview.SelfHosted.Workflow' -Skip {}
+} else {
 Describe 'AddTokenToLabview.SelfHosted.Workflow' {
     $meta = @{
         requirement = 'REQ-008'
@@ -58,4 +60,5 @@ Describe 'AddTokenToLabview.SelfHosted.Workflow' {
             Set-ItResult -Skipped -Because 'No workflow found using add-token-to-labview action'
         }
     }
+}
 }

--- a/tests/pester/ApplyVipc.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/ApplyVipc.SelfHosted.Workflow.Tests.ps1
@@ -1,4 +1,5 @@
 #requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 

--- a/tests/pester/Build.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/Build.SelfHosted.Workflow.Tests.ps1
@@ -1,4 +1,5 @@
 #requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 

--- a/tests/pester/BuildLvlibp.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/BuildLvlibp.SelfHosted.Workflow.Tests.ps1
@@ -1,4 +1,5 @@
 #requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 

--- a/tests/pester/BuildViPackage.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/BuildViPackage.SelfHosted.Workflow.Tests.ps1
@@ -1,4 +1,5 @@
 #requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 

--- a/tests/pester/CloseLabview.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/CloseLabview.SelfHosted.Workflow.Tests.ps1
@@ -1,4 +1,5 @@
 #requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 

--- a/tests/pester/Dispatcher.ArgsInputs.Tests.ps1
+++ b/tests/pester/Dispatcher.ArgsInputs.Tests.ps1
@@ -1,3 +1,4 @@
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
 Describe 'Dispatcher Args Inputs' {
     BeforeEach { Add-TestResult -Property @{ Owner = "DevTools"; Evidence = "tests/pester/Dispatcher.ArgsInputs.Tests.ps1" } }
     It 'dummy test' {

--- a/tests/pester/Dispatcher.DryRun.Tests.ps1
+++ b/tests/pester/Dispatcher.DryRun.Tests.ps1
@@ -1,4 +1,5 @@
 #requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
 # Pester v5+ tests that do NOT require LabVIEW/g-cli.
 # Run:  Invoke-Pester -CI -Path ./tests/pester
 # Requirement: REQ-002 - Dispatcher dry-run mode prints descriptions and warns on unknown arguments without executing actions.

--- a/tests/pester/Dispatcher.InvalidPaths.Tests.ps1
+++ b/tests/pester/Dispatcher.InvalidPaths.Tests.ps1
@@ -1,4 +1,5 @@
 #requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
 # Pester v5+ tests verifying dispatcher handling of invalid RelativePath
 # Requirement: REQ-005 - Dispatcher fails when RelativePath is missing or invalid.
 

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -1,4 +1,5 @@
 #requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
 # Pester v5+ tests that do NOT require LabVIEW/g-cli.
 # Run:  Invoke-Pester -CI -Path ./tests/pester
 # Requirement: REQ-001 - Dispatcher discovers available actions, describes them, and validates arguments.

--- a/tests/pester/MissingInProject.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/MissingInProject.SelfHosted.Workflow.Tests.ps1
@@ -1,4 +1,5 @@
 #requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 

--- a/tests/pester/ModifyVipbDisplayInfo.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/ModifyVipbDisplayInfo.SelfHosted.Workflow.Tests.ps1
@@ -1,4 +1,5 @@
 #requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 

--- a/tests/pester/Modules/AddTestResult/AddTestResult.psm1
+++ b/tests/pester/Modules/AddTestResult/AddTestResult.psm1
@@ -1,0 +1,7 @@
+function Add-TestResult {
+    [CmdletBinding()]
+    param(
+        [hashtable]$Property
+    )
+}
+Export-ModuleMember -Function Add-TestResult

--- a/tests/pester/PathRestoration.Actions.Tests.ps1
+++ b/tests/pester/PathRestoration.Actions.Tests.ps1
@@ -1,4 +1,5 @@
 #requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 

--- a/tests/pester/PrepareLabviewSource.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/PrepareLabviewSource.SelfHosted.Workflow.Tests.ps1
@@ -1,4 +1,5 @@
 #requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 

--- a/tests/pester/RelativePath.Actions.Tests.ps1
+++ b/tests/pester/RelativePath.Actions.Tests.ps1
@@ -1,4 +1,5 @@
 #requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
 # Pester v5+ tests verifying RelativePath-consuming actions
 # Requirement: REQ-003 - Actions correctly resolve and pass RelativePath arguments without warnings.
 

--- a/tests/pester/RenameFile.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RenameFile.SelfHosted.Workflow.Tests.ps1
@@ -1,4 +1,5 @@
 #requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 

--- a/tests/pester/RestoreSetupLvSource.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RestoreSetupLvSource.SelfHosted.Workflow.Tests.ps1
@@ -1,4 +1,5 @@
 #requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 

--- a/tests/pester/RevertDevelopmentMode.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RevertDevelopmentMode.SelfHosted.Workflow.Tests.ps1
@@ -1,4 +1,5 @@
 #requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 

--- a/tests/pester/RunUnitTests.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RunUnitTests.SelfHosted.Workflow.Tests.ps1
@@ -1,4 +1,5 @@
 #requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 

--- a/tests/pester/ScriptPath.Tests.ps1
+++ b/tests/pester/ScriptPath.Tests.ps1
@@ -1,4 +1,5 @@
 #requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
 # Verify that each action script exists in the expected location.
 # Requirement: REQ-004 - Every action script exists at the expected path.
 

--- a/tests/pester/SetDevelopmentMode.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/SetDevelopmentMode.SelfHosted.Workflow.Tests.ps1
@@ -1,4 +1,5 @@
 #requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 


### PR DESCRIPTION
## Summary
- add Add-TestResult stub module for Pester
- configure tests to load stub via PSModulePath and skip missing runner label gracefully

## Testing
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a173e5ca5c8329a401394d54069466