### PR TITLE
Load dispatcher registry from generated mappings

### DIFF
--- a/actions/Invoke-OSAction.ps1
+++ b/actions/Invoke-OSAction.ps1
@@ -16,8 +16,9 @@ $ErrorActionPreference = 'Stop'
 
 Import-Module (Join-Path $PSScriptRoot 'OpenSourceActions.psm1') -Force
 
-# Ordered registry of action name to adapter function
-$Registry = [ordered]@{
+# Attempt to build registry from generated dispatcher metadata; fall back to
+# a static map only if loading fails or produces no entries.
+$FallbackRegistry = [ordered]@{
     'add-token-to-labview'      = 'InvokeAddTokenToLabVIEW'
     'apply-vipc'               = 'InvokeApplyVIPC'
     'build'                    = 'InvokeBuild'
@@ -34,6 +35,27 @@ $Registry = [ordered]@{
     'run-unit-tests'           = 'InvokeRunUnitTests'
     'set-development-mode'     = 'InvokeSetDevelopmentMode'
 }
+
+$Registry = $null
+$dispatcherPath = Join-Path $PSScriptRoot '..' 'dispatchers.json'
+try {
+  if (Test-Path $dispatcherPath) {
+    $raw = Get-Content -Path $dispatcherPath -Raw | ConvertFrom-Json -AsHashtable
+    $generated = [ordered]@{}
+    foreach ($fn in $raw.Keys) {
+      if ($fn -notlike 'Invoke*') { continue }
+      $name = $fn -replace '^Invoke'
+      $name = $name -creplace '([a-z0-9])([A-Z])', '$1-$2'
+      $name = $name -creplace '([A-Z])([A-Z][a-z])', '$1-$2'
+      $name = $name -ireplace 'Lab-VIEW', 'LabVIEW'
+      $generated[$name.ToLowerInvariant()] = $fn
+    }
+    if ($generated.Count -gt 0) { $Registry = $generated }
+  }
+} catch {
+  # Ignore errors and fall back to the static table
+}
+if (-not $Registry) { $Registry = $FallbackRegistry }
 
 function Set-LogLevel {
   param([string]$Level)

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -26,6 +26,23 @@ Describe 'Unified Dispatcher — discovery and validation' {
     $out | Should -Match 'missing-in-project'
     $out | Should -Match 'run-unit-tests'
   }
+  It 'registry includes all Invoke* adapters in module' -Tag 'REQ-001' {
+    $modulePath = Join-Path (Split-Path $global:dispatcher -Parent) 'OpenSourceActions.psm1'
+    $module = Import-Module $modulePath -PassThru
+    $fnNames = (Get-Command -Module $module | Where-Object Name -like 'Invoke*').Name
+    function Convert-Name([string]$fn) {
+      $name = $fn -replace '^Invoke'
+      $name = $name -creplace '([a-z0-9])([A-Z])', '$1-$2'
+      $name = $name -creplace '([A-Z])([A-Z][a-z])', '$1-$2'
+      $name = $name -ireplace 'Lab-VIEW', 'LabVIEW'
+      return $name.ToLowerInvariant()
+    }
+    $expected = $fnNames | ForEach-Object { Convert-Name $_ }
+    $listed = pwsh -NoProfile -File $global:dispatcher -ListActions | Out-String
+    foreach ($action in $expected) {
+      $listed | Should -Match " - $action"
+    }
+  }
   It 'describes a known action (build-lvlibp)' -Tag 'REQ-001' {
     $json = Get-LabVIEWIconEditorArgsJson
     $out = pwsh -NoProfile -File $global:dispatcher -Describe build-lvlibp -ArgsJson $json | Out-String


### PR DESCRIPTION
## Summary
- Build action registry from `dispatchers.json` and fall back to legacy table when unavailable
- Add Pester test verifying dispatcher lists every adapter defined in `OpenSourceActions.psm1`

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `TERM=dumb pwsh -NoLogo -Command "Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a18f0315988329add81662644dd19a