### PR TITLE
test: add run-pester-tests workflow coverage

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -37,6 +37,7 @@ This project tracks high‑level requirements and maps each one to the Pester te
 | REQ-031 | Parsing logic validates presence of required fields and reports missing or malformed data. | `scripts/__tests__/junit-parser.test.js` |  |  |  |
 | REQ-032 | Parser tolerates and retains unknown attributes for future extensibility. | `scripts/__tests__/junit-parser.test.js` |  |  |  |
 | REQ-033 | Tests ending with `SelfHosted.Workflow.Tests.ps1` execute only in dry run mode unless the workflow targets a self-hosted Windows runner labeled `self-hosted-windows-lv`. | `tests/pester/*SelfHosted.Workflow.Tests.ps1` |  |  | false |
+| REQ-034 | Workflow tests the composite action defined in run-pester-tests/action.yml on a self-hosted Windows runner labeled icon-editor-windows. | `tests/pester/RunPesterTests.SelfHosted.Workflow.Tests.ps1` | icon-editor-windows | integration | false |
 
 Each test file is annotated with its corresponding requirement ID to maintain traceability between requirements and test coverage.
 

--- a/requirements.json
+++ b/requirements.json
@@ -261,6 +261,14 @@
       "tests": [
         "SelfHosted.Workflow.Tests"
       ]
+    },
+    {
+      "id": "REQ-034",
+      "description": "Workflow tests the composite action defined in run-pester-tests/action.yml on a self-hosted Windows runner labeled icon-editor-windows.",
+      "runner": "icon-editor-windows",
+      "tests": [
+        "RunPesterTests.SelfHosted.Workflow"
+      ]
     }
   ]
 }

--- a/tests/pester/Dispatcher.DryRun.Tests.ps1
+++ b/tests/pester/Dispatcher.DryRun.Tests.ps1
@@ -41,6 +41,7 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions' {
        NewFilename               = 'new.txt'
        ReleaseNotesFile          = 'notes.md'
        ExtraParam                = 'extra'
+       WorkingDirectory          = '/tmp'
     }
   foreach ($kvp in $extra.GetEnumerator()) { $script:args | Add-Member -NotePropertyName $kvp.Key -NotePropertyValue $kvp.Value }
   $script:argsJson = $script:args | ConvertTo-Json -Compress

--- a/tests/pester/Fixtures/run-pester-tests/tests/pester/Failing.Tests.ps1
+++ b/tests/pester/Fixtures/run-pester-tests/tests/pester/Failing.Tests.ps1
@@ -1,0 +1,5 @@
+Describe 'Failing' {
+    It 'fails' {
+        1 | Should -Be 2
+    }
+}

--- a/tests/pester/Fixtures/run-pester-tests/tests/pester/Passing.Tests.ps1
+++ b/tests/pester/Fixtures/run-pester-tests/tests/pester/Passing.Tests.ps1
@@ -1,0 +1,5 @@
+Describe 'Passing' {
+    It 'succeeds' {
+        1 | Should -Be 1
+    }
+}

--- a/tests/pester/RunPesterTests.SelfHosted.Workflow.Tests.ps1
+++ b/tests/pester/RunPesterTests.SelfHosted.Workflow.Tests.ps1
@@ -1,0 +1,39 @@
+#requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Describe 'RunPesterTests.SelfHosted.Workflow' {
+    $meta = @{
+        requirement = 'REQ-034'
+        Owner       = 'DevTools'
+        Evidence    = 'tests/pester/RunPesterTests.SelfHosted.Workflow.Tests.ps1'
+    }
+
+    It 'returns non-zero exit code when tests fail' -Tag 'REQ-034' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
+        $fixture = Join-Path $repoRoot 'tests/pester/Fixtures/run-pester-tests'
+        pwsh -NoProfile -File $dispatcher -ActionName run-pester-tests -ArgsYaml "@{ WorkingDirectory = '$fixture' }" *> $null
+        $LASTEXITCODE | Should -Not -Be 0
+    }
+
+    It 'returns zero exit code when all tests pass' -Tag 'REQ-034' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
+        $fixture = Join-Path $repoRoot 'tests/pester/Fixtures/run-pester-tests'
+        $temp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+        Copy-Item -Recurse $fixture $temp
+        Remove-Item (Join-Path $temp 'tests/pester/Failing.Tests.ps1')
+        pwsh -NoProfile -File $dispatcher -ActionName run-pester-tests -ArgsYaml "@{ WorkingDirectory = '$temp' }" *> $null
+        $LASTEXITCODE | Should -Be 0
+    }
+
+    It 'prints dry-run information' -Tag 'REQ-034' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
+        $fixture = Join-Path $repoRoot 'tests/pester/Fixtures/run-pester-tests'
+        $info = pwsh -NoProfile -File $dispatcher -ActionName run-pester-tests -ArgsYaml "@{ WorkingDirectory = '$fixture' }" -DryRun 6>&1 | Out-String
+        $info | Should -Match 'DryRun: & .*RunPesterTests.ps1'
+    }
+}


### PR DESCRIPTION
## Summary
- add Pester fixture repo with passing and failing tests
- exercise run-pester-tests action including dry run behaviour
- document new requirement mapping

## Testing
- `apt-get update && apt-get install -y apt-utils`
- `curl -fsSL https://deb.nodesource.com/setup_24.x | bash -`
- `apt-get install -y nodejs`
- `go install github.com/rhysd/actionlint/cmd/actionlint@latest`
- `wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb && dpkg -i packages-microsoft-prod.deb`
- `apt-get update`
- `apt-get install -y powershell`
- `node --version`
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `/root/.local/share/mise/installs/go/1.24.3/bin/actionlint`
- `pwsh -NoLogo -Command "Install-Module -Name Pester -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"` *(fails: Exception calling "WriteElementString" with "2" argument(s): ", hexadecimal value 0x1B, is an invalid character.)*


------
https://chatgpt.com/codex/tasks/task_e_68a200320ab883299f9a1ea1957fb08a