### PR TITLE
Remove PyYAML fallback from PowerShell tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 - Run `npm run lint:md` to lint Markdown files.
 - Run `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')` to verify links.
 - Run `actionlint` to validate GitHub Actions workflows.
-- Run `pwsh -NoLogo -Command "Install-Module -Name Pester -Force -Scope AllUsers; if (\$env:RUNNER_TYPE -ne 'integration') { Install-Module -Name powershell-yaml -Force -Scope AllUsers }; Invoke-Pester -CI -Path ./tests/pester"`.
+- Run `pwsh -NoLogo -Command "Install-Module -Name Pester -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"`.
 - If `$env:RUNNER_TYPE` is `integration`, verify native YAML parsing with `pwsh -NoLogo -Command "ConvertFrom-Yaml 'a: 1' | Out-Null"` before running Pester.
 
 All tests above are mandatory; they must pass before committing.

--- a/tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/AddTokenToLabview.SelfHosted.Workflow.Tests.ps1
@@ -3,16 +3,6 @@ $env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::Path
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
-    try {
-        Import-Module powershell-yaml -ErrorAction Stop
-    }
-    catch {
-        Set-ItResult -Skipped -Because 'powershell-yaml module not installed'
-        return
-    }
-}
-
 
 $missingLabel = -not ($env:RUNNER_LABELS -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ -eq 'icon-editor-windows' })
 

--- a/tests/pester/ApplyVipc.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/ApplyVipc.SelfHosted.Workflow.Tests.ps1
@@ -3,16 +3,6 @@ $env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::Path
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
-    try {
-        Import-Module powershell-yaml -ErrorAction Stop
-    }
-    catch {
-        Set-ItResult -Skipped -Because 'powershell-yaml module not installed'
-        return
-    }
-}
-
 Describe 'ApplyVipc.SelfHosted.DryRunTrue.Workflow' {
     $meta = @{
         requirement = 'REQ-006'

--- a/tests/pester/Build.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/Build.SelfHosted.Workflow.Tests.ps1
@@ -3,16 +3,6 @@ $env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::Path
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
-    try {
-        Import-Module powershell-yaml -ErrorAction Stop
-    }
-    catch {
-        Set-ItResult -Skipped -Because 'powershell-yaml module not installed'
-        return
-    }
-}
-
 Describe 'Build.SelfHosted.Workflow' {
     $meta = @{
         requirement = 'REQ-009'

--- a/tests/pester/BuildLvlibp.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/BuildLvlibp.SelfHosted.Workflow.Tests.ps1
@@ -3,16 +3,6 @@ $env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::Path
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
-    try {
-        Import-Module powershell-yaml -ErrorAction Stop
-    }
-    catch {
-        Set-ItResult -Skipped -Because 'powershell-yaml module not installed'
-        return
-    }
-}
-
 Describe 'BuildLvlibp.SelfHosted.Workflow' {
     $meta = @{
         requirement = 'REQ-010'

--- a/tests/pester/BuildViPackage.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/BuildViPackage.SelfHosted.Workflow.Tests.ps1
@@ -3,16 +3,6 @@ $env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::Path
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
-    try {
-        Import-Module powershell-yaml -ErrorAction Stop
-    }
-    catch {
-        Set-ItResult -Skipped -Because 'powershell-yaml module not installed'
-        return
-    }
-}
-
 Describe 'BuildViPackage.SelfHosted.Workflow' {
     $meta = @{
         requirement = 'REQ-011'

--- a/tests/pester/CloseLabview.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/CloseLabview.SelfHosted.Workflow.Tests.ps1
@@ -3,16 +3,6 @@ $env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::Path
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
-    try {
-        Import-Module powershell-yaml -ErrorAction Stop
-    }
-    catch {
-        Set-ItResult -Skipped -Because 'powershell-yaml module not installed'
-        return
-    }
-}
-
 Describe 'CloseLabview.SelfHosted.Workflow' {
     $meta = @{
         requirement = 'REQ-012'

--- a/tests/pester/MissingInProject.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/MissingInProject.SelfHosted.Workflow.Tests.ps1
@@ -3,16 +3,6 @@ $env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::Path
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
-    try {
-        Import-Module powershell-yaml -ErrorAction Stop
-    }
-    catch {
-        Set-ItResult -Skipped -Because 'powershell-yaml module not installed'
-        return
-    }
-}
-
 Describe 'MissingInProject.SelfHosted.Workflow' {
     $meta = @{
         requirement = 'REQ-014'

--- a/tests/pester/ModifyVipbDisplayInfo.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/ModifyVipbDisplayInfo.SelfHosted.Workflow.Tests.ps1
@@ -3,16 +3,6 @@ $env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::Path
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
-    try {
-        Import-Module powershell-yaml -ErrorAction Stop
-    }
-    catch {
-        Set-ItResult -Skipped -Because 'powershell-yaml module not installed'
-        return
-    }
-}
-
 Describe 'ModifyVipbDisplayInfo.SelfHosted.Workflow' {
     $meta = @{
         requirement = 'REQ-015'

--- a/tests/pester/Modules/ConvertFromYaml/ConvertFromYaml.psd1
+++ b/tests/pester/Modules/ConvertFromYaml/ConvertFromYaml.psd1
@@ -1,0 +1,5 @@
+@{
+    RootModule = 'ConvertFromYaml.psm1'
+    ModuleVersion = '0.0.1'
+    FunctionsToExport = @('ConvertFrom-Yaml')
+}

--- a/tests/pester/Modules/ConvertFromYaml/ConvertFromYaml.psm1
+++ b/tests/pester/Modules/ConvertFromYaml/ConvertFromYaml.psm1
@@ -1,0 +1,11 @@
+function ConvertFrom-Yaml {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)][string]$Yaml
+    )
+    process {
+        $json = $Yaml | node -e "const fs=require('fs'); const yaml=require('js-yaml'); const input=fs.readFileSync(0,'utf8'); process.stdout.write(JSON.stringify(yaml.load(input)));"
+        $json | ConvertFrom-Json -AsHashtable
+    }
+}
+Export-ModuleMember -Function ConvertFrom-Yaml

--- a/tests/pester/PrepareLabviewSource.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/PrepareLabviewSource.SelfHosted.Workflow.Tests.ps1
@@ -3,16 +3,6 @@ $env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::Path
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
-    try {
-        Import-Module powershell-yaml -ErrorAction Stop
-    }
-    catch {
-        Set-ItResult -Skipped -Because 'powershell-yaml module not installed'
-        return
-    }
-}
-
 Describe 'PrepareLabviewSource.SelfHosted.Workflow' {
     $meta = @{
         requirement = 'REQ-011'

--- a/tests/pester/RenameFile.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RenameFile.SelfHosted.Workflow.Tests.ps1
@@ -3,16 +3,6 @@ $env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::Path
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
-    try {
-        Import-Module powershell-yaml -ErrorAction Stop
-    }
-    catch {
-        Set-ItResult -Skipped -Because 'powershell-yaml module not installed'
-        return
-    }
-}
-
 Describe 'RenameFile.SelfHosted.Workflow' {
     $meta = @{
         requirement = 'REQ-011'

--- a/tests/pester/RestoreSetupLvSource.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RestoreSetupLvSource.SelfHosted.Workflow.Tests.ps1
@@ -3,16 +3,6 @@ $env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::Path
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
-    try {
-        Import-Module powershell-yaml -ErrorAction Stop
-    }
-    catch {
-        Set-ItResult -Skipped -Because 'powershell-yaml module not installed'
-        return
-    }
-}
-
 Describe 'RestoreSetupLvSource.SelfHosted.Workflow' {
     $meta = @{
         requirement = 'REQ-018'

--- a/tests/pester/RevertDevelopmentMode.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RevertDevelopmentMode.SelfHosted.Workflow.Tests.ps1
@@ -3,16 +3,6 @@ $env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::Path
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
-    try {
-        Import-Module powershell-yaml -ErrorAction Stop
-    }
-    catch {
-        Set-ItResult -Skipped -Because 'powershell-yaml module not installed'
-        return
-    }
-}
-
 Describe 'RevertDevelopmentMode.SelfHosted.Workflow' {
     $meta = @{
         requirement = 'REQ-019'

--- a/tests/pester/RunUnitTests.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RunUnitTests.SelfHosted.Workflow.Tests.ps1
@@ -3,16 +3,6 @@ $env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::Path
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
-    try {
-        Import-Module powershell-yaml -ErrorAction Stop
-    }
-    catch {
-        Set-ItResult -Skipped -Because 'powershell-yaml module not installed'
-        return
-    }
-}
-
 Describe 'RunUnitTests.SelfHosted.Workflow' {
     $meta = @{
         requirement = 'REQ-011'

--- a/tests/pester/SetDevelopmentMode.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/SetDevelopmentMode.SelfHosted.Workflow.Tests.ps1
@@ -3,16 +3,6 @@ $env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::Path
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
-    try {
-        Import-Module powershell-yaml -ErrorAction Stop
-    }
-    catch {
-        Set-ItResult -Skipped -Because 'powershell-yaml module not installed'
-        return
-    }
-}
-
 Describe 'SetDevelopmentMode.SelfHosted.Workflow' {
     $meta = @{
         requirement = 'REQ-021'


### PR DESCRIPTION
## Summary
- drop powershell-yaml installation instructions and module import
- rely on built-in YAML parsing with new ConvertFrom-Yaml helper

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "ConvertFrom-Yaml 'a: 1' | Out-Null"`
- `pwsh -NoLogo -Command 'Invoke-Pester -CI -Path ./tests/pester'`


------
https://chatgpt.com/codex/tasks/task_e_68a18736dc2083299941c22a03ab53e4