### PR TITLE
Disable Pester color output

### DIFF
--- a/scripts/run-pester-tests/RunPesterTests.ps1
+++ b/scripts/run-pester-tests/RunPesterTests.ps1
@@ -22,6 +22,9 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $testPath = Join-Path $WorkingDirectory 'tests/pester'
-Invoke-Pester -CI -Path $testPath
+$ansiRegex = [regex]'\x1B\[[0-9;]*[A-Za-z]'
+$cfg = New-PesterConfiguration
+$cfg.Output.NoColor = $true
+Invoke-Pester -CI -Configuration $cfg -Path $testPath 2>&1 | ForEach-Object { $ansiRegex.Replace($_, '') }
 exit $LASTEXITCODE
 

--- a/tests/pester/Dispatcher.DryRun.Tests.ps1
+++ b/tests/pester/Dispatcher.DryRun.Tests.ps1
@@ -19,6 +19,7 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions' {
     }
   $script:args = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
   $extra = @{
+       WorkingDirectory         = $repoRoot
        VIP_LVVersion             = '2021'
        VIPCPath                  = 'dummy.vipc'
        LabVIEW_Project           = 'My.lvproj'


### PR DESCRIPTION
## Summary
- ensure RunPesterTests runs Pester without color and strips ANSI sequences
- supply WorkingDirectory to dispatcher dry-run tests so all actions dry-run cleanly

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -NonInteractive -Command "Install-Module -Name Pester -Force -Scope AllUsers; Invoke-Pester -CI -Path ./tests/pester"`


------
https://chatgpt.com/codex/tasks/task_e_68a209141d8483299c7b97ff33fb56e4