### PR TITLE
Safely parse PowerShell param blocks for dispatcher registry

### DIFF
--- a/dispatchers.json
+++ b/dispatchers.json
@@ -1,62 +1,603 @@
 {
   "InvokeAddTokenToLabVIEW": {
     "description": "",
-    "parameters": {}
+    "parameters": {
+      "DryRun": {
+        "type": "boolean",
+        "required": false,
+        "description": ""
+      },
+      "gcliPath": {
+        "type": "string",
+        "required": false,
+        "description": ""
+      },
+      "MinimumSupportedLVVersion": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "RelativePath": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "SupportedBitness": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      }
+    }
   },
   "InvokeApplyVIPC": {
     "description": "",
-    "parameters": {}
+    "parameters": {
+      "DryRun": {
+        "type": "boolean",
+        "required": false,
+        "description": ""
+      },
+      "gcliPath": {
+        "type": "string",
+        "required": false,
+        "description": ""
+      },
+      "MinimumSupportedLVVersion": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "RelativePath": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "SupportedBitness": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "VIP_LVVersion": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "VIPCPath": {
+        "type": "string",
+        "required": false,
+        "description": ""
+      }
+    }
   },
   "InvokeBuild": {
     "description": "",
-    "parameters": {}
+    "parameters": {
+      "AuthorName": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "Build": {
+        "type": "number",
+        "required": true,
+        "description": ""
+      },
+      "Commit": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "CompanyName": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "DryRun": {
+        "type": "boolean",
+        "required": false,
+        "description": ""
+      },
+      "gcliPath": {
+        "type": "string",
+        "required": false,
+        "description": ""
+      },
+      "LabVIEWMinorRevision": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "Major": {
+        "type": "number",
+        "required": true,
+        "description": ""
+      },
+      "Minor": {
+        "type": "number",
+        "required": true,
+        "description": ""
+      },
+      "Patch": {
+        "type": "number",
+        "required": true,
+        "description": ""
+      },
+      "RelativePath": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      }
+    }
   },
   "InvokeBuildLvlibp": {
     "description": "",
-    "parameters": {}
+    "parameters": {
+      "Build": {
+        "type": "number",
+        "required": true,
+        "description": ""
+      },
+      "Build_Spec": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "Commit": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "DryRun": {
+        "type": "boolean",
+        "required": false,
+        "description": ""
+      },
+      "gcliPath": {
+        "type": "string",
+        "required": false,
+        "description": ""
+      },
+      "LabVIEW_Project": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "Major": {
+        "type": "number",
+        "required": true,
+        "description": ""
+      },
+      "MinimumSupportedLVVersion": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "Minor": {
+        "type": "number",
+        "required": true,
+        "description": ""
+      },
+      "Patch": {
+        "type": "number",
+        "required": true,
+        "description": ""
+      },
+      "RelativePath": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "SupportedBitness": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      }
+    }
   },
   "InvokeBuildViPackage": {
     "description": "",
-    "parameters": {}
+    "parameters": {
+      "Build": {
+        "type": "number",
+        "required": true,
+        "description": ""
+      },
+      "Commit": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "DisplayInformationJSON": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "DryRun": {
+        "type": "boolean",
+        "required": false,
+        "description": ""
+      },
+      "gcliPath": {
+        "type": "string",
+        "required": false,
+        "description": ""
+      },
+      "LabVIEWMinorRevision": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "Major": {
+        "type": "number",
+        "required": true,
+        "description": ""
+      },
+      "MinimumSupportedLVVersion": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "Minor": {
+        "type": "number",
+        "required": true,
+        "description": ""
+      },
+      "Patch": {
+        "type": "number",
+        "required": true,
+        "description": ""
+      },
+      "RelativePath": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "ReleaseNotesFile": {
+        "type": "string",
+        "required": false,
+        "description": ""
+      },
+      "SupportedBitness": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "VIPBPath": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      }
+    }
   },
   "InvokeCloseLabVIEW": {
     "description": "",
-    "parameters": {}
+    "parameters": {
+      "DryRun": {
+        "type": "boolean",
+        "required": false,
+        "description": ""
+      },
+      "gcliPath": {
+        "type": "string",
+        "required": false,
+        "description": ""
+      },
+      "MinimumSupportedLVVersion": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "SupportedBitness": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      }
+    }
   },
   "InvokeGenerateReleaseNotes": {
     "description": "",
-    "parameters": {}
+    "parameters": {
+      "DryRun": {
+        "type": "boolean",
+        "required": false,
+        "description": ""
+      },
+      "gcliPath": {
+        "type": "string",
+        "required": false,
+        "description": ""
+      },
+      "OutputPath": {
+        "type": "string",
+        "required": false,
+        "default": "Tooling/deployment/release_notes.md",
+        "description": ""
+      }
+    }
   },
   "InvokeMissingInProject": {
     "description": "",
-    "parameters": {}
+    "parameters": {
+      "Arch": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "DryRun": {
+        "type": "boolean",
+        "required": false,
+        "description": ""
+      },
+      "gcliPath": {
+        "type": "string",
+        "required": false,
+        "description": ""
+      },
+      "LVVersion": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "ProjectFile": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      }
+    }
   },
   "InvokeModifyVIPBDisplayInfo": {
     "description": "",
-    "parameters": {}
+    "parameters": {
+      "Build": {
+        "type": "number",
+        "required": true,
+        "description": ""
+      },
+      "Commit": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "DisplayInformationJSON": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "DryRun": {
+        "type": "boolean",
+        "required": false,
+        "description": ""
+      },
+      "gcliPath": {
+        "type": "string",
+        "required": false,
+        "description": ""
+      },
+      "LabVIEWMinorRevision": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "Major": {
+        "type": "number",
+        "required": true,
+        "description": ""
+      },
+      "MinimumSupportedLVVersion": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "Minor": {
+        "type": "number",
+        "required": true,
+        "description": ""
+      },
+      "Patch": {
+        "type": "number",
+        "required": true,
+        "description": ""
+      },
+      "RelativePath": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "ReleaseNotesFile": {
+        "type": "string",
+        "required": false,
+        "description": ""
+      },
+      "SupportedBitness": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "VIPBPath": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      }
+    }
   },
   "InvokePrepareLabVIEWSource": {
     "description": "",
-    "parameters": {}
+    "parameters": {
+      "Build_Spec": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "DryRun": {
+        "type": "boolean",
+        "required": false,
+        "description": ""
+      },
+      "gcliPath": {
+        "type": "string",
+        "required": false,
+        "description": ""
+      },
+      "LabVIEW_Project": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "MinimumSupportedLVVersion": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "RelativePath": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "SupportedBitness": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      }
+    }
   },
   "InvokeRenameFile": {
     "description": "",
-    "parameters": {}
+    "parameters": {
+      "CurrentFilename": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "DryRun": {
+        "type": "boolean",
+        "required": false,
+        "description": ""
+      },
+      "gcliPath": {
+        "type": "string",
+        "required": false,
+        "description": ""
+      },
+      "NewFilename": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      }
+    }
   },
   "InvokeRestoreSetupLVSource": {
     "description": "",
-    "parameters": {}
+    "parameters": {
+      "Build_Spec": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "DryRun": {
+        "type": "boolean",
+        "required": false,
+        "description": ""
+      },
+      "gcliPath": {
+        "type": "string",
+        "required": false,
+        "description": ""
+      },
+      "LabVIEW_Project": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "MinimumSupportedLVVersion": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "RelativePath": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "SupportedBitness": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      }
+    }
   },
   "InvokeRevertDevelopmentMode": {
     "description": "",
-    "parameters": {}
+    "parameters": {
+      "DryRun": {
+        "type": "boolean",
+        "required": false,
+        "description": ""
+      },
+      "gcliPath": {
+        "type": "string",
+        "required": false,
+        "description": ""
+      },
+      "RelativePath": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      }
+    }
   },
   "InvokeRunUnitTests": {
     "description": "",
-    "parameters": {}
+    "parameters": {
+      "DryRun": {
+        "type": "boolean",
+        "required": false,
+        "description": ""
+      },
+      "gcliPath": {
+        "type": "string",
+        "required": false,
+        "description": ""
+      },
+      "MinimumSupportedLVVersion": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      },
+      "SupportedBitness": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      }
+    }
   },
   "InvokeSetDevelopmentMode": {
     "description": "",
-    "parameters": {}
+    "parameters": {
+      "DryRun": {
+        "type": "boolean",
+        "required": false,
+        "description": ""
+      },
+      "gcliPath": {
+        "type": "string",
+        "required": false,
+        "description": ""
+      },
+      "RelativePath": {
+        "type": "string",
+        "required": true,
+        "description": ""
+      }
+    }
+  },
+  "Set": {
+    "description": "",
+    "parameters": {
+      "Level": {
+        "type": "string",
+        "required": false,
+        "description": ""
+      }
+    }
   }
 }

--- a/scripts/__tests__/dispatcher-registry.test.js
+++ b/scripts/__tests__/dispatcher-registry.test.js
@@ -1,0 +1,15 @@
+import fs from 'fs';
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+test('All dispatchers have parameters', () => {
+  const registry = JSON.parse(
+    fs.readFileSync(new URL('../../dispatchers.json', import.meta.url), 'utf8')
+  );
+  for (const [name, info] of Object.entries(registry)) {
+    assert.ok(
+      Object.keys(info.parameters).length > 0,
+      `${name} has empty parameters`
+    );
+  }
+});

--- a/scripts/derive-dispatcher-registry.ts
+++ b/scripts/derive-dispatcher-registry.ts
@@ -50,16 +50,58 @@ function extractDescription(content: string, index: number): string {
   return desc.join(' ');
 }
 
+function extractParamBlock(content: string, start: number): string | null {
+  const rest = content.slice(start);
+  const paramMatch = /\bparam\s*\(/i.exec(rest);
+  if (!paramMatch) return null;
+  const before = rest
+    .slice(0, paramMatch.index)
+    .split(/\r?\n/)
+    .map(l => l.trim())
+    .filter(l => l && !l.startsWith('#') && !l.startsWith('['));
+  if (before.length > 0) return null;
+  let idx = start + paramMatch.index + paramMatch[0].length;
+  let depth = 1;
+  let inSingle = false, inDouble = false, inComment = false;
+  while (idx < content.length) {
+    const ch = content[idx];
+    const prev = content[idx - 1];
+    if (inComment) {
+      if (ch === '\n' || ch === '\r') inComment = false;
+    } else if (!inDouble && ch === "'" && prev !== '`') {
+      inSingle = !inSingle;
+    } else if (!inSingle && ch === '"' && prev !== '`') {
+      inDouble = !inDouble;
+    } else if (!inSingle && !inDouble) {
+      if (ch === '#') {
+        inComment = true;
+      } else if (ch === '(') {
+        depth++;
+      } else if (ch === ')') {
+        depth--;
+        if (depth === 0) {
+          return content.slice(start + paramMatch.index + paramMatch[0].length, idx);
+        }
+      }
+    }
+    idx++;
+  }
+  return null;
+}
+
 async function main() {
   const files = await glob('actions/*.{ps1,psm1}');
   const registry: Record<string, FuncInfo> = {};
   for (const file of files) {
     const content = await fs.readFile(file, 'utf8');
-    const regex = /function\s+(\w+)\s*\{[\s\S]*?param\(([^\)]*)\)/gi;
+    const fnRegex = /function\s+(\w+)\b/gi;
     let match: RegExpExecArray | null;
-    while ((match = regex.exec(content)) !== null) {
+    while ((match = fnRegex.exec(content)) !== null) {
       const fn = match[1];
-      const paramsBlock = match[2];
+      const bodyStart = content.indexOf('{', fnRegex.lastIndex);
+      if (bodyStart === -1) continue;
+      const paramsBlock = extractParamBlock(content, bodyStart + 1);
+      if (!paramsBlock) continue;
       const description = extractDescription(content, match.index);
       registry[fn] = { description, parameters: parseParams(paramsBlock) };
     }


### PR DESCRIPTION
## Summary
- parse PowerShell dispatcher parameter blocks with balanced parentheses
- regenerate dispatcher registry with populated parameters
- add a test ensuring each dispatcher lists its parameters

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "Install-Module -Name Pester -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a18cbe7dfc83299aeaa3d0fdebaf40