### PR TITLE
feat: include error details in step summary

### DIFF
--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -31,6 +31,18 @@ test('writeErrorSummary skips summary file for non-Error throws', async () => {
   delete process.env.GITHUB_STEP_SUMMARY;
 });
 
+test('writeErrorSummary appends error details to summary file', async () => {
+  const tmp = new URL('./error-summary.md', import.meta.url);
+  await fs.rm(tmp, { force: true });
+  process.env.GITHUB_STEP_SUMMARY = fileURLToPath(tmp);
+  const err = new Error('kaboom');
+  await writeErrorSummary(err);
+  const content = await fs.readFile(tmp, 'utf8');
+  assert.match(content, /kaboom/);
+  await fs.rm(tmp, { force: true });
+  delete process.env.GITHUB_STEP_SUMMARY;
+});
+
 test('associates classname with requirement', async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'junit-'));
   const xml = `<testsuite><testcase classname="Dispatcher.Tests" name="sample" time="0.1"/></testsuite>`;

--- a/scripts/error-handler.ts
+++ b/scripts/error-handler.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs/promises';
+
 export function formatError(err: unknown): string {
   if (err instanceof Error) {
     return err.stack ?? err.message;
@@ -20,4 +22,13 @@ export function formatError(err: unknown): string {
 
 export async function writeErrorSummary(err: unknown): Promise<void> {
   console.error(`Error generating CI summary: ${formatError(err)}`);
+  if (!(err instanceof Error)) return;
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY || 'error-summary.md';
+  try {
+    const formatted = `\n\n### Error generating CI summary\n\n\u0060\u0060\u0060\n${formatError(err)}\n\u0060\u0060\u0060\n`;
+    await fs.appendFile(summaryPath, formatted, 'utf8');
+  } catch (writeErr) {
+    console.error(`Failed to write error summary: ${formatError(writeErr)}`);
+    console.error('Error details not written to summary file. See logs for details.');
+  }
 }


### PR DESCRIPTION
## Summary
- append formatted error details to step summary file
- test that summary captures reported errors

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "Set-PSRepository -Name PSGallery -InstallationPolicy Trusted; Install-Module -Name Pester -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"`

------
https://chatgpt.com/codex/tasks/task_e_68a195716e288329b049d5dee4491982