### PR TITLE
chore: add markdown link check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "derive:registry": "tsx scripts/derive-dispatcher-registry.ts",
     "generate:summary": "tsx scripts/generate-ci-summary.ts",
     "postinstall": "patch-package",
-    "lint:md": "markdownlint-cli2 README.md \"docs/**/*.md\" \"scripts/**/*.md\""
+    "lint:md": "markdownlint-cli2 README.md \"docs/**/*.md\" \"scripts/**/*.md\"",
+    "link:check": "markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')"
   },
   "dependencies": {
     "glob": "^10.3.10",


### PR DESCRIPTION
## Summary
- add `link:check` npm script to run markdown-link-check across docs and scripts

## Testing
- `npm run check:node`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'` *(failed: Parameter set cannot be resolved using the specified named parameters)*

------
https://chatgpt.com/codex/tasks/task_e_68a21ba901b88329a8ab7fab3ac29dd4