### PR TITLE
chore: add working directory handling for tests

### DIFF
--- a/docs/testing-pester.md
+++ b/docs/testing-pester.md
@@ -2,7 +2,7 @@
 
 ## Canonical argument helper
 
-Pester tests share a small helper module, `tests/pester/Helper/ArgsJson.psm1`, which exposes `Get-LabVIEWIconEditorArgsJson`. The function returns a canonical set of dispatcher arguments so every test starts from the same baseline. Using the helper avoids repeating boilerplate and keeps tests resilient to environment differences.
+Pester tests share a small helper module, `tests/pester/Helper/ArgsJson.psm1`, which exposes `Get-LabVIEWIconEditorArgsJson`. The function returns a canonical set of dispatcher arguments and the project root so every test starts from the same baseline. Using the helper avoids repeating boilerplate and keeps tests resilient to environment differences.
 
 ## labview-icon-editor reference project
 
@@ -15,7 +15,7 @@ The helper points at the **labview-icon-editor** project. This open-source repos
    ```powershell
    Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
    ```
-3. Use `Get-LabVIEWIconEditorArgsJson` to obtain the canonical JSON for dispatcher calls.
+3. Use `Get-LabVIEWIconEditorArgsJson` to obtain the canonical JSON and working directory for dispatcher calls.
 4. Include both positive and negative path tests where practical.
 5. Run the suite before submitting a pull request with:
 
@@ -32,8 +32,10 @@ The helper points at the **labview-icon-editor** project. This open-source repos
 
 ```powershell
 It 'describes a known action' {
-  $json = Get-LabVIEWIconEditorArgsJson
-  $out = pwsh -NoProfile -File $global:dispatcher -Describe build-lvlibp -ArgsJson $json | Out-String
+  $params = Get-LabVIEWIconEditorArgsJson
+  $json = $params.ArgsJson
+  $wd = $params.WorkingDirectory
+  $out = pwsh -NoProfile -File $global:dispatcher -Describe build-lvlibp -ArgsJson $json -WorkingDirectory $wd | Out-String
   $out | Should -Match 'Major'
 }
 ```
@@ -42,8 +44,10 @@ It 'describes a known action' {
 
 ```powershell
 It 'fails on unknown action' {
-  $json = Get-LabVIEWIconEditorArgsJson
-  pwsh -NoProfile -File $global:dispatcher -ActionName no-such-action -ArgsJson $json *>$null
+  $params = Get-LabVIEWIconEditorArgsJson
+  $json = $params.ArgsJson
+  $wd = $params.WorkingDirectory
+  pwsh -NoProfile -File $global:dispatcher -ActionName no-such-action -ArgsJson $json -WorkingDirectory $wd *>$null
   $LASTEXITCODE | Should -Be 1
 }
 ```

--- a/tests/pester/Dispatcher.DryRun.Tests.ps1
+++ b/tests/pester/Dispatcher.DryRun.Tests.ps1
@@ -21,7 +21,9 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions' {
         Owner       = 'DevTools'
         Evidence    = 'tests/pester/Dispatcher.DryRun.Tests.ps1'
     }
-  $script:args = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
+  $params = Get-LabVIEWIconEditorArgsJson
+  $script:projectRoot = $params.WorkingDirectory
+  $script:args = $params.ArgsJson | ConvertFrom-Json
   $extra = @{
        VIP_LVVersion             = '2021'
        VIPCPath                  = 'dummy.vipc'
@@ -45,25 +47,26 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions' {
        NewFilename               = 'new.txt'
        ReleaseNotesFile          = 'notes.md'
        ExtraParam                = 'extra'
+       WorkingDirectory          = $script:projectRoot
     }
   foreach ($kvp in $extra.GetEnumerator()) { $script:args | Add-Member -NotePropertyName $kvp.Key -NotePropertyValue $kvp.Value }
   $script:argsJson = $script:args | ConvertTo-Json -Compress
-  $actions = pwsh -NoProfile -File $global:dispatcher -ListActions |
+  $actions = pwsh -NoProfile -File $global:dispatcher -ListActions -WorkingDirectory $script:projectRoot |
     Where-Object { $_ -match '^\s+- ' } |
     ForEach-Object { @{ Action = $_.Trim().Substring(2); ArgsJson = $script:argsJson } }
 
   It "describes <Action>" -Tag 'REQ-002' -ForEach $actions {
     param($Action, $ArgsJson)
     Write-Host "Testing $Action with ArgsJson $ArgsJson"
-    pwsh -NoProfile -File $global:dispatcher -Describe $Action -ArgsJson $ArgsJson *> $null
+    pwsh -NoProfile -File $global:dispatcher -Describe $Action -ArgsJson $ArgsJson -WorkingDirectory $script:projectRoot *> $null
     $LASTEXITCODE | Should -Be 0
   }
 
   It "prints description before dry-run <Action>" -Tag 'REQ-002' -ForEach $actions {
     param($Action, $ArgsJson)
     Write-Host "Testing $Action with ArgsJson $ArgsJson"
-    $describeOut = & $global:dispatcher -Describe $Action -ArgsJson $ArgsJson 6>&1 | Out-String
-    & $global:dispatcher -ActionName $Action -ArgsJson $ArgsJson -DryRun *> $null
+    $describeOut = & $global:dispatcher -Describe $Action -ArgsJson $ArgsJson -WorkingDirectory $script:projectRoot 6>&1 | Out-String
+    & $global:dispatcher -ActionName $Action -ArgsJson $ArgsJson -WorkingDirectory $script:projectRoot -DryRun *> $null
     $LASTEXITCODE | Should -Be 0
     $describeOut | Should -Match "$Action parameters:"
   }
@@ -71,7 +74,7 @@ Describe 'Unified Dispatcher — DryRun behavior for all actions' {
   It "dry-runs <Action> and warns on unknown args" -Tag 'REQ-002' -ForEach $actions {
     param($Action, $ArgsJson)
     Write-Host "Testing $Action with ArgsJson $ArgsJson"
-    $out = & $global:dispatcher -ActionName $Action -ArgsJson $ArgsJson -DryRun *>&1 | Out-String
+    $out = & $global:dispatcher -ActionName $Action -ArgsJson $ArgsJson -WorkingDirectory $script:projectRoot -DryRun *>&1 | Out-String
     $LASTEXITCODE | Should -Be 0
     $out | Should -Match 'Ignored unknown parameters'
   }

--- a/tests/pester/Dispatcher.InvalidPaths.Tests.ps1
+++ b/tests/pester/Dispatcher.InvalidPaths.Tests.ps1
@@ -10,6 +10,9 @@ $repoRoot   = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
 $global:dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
 Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
 
+$params = Get-LabVIEWIconEditorArgsJson
+$projectRoot = $params.WorkingDirectory
+
 Describe 'Invalid RelativePath handling' {
     $meta = @{
         requirement = 'REQ-005'
@@ -19,13 +22,13 @@ Describe 'Invalid RelativePath handling' {
 
     It 'fails when RelativePath does not exist' -Tag 'REQ-005' {
         $json = @{ RelativePath = 'NoSuchDir' } | ConvertTo-Json -Compress
-        $out = pwsh -NonInteractive -NoProfile -File $global:dispatcher -ActionName set-development-mode -ArgsJson $json *>&1 | Out-String
+        $out = pwsh -NonInteractive -NoProfile -File $global:dispatcher -ActionName set-development-mode -ArgsJson $json -WorkingDirectory $projectRoot *>&1 | Out-String
         $LASTEXITCODE | Should -Not -Be 0
         $out | Should -Match 'An unexpected error occurred during script execution'
     }
 
     It 'fails when RelativePath is missing' -Tag 'REQ-005' {
-        $out = pwsh -NonInteractive -NoProfile -File $global:dispatcher -ActionName set-development-mode -ArgsJson '{}' *>&1 | Out-String
+        $out = pwsh -NonInteractive -NoProfile -File $global:dispatcher -ActionName set-development-mode -ArgsJson '{}' -WorkingDirectory $projectRoot *>&1 | Out-String
         $LASTEXITCODE | Should -Not -Be 0
         $out | Should -Match 'missing mandatory'
         $out | Should -Match 'RelativePath'

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -23,8 +23,10 @@ $meta = @{
 
 Describe 'Unified Dispatcher — discovery and validation' {
   It 'lists available actions' -Tag 'REQ-001' {
-    $json = Get-LabVIEWIconEditorArgsJson
-    $out = pwsh -NoProfile -File $global:dispatcher -ListActions -ArgsJson $json | Out-String
+    $params = Get-LabVIEWIconEditorArgsJson
+    $json = $params.ArgsJson
+    $projectRoot = $params.WorkingDirectory
+    $out = pwsh -NoProfile -File $global:dispatcher -ListActions -ArgsJson $json -WorkingDirectory $projectRoot | Out-String
     $out | Should -Match 'apply-vipc'
     $out | Should -Match 'build-lvlibp'
     $out | Should -Match 'missing-in-project'
@@ -42,14 +44,17 @@ Describe 'Unified Dispatcher — discovery and validation' {
       return $name.ToLowerInvariant()
     }
     $expected = $fnNames | ForEach-Object { Convert-Name $_ }
-    $listed = pwsh -NoProfile -File $global:dispatcher -ListActions | Out-String
+    $wd = (Get-LabVIEWIconEditorArgsJson).WorkingDirectory
+    $listed = pwsh -NoProfile -File $global:dispatcher -ListActions -WorkingDirectory $wd | Out-String
     foreach ($action in $expected) {
       $listed | Should -Match " - $action"
     }
   }
   It 'describes a known action (build-lvlibp)' -Tag 'REQ-001' {
-    $json = Get-LabVIEWIconEditorArgsJson
-    $out = pwsh -NoProfile -File $global:dispatcher -Describe build-lvlibp -ArgsJson $json | Out-String
+    $params = Get-LabVIEWIconEditorArgsJson
+    $json = $params.ArgsJson
+    $projectRoot = $params.WorkingDirectory
+    $out = pwsh -NoProfile -File $global:dispatcher -Describe build-lvlibp -ArgsJson $json -WorkingDirectory $projectRoot | Out-String
     $out | Should -Match 'Major'
     $out | Should -Match 'Minor'
     $out | Should -Match 'Patch'
@@ -58,16 +63,20 @@ Describe 'Unified Dispatcher — discovery and validation' {
   }
 
   It 'fails gracefully on unknown action' -Tag 'REQ-001' {
-    $json = Get-LabVIEWIconEditorArgsJson
-    pwsh -NoProfile -File $global:dispatcher -ActionName no-such-action -ArgsJson $json *>$null
+    $params = Get-LabVIEWIconEditorArgsJson
+    $json = $params.ArgsJson
+    $projectRoot = $params.WorkingDirectory
+    pwsh -NoProfile -File $global:dispatcher -ActionName no-such-action -ArgsJson $json -WorkingDirectory $projectRoot *>$null
     $LASTEXITCODE | Should -Be 1
   }
 }
 
 Describe 'ArgsJson path handling' {
   It 'handles Windows paths without manual escaping' -Tag 'REQ-001' {
-    $json = Get-LabVIEWIconEditorArgsJson
-    & $global:dispatcher -ActionName set-development-mode -ArgsJson $json -DryRun *> $null
+    $params = Get-LabVIEWIconEditorArgsJson
+    $json = $params.ArgsJson
+    $projectRoot = $params.WorkingDirectory
+    & $global:dispatcher -ActionName set-development-mode -ArgsJson $json -WorkingDirectory $projectRoot -DryRun *> $null
     $LASTEXITCODE | Should -Be 0
   }
 }
@@ -79,7 +88,8 @@ Describe 'ArgsFile handling' {
 
     $override = @{ SupportedBitness = '64' }
 
-    $out = & $global:dispatcher -ActionName close-labview -ArgsFile $jsonFile -ArgsYaml $override -DryRun *>&1 | Out-String
+    $projectRoot = (Get-LabVIEWIconEditorArgsJson).WorkingDirectory
+    $out = & $global:dispatcher -ActionName close-labview -ArgsFile $jsonFile -ArgsYaml $override -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
     $LASTEXITCODE | Should -Be 0
     $out | Should -Match '"SupportedBitness":"64"'
   }
@@ -101,22 +111,26 @@ Describe 'Filter-Args helper' {
 
   Describe 'close-labview parameter aliases' {
     It 'accepts camelCase args' -Tag 'REQ-001' {
-      $base = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
+      $params = Get-LabVIEWIconEditorArgsJson
+      $base = $params.ArgsJson | ConvertFrom-Json
+      $projectRoot = $params.WorkingDirectory
       $json = @{
         MinimumSupportedLVVersion = $base.MinimumSupportedLVVersion
         SupportedBitness = $base.SupportedBitness
       } | ConvertTo-Json -Compress
-      & $global:dispatcher -ActionName close-labview -ArgsJson $json -DryRun *> $null
+      & $global:dispatcher -ActionName close-labview -ArgsJson $json -WorkingDirectory $projectRoot -DryRun *> $null
       $LASTEXITCODE | Should -Be 0
     }
 
     It 'accepts snake_case args without warnings' -Tag 'REQ-001' {
-      $base = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
+      $params = Get-LabVIEWIconEditorArgsJson
+      $base = $params.ArgsJson | ConvertFrom-Json
+      $projectRoot = $params.WorkingDirectory
       $json = @{
         minimum_supported_lv_version = $base.MinimumSupportedLVVersion
         supported_bitness = $base.SupportedBitness
       } | ConvertTo-Json -Compress
-      $out = & $global:dispatcher -ActionName close-labview -ArgsJson $json -DryRun *>&1 | Out-String
+      $out = & $global:dispatcher -ActionName close-labview -ArgsJson $json -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
       $LASTEXITCODE | Should -Be 0
       $out | Should -Not -Match 'Ignored unknown parameters'
       $out | Should -Not -Match 'Missing an argument'

--- a/tests/pester/Helper/ArgsJson.psm1
+++ b/tests/pester/Helper/ArgsJson.psm1
@@ -1,16 +1,16 @@
 function Get-LabVIEWIconEditorArgsJson {
-    [OutputType([string])]
+    [OutputType([pscustomobject])]
     param()
 
-    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..')).Path
     if ($env:LABVIEW_ICON_EDITOR_PATH) {
-        $relativePath = $env:LABVIEW_ICON_EDITOR_PATH
+        $workingDir = $env:LABVIEW_ICON_EDITOR_PATH
     } elseif ($IsWindows) {
-        $relativePath = Join-Path $repoRoot 'labview-icon-editor'
+        $workingDir = Join-Path $repoRoot 'labview-icon-editor'
     } elseif ($IsLinux) {
-        $relativePath = Join-Path $repoRoot 'labview-icon-editor'
+        $workingDir = Join-Path $repoRoot 'labview-icon-editor'
     } elseif ($IsMacOS) {
-        $relativePath = Join-Path $repoRoot 'labview-icon-editor'
+        $workingDir = Join-Path $repoRoot 'labview-icon-editor'
     } else {
         throw 'Unsupported platform'
     }
@@ -18,10 +18,13 @@ function Get-LabVIEWIconEditorArgsJson {
     $args = @{
         MinimumSupportedLVVersion = '2021'
         SupportedBitness          = '64'
-        RelativePath              = $relativePath
+        RelativePath              = '.'
     }
 
-    return ($args | ConvertTo-Json -Compress)
+    return [pscustomobject]@{
+        ArgsJson        = ($args | ConvertTo-Json -Compress)
+        WorkingDirectory = $workingDir
+    }
 }
 
 Export-ModuleMember -Function Get-LabVIEWIconEditorArgsJson

--- a/tests/pester/RelativePath.Actions.Tests.ps1
+++ b/tests/pester/RelativePath.Actions.Tests.ps1
@@ -18,9 +18,11 @@ $meta = @{
 
 Describe 'add-token-to-labview resolves RelativePath' {
     It 'dry-runs without warnings' -Tag 'REQ-003' {
-        $json = Get-LabVIEWIconEditorArgsJson
+        $params = Get-LabVIEWIconEditorArgsJson
+        $json = $params.ArgsJson
+        $projectRoot = $params.WorkingDirectory
         $expected = ($json | ConvertFrom-Json).RelativePath
-        $out = & $dispatcher -ActionName add-token-to-labview -ArgsJson $json -DryRun *>&1 | Out-String
+        $out = & $dispatcher -ActionName add-token-to-labview -ArgsJson $json -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
         $jsonLine = $out -split "`n" | Where-Object { $_ -match '{' } | Select-Object -Last 1
         $jsonText = $jsonLine -replace '^[^{}]*({.*})','$1'
@@ -31,9 +33,11 @@ Describe 'add-token-to-labview resolves RelativePath' {
 
 Describe 'apply-vipc resolves RelativePath' {
     It 'dry-runs without warnings'  -Tag 'REQ-003' {
-        $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
+        $params = Get-LabVIEWIconEditorArgsJson
+        $b = $params.ArgsJson | ConvertFrom-Json
+        $projectRoot = $params.WorkingDirectory
         $args = @{ MinimumSupportedLVVersion = $b.MinimumSupportedLVVersion; SupportedBitness = $b.SupportedBitness; RelativePath = $b.RelativePath; VIP_LVVersion = '2021'; VIPCPath = 'dummy.vipc' } | ConvertTo-Json -Compress
-        $out = & $dispatcher -ActionName apply-vipc -ArgsJson $args -DryRun *>&1 | Out-String
+        $out = & $dispatcher -ActionName apply-vipc -ArgsJson $args -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
         $jsonLine = $out -split "`n" | Where-Object { $_ -match '{' } | Select-Object -Last 1
         $jsonText = $jsonLine -replace '^[^{}]*({.*})','$1'
@@ -44,9 +48,11 @@ Describe 'apply-vipc resolves RelativePath' {
 
 Describe 'build-vi-package resolves RelativePath' {
     It 'dry-runs without warnings'  -Tag 'REQ-003' {
-        $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
+        $params = Get-LabVIEWIconEditorArgsJson
+        $b = $params.ArgsJson | ConvertFrom-Json
+        $projectRoot = $params.WorkingDirectory
         $args = @{ MinimumSupportedLVVersion=$b.MinimumSupportedLVVersion; SupportedBitness=$b.SupportedBitness; LabVIEWMinorRevision='2021'; RelativePath=$b.RelativePath; VIPBPath='dummy.vipb'; Major=1; Minor=0; Patch=0; Build=1; Commit='deadbeef'; DisplayInformationJSON='{}'; ReleaseNotesFile='notes.md' } | ConvertTo-Json -Compress
-        $out = & $dispatcher -ActionName build-vi-package -ArgsJson $args -DryRun *>&1 | Out-String
+        $out = & $dispatcher -ActionName build-vi-package -ArgsJson $args -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
         $jsonLine = $out -split "`n" | Where-Object { $_ -match '{' } | Select-Object -Last 1
         $jsonText = $jsonLine -replace '^[^{}]*({.*})','$1'
@@ -57,9 +63,11 @@ Describe 'build-vi-package resolves RelativePath' {
 
 Describe 'build resolves RelativePath' {
     It 'dry-runs without warnings'  -Tag 'REQ-003' {
-        $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
+        $params = Get-LabVIEWIconEditorArgsJson
+        $b = $params.ArgsJson | ConvertFrom-Json
+        $projectRoot = $params.WorkingDirectory
         $args = @{ RelativePath=$b.RelativePath; Major=1; Minor=0; Patch=0; Build=1; Commit='deadbeef'; LabVIEWMinorRevision='2021'; CompanyName='Company'; AuthorName='Author' } | ConvertTo-Json -Compress
-        $out = & $dispatcher -ActionName build -ArgsJson $args -DryRun *>&1 | Out-String
+        $out = & $dispatcher -ActionName build -ArgsJson $args -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
         $jsonLine = $out -split "`n" | Where-Object { $_ -match '{' } | Select-Object -Last 1
         $jsonText = $jsonLine -replace '^[^{}]*({.*})','$1'
@@ -70,9 +78,11 @@ Describe 'build resolves RelativePath' {
 
 Describe 'build-lvlibp resolves RelativePath' {
     It 'dry-runs without warnings'  -Tag 'REQ-003' {
-        $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
+        $params = Get-LabVIEWIconEditorArgsJson
+        $b = $params.ArgsJson | ConvertFrom-Json
+        $projectRoot = $params.WorkingDirectory
         $args = @{ MinimumSupportedLVVersion=$b.MinimumSupportedLVVersion; SupportedBitness=$b.SupportedBitness; RelativePath=$b.RelativePath; LabVIEW_Project='My.lvproj'; Build_Spec='MyBuild'; Major=1; Minor=0; Patch=0; Build=1; Commit='deadbeef' } | ConvertTo-Json -Compress
-        $out = & $dispatcher -ActionName build-lvlibp -ArgsJson $args -DryRun *>&1 | Out-String
+        $out = & $dispatcher -ActionName build-lvlibp -ArgsJson $args -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
         $jsonLine = $out -split "`n" | Where-Object { $_ -match '{' } | Select-Object -Last 1
         $jsonText = $jsonLine -replace '^[^{}]*({.*})','$1'
@@ -83,9 +93,11 @@ Describe 'build-lvlibp resolves RelativePath' {
 
 Describe 'modify-vipb-display-info resolves RelativePath' {
     It 'dry-runs without warnings'  -Tag 'REQ-003' {
-        $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
+        $params = Get-LabVIEWIconEditorArgsJson
+        $b = $params.ArgsJson | ConvertFrom-Json
+        $projectRoot = $params.WorkingDirectory
         $args = @{ SupportedBitness=$b.SupportedBitness; RelativePath=$b.RelativePath; VIPBPath='dummy.vipb'; MinimumSupportedLVVersion=$b.MinimumSupportedLVVersion; LabVIEWMinorRevision='2021'; Major=1; Minor=0; Patch=0; Build=1; Commit='deadbeef'; DisplayInformationJSON='{}'; ReleaseNotesFile='notes.md' } | ConvertTo-Json -Compress
-        $out = & $dispatcher -ActionName modify-vipb-display-info -ArgsJson $args -DryRun *>&1 | Out-String
+        $out = & $dispatcher -ActionName modify-vipb-display-info -ArgsJson $args -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
         $jsonLine = $out -split "`n" | Where-Object { $_ -match '{' } | Select-Object -Last 1
         $jsonText = $jsonLine -replace '^[^{}]*({.*})','$1'
@@ -96,9 +108,11 @@ Describe 'modify-vipb-display-info resolves RelativePath' {
 
 Describe 'prepare-labview-source resolves RelativePath' {
     It 'dry-runs without warnings'  -Tag 'REQ-003' {
-        $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
+        $params = Get-LabVIEWIconEditorArgsJson
+        $b = $params.ArgsJson | ConvertFrom-Json
+        $projectRoot = $params.WorkingDirectory
         $args = @{ MinimumSupportedLVVersion=$b.MinimumSupportedLVVersion; SupportedBitness=$b.SupportedBitness; RelativePath=$b.RelativePath; LabVIEW_Project='My.lvproj'; Build_Spec='MyBuild' } | ConvertTo-Json -Compress
-        $out = & $dispatcher -ActionName prepare-labview-source -ArgsJson $args -DryRun *>&1 | Out-String
+        $out = & $dispatcher -ActionName prepare-labview-source -ArgsJson $args -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
         $jsonLine = $out -split "`n" | Where-Object { $_ -match '{' } | Select-Object -Last 1
         $jsonText = $jsonLine -replace '^[^{}]*({.*})','$1'
@@ -109,9 +123,11 @@ Describe 'prepare-labview-source resolves RelativePath' {
 
 Describe 'restore-setup-lv-source resolves RelativePath' {
     It 'dry-runs without warnings'  -Tag 'REQ-003' {
-        $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
+        $params = Get-LabVIEWIconEditorArgsJson
+        $b = $params.ArgsJson | ConvertFrom-Json
+        $projectRoot = $params.WorkingDirectory
         $args = @{ MinimumSupportedLVVersion=$b.MinimumSupportedLVVersion; SupportedBitness=$b.SupportedBitness; RelativePath=$b.RelativePath; LabVIEW_Project='My.lvproj'; Build_Spec='MyBuild' } | ConvertTo-Json -Compress
-        $out = & $dispatcher -ActionName restore-setup-lv-source -ArgsJson $args -DryRun *>&1 | Out-String
+        $out = & $dispatcher -ActionName restore-setup-lv-source -ArgsJson $args -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
         $jsonLine = $out -split "`n" | Where-Object { $_ -match '{' } | Select-Object -Last 1
         $jsonText = $jsonLine -replace '^[^{}]*({.*})','$1'
@@ -122,9 +138,11 @@ Describe 'restore-setup-lv-source resolves RelativePath' {
 
 Describe 'revert-development-mode resolves RelativePath' {
     It 'dry-runs without warnings'  -Tag 'REQ-003' {
-        $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
+        $params = Get-LabVIEWIconEditorArgsJson
+        $b = $params.ArgsJson | ConvertFrom-Json
+        $projectRoot = $params.WorkingDirectory
         $args = @{ RelativePath=$b.RelativePath } | ConvertTo-Json -Compress
-        $out = & $dispatcher -ActionName revert-development-mode -ArgsJson $args -DryRun *>&1 | Out-String
+        $out = & $dispatcher -ActionName revert-development-mode -ArgsJson $args -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
         $jsonLine = $out -split "`n" | Where-Object { $_ -match '{' } | Select-Object -Last 1
         $jsonText = $jsonLine -replace '^[^{}]*({.*})','$1'
@@ -135,9 +153,11 @@ Describe 'revert-development-mode resolves RelativePath' {
 
 Describe 'set-development-mode resolves RelativePath' {
     It 'dry-runs without warnings'  -Tag 'REQ-003' {
-        $b = Get-LabVIEWIconEditorArgsJson | ConvertFrom-Json
+        $params = Get-LabVIEWIconEditorArgsJson
+        $b = $params.ArgsJson | ConvertFrom-Json
+        $projectRoot = $params.WorkingDirectory
         $args = @{ RelativePath=$b.RelativePath } | ConvertTo-Json -Compress
-        $out = & $dispatcher -ActionName set-development-mode -ArgsJson $args -DryRun *>&1 | Out-String
+        $out = & $dispatcher -ActionName set-development-mode -ArgsJson $args -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
         $jsonLine = $out -split "`n" | Where-Object { $_ -match '{' } | Select-Object -Last 1
         $jsonText = $jsonLine -replace '^[^{}]*({.*})','$1'

--- a/tests/pester/ScriptPath.Tests.ps1
+++ b/tests/pester/ScriptPath.Tests.ps1
@@ -9,8 +9,10 @@ $ErrorActionPreference = 'Stop'
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
 $scriptRoot = Join-Path $repoRoot 'scripts'
 
+Import-Module (Join-Path $PSScriptRoot 'Helper' 'ArgsJson.psm1')
+$projectRoot = (Get-LabVIEWIconEditorArgsJson).WorkingDirectory
 $dispatcher = Join-Path $repoRoot 'actions' 'Invoke-OSAction.ps1'
-$actionNames = pwsh -NoProfile -File $dispatcher -ListActions |
+$actionNames = pwsh -NoProfile -File $dispatcher -ListActions -WorkingDirectory $projectRoot |
     Where-Object { $_ -match '^\s+- ' } |
     ForEach-Object { $_.Trim().Substring(2) }
 


### PR DESCRIPTION
## Summary
- output labview project root separately from helper
- pass -WorkingDirectory to dispatcher invocations in tests
- document updated helper usage for Pester tests

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command 'Import-Module Pester -MinimumVersion 5.0.0; $cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.Run.ContinuousIntegration = $true; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'`


------
https://chatgpt.com/codex/tasks/task_e_68a22211a2b88329ae9d10e998ea9042