### PR TITLE
ci: check markdown links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           node-version: 24
       - run: npm run check:node
       - run: npm install
+      - run: npm run link:check
       - run: npm run test:ci
       - run: npm run derive:registry
       - run: npm run generate:summary


### PR DESCRIPTION
## Summary
- run markdown link check as part of Node CI workflow

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command 'Import-Module Pester; $cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'` *(fails: prompts for WorkingDirectory)*

------
https://chatgpt.com/codex/tasks/task_e_68a21e2b1a088329a917cced197fc40c