### PR TITLE
Add workflow for running Pester tests on external repositories

### DIFF
--- a/.github/workflows/run-pester-tests.yml
+++ b/.github/workflows/run-pester-tests.yml
@@ -1,0 +1,28 @@
+name: Run Pester tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: 'owner/repo of the repository to test'
+        required: true
+      ref:
+        description: 'Branch or tag to check out'
+        required: false
+        default: 'main'
+
+jobs:
+  run-pester-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Checkout target repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
+          path: target
+          token: ${{ secrets.REPO_TOKEN }}
+      - name: Run Pester tests
+        shell: pwsh
+        run: ./actions/Invoke-OSAction.ps1 -ActionName run-pester-tests -WorkingDirectory "${{ github.workspace }}/target"

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,3 +31,9 @@ Open Source LabVIEW Actions unifies LabVIEW CI/CD scripts behind a single PowerS
 | [revert-development-mode](actions/revert-development-mode.md) | Restore the repository from development mode by restoring packaged sources and closing LabVIEW. |
 | [run-unit-tests](actions/run-unit-tests.md) | Run LabVIEW unit tests via the LabVIEW Unit Test Framework CLI and report pass/fail/error using standard exit codes. |
 | [set-development-mode](actions/set-development-mode.md) | Configure the repository for development mode by removing packed libraries, adding tokens, preparing sources, and closing LabVIEW. |
+
+## Workflow Examples
+
+| Workflow | Purpose |
+| --- | --- |
+| [run-pester-tests](workflows/run-pester-tests.md) | Run Pester tests in a target repository. |

--- a/docs/workflows/run-pester-tests.md
+++ b/docs/workflows/run-pester-tests.md
@@ -1,0 +1,51 @@
+# run-pester-tests workflow
+
+## Purpose
+
+Run Pester tests in a target repository by dispatching the `run-pester-tests` action through `Invoke-OSAction.ps1`.
+
+## Inputs
+
+| Input | Description |
+| --- | --- |
+| `repository` | Repository in `owner/repo` format to test. |
+| `ref` | Branch or tag to check out. Defaults to `main`. |
+
+## Required secrets
+
+| Secret | Description |
+| --- | --- |
+| `REPO_TOKEN` | Personal access token with permission to read the target repository. Used by `actions/checkout` when accessing another repository. |
+
+## Example
+
+```yaml
+name: Run Pester tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: 'owner/repo of the repository to test'
+        required: true
+      ref:
+        description: 'Branch or tag to check out'
+        required: false
+        default: 'main'
+
+jobs:
+  run-pester-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Checkout target repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
+          path: target
+          token: ${{ secrets.REPO_TOKEN }}
+      - name: Run Pester tests
+        shell: pwsh
+        run: ./actions/Invoke-OSAction.ps1 -ActionName run-pester-tests -WorkingDirectory "${{ github.workspace }}/target"
+```


### PR DESCRIPTION
## Summary
- add reusable workflow to execute Pester tests in a specified repository
- document required inputs and secrets for the workflow

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "Install-Module -Name Pester -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"` *(fails: Tests Passed: 90, Failed: 2)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f0bdfa24832989d92224b5692ed3