### PR TITLE
docs: add dispatcher descriptions

### DIFF
--- a/actions/Invoke-OSAction.ps1
+++ b/actions/Invoke-OSAction.ps1
@@ -58,6 +58,8 @@ try {
 }
 if (-not $Registry) { $Registry = $FallbackRegistry }
 
+# Sets the verbosity for informational and verbose messages.
+# Level: Desired log level (ERROR, WARN, INFO, DEBUG).
 function Set-LogLevel {
   param([string]$Level)
   switch ($Level.ToUpperInvariant()) {
@@ -69,11 +71,14 @@ function Set-LogLevel {
   }
 }
 
+# Outputs the list of available actions.
 function Show-List {
   Write-Output 'Available actions:'
   $Registry.Keys | Sort-Object | ForEach-Object { Write-Output " - $_" }
 }
 
+# Displays parameter information for an action.
+# Name: Action name to describe.
 function Show-Description([string]$Name) {
   $key = $Name.ToLowerInvariant()
   if (-not $Registry.Contains($key)) { throw "Unknown action '$Name'" }
@@ -88,6 +93,11 @@ function Show-Description([string]$Name) {
   $consoleLines | ForEach-Object { Write-Output $_ }
 }
 
+# Filters a set of input arguments to those accepted by a dispatcher.
+# InputArgs: Hashtable of supplied arguments.
+# FuncName: Target dispatcher function name.
+# ActionNameForWarn: Action name used when emitting warnings.
+# ReturnUnknownParams: If set, returns unknown parameters as well.
 function Filter-Args([hashtable]$InputArgs, [string]$FuncName, [string]$ActionNameForWarn, [switch]$ReturnUnknownParams) {
   $cmd = Get-Command $FuncName -ErrorAction Stop
 

--- a/actions/OpenSourceActions.psm1
+++ b/actions/OpenSourceActions.psm1
@@ -1,3 +1,8 @@
+# Runs a helper script from the repository's scripts directory.
+# ScriptSegments: Path segments under the scripts folder that locate the target script.
+# Arguments: Hashtable of arguments forwarded to the script.
+# DryRun: If set, writes the command without executing it.
+# gcliPath: Optional path prepended to PATH for locating the g CLI.
 function Run-OpenSourceActionScript {
     param(
         [Parameter(Mandatory)] [string[]] $ScriptSegments,
@@ -28,6 +33,12 @@ function Run-OpenSourceActionScript {
     }
 }
 
+# Adds an authentication token to a LabVIEW installation.
+# MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports.
+# SupportedBitness: Target LabVIEW bitness (32- or 64-bit).
+# RelativePath: Path to the project root relative to the working directory.
+# DryRun: If set, prints the command instead of executing it.
+# gcliPath: Optional path prepended to PATH for locating the g CLI.
 function InvokeAddTokenToLabVIEW {
     [CmdletBinding()]
     param(
@@ -46,6 +57,14 @@ function InvokeAddTokenToLabVIEW {
     return Run-OpenSourceActionScript -ScriptSegments @('add-token-to-labview','AddTokenToLabVIEW.ps1') -Arguments $args -DryRun:$DryRun -gcliPath $gcliPath
 }
 
+# Applies a VI Package Configuration to a LabVIEW project.
+# MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports.
+# VIP_LVVersion: LabVIEW version used to build the VIPC.
+# SupportedBitness: Target LabVIEW bitness (32- or 64-bit).
+# RelativePath: Path to the project root relative to the working directory.
+# VIPCPath: Optional path to the VIPC file.
+# DryRun: If set, prints the command instead of executing it.
+# gcliPath: Optional path prepended to PATH for locating the g CLI.
 function InvokeApplyVIPC {
     [CmdletBinding()]
     param(
@@ -68,6 +87,21 @@ function InvokeApplyVIPC {
     return Run-OpenSourceActionScript -ScriptSegments @('apply-vipc','ApplyVIPC.ps1') -Arguments $args -DryRun:$DryRun -gcliPath $gcliPath
 }
 
+# Builds a VI Package using the provided VIPB file and version metadata.
+# MinimumSupportedLVVersion: Minimum LabVIEW version that the package supports.
+# SupportedBitness: Target LabVIEW bitness (32- or 64-bit).
+# LabVIEWMinorRevision: Minor revision of LabVIEW used to build the package.
+# RelativePath: Path to the project root relative to the working directory.
+# VIPBPath: Path to the VIPB build specification file.
+# Major: Major version component.
+# Minor: Minor version component.
+# Patch: Patch version component.
+# Build: Build number component.
+# Commit: Commit identifier used for the build metadata.
+# DisplayInformationJSON: JSON string containing display information for the package.
+# ReleaseNotesFile: Optional path to a release notes file.
+# DryRun: If set, prints the command instead of executing it.
+# gcliPath: Optional path prepended to PATH for locating the g CLI.
 function InvokeBuildViPackage {
     [CmdletBinding()]
     param(
@@ -104,6 +138,18 @@ function InvokeBuildViPackage {
     return Run-OpenSourceActionScript -ScriptSegments @('build-vi-package','build_vip.ps1') -Arguments $args -DryRun:$DryRun -gcliPath $gcliPath
 }
 
+# Builds the project and records version information.
+# RelativePath: Path to the project root relative to the working directory.
+# Major: Major version component.
+# Minor: Minor version component.
+# Patch: Patch version component.
+# Build: Build number component.
+# Commit: Commit identifier used for the build metadata.
+# LabVIEWMinorRevision: Minor revision of LabVIEW used for the build.
+# CompanyName: Company name recorded in build metadata.
+# AuthorName: Author name recorded in build metadata.
+# DryRun: If set, prints the command instead of executing it.
+# gcliPath: Optional path prepended to PATH for locating the g CLI.
 function InvokeBuild {
     [CmdletBinding()]
     param(
@@ -134,6 +180,19 @@ function InvokeBuild {
     return Run-OpenSourceActionScript -ScriptSegments @('build','Build.ps1') -Arguments $args -DryRun:$DryRun -gcliPath $gcliPath
 }
 
+# Builds a LabVIEW Packed Library using a project and build spec.
+# MinimumSupportedLVVersion: Minimum LabVIEW version that the library supports.
+# SupportedBitness: Target LabVIEW bitness (32- or 64-bit).
+# RelativePath: Path to the project root relative to the working directory.
+# LabVIEW_Project: Path to the LabVIEW project file.
+# Build_Spec: Name of the build specification within the project.
+# Major: Major version component.
+# Minor: Minor version component.
+# Patch: Patch version component.
+# Build: Build number component.
+# Commit: Commit identifier used for the build metadata.
+# DryRun: If set, prints the command instead of executing it.
+# gcliPath: Optional path prepended to PATH for locating the g CLI.
 function InvokeBuildLvlibp {
     [CmdletBinding()]
     param(
@@ -166,6 +225,11 @@ function InvokeBuildLvlibp {
     return Run-OpenSourceActionScript -ScriptSegments @('build-lvlibp','Build_lvlibp.ps1') -Arguments $args -DryRun:$DryRun -gcliPath $gcliPath
 }
 
+# Closes any running instance of LabVIEW.
+# MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports.
+# SupportedBitness: Target LabVIEW bitness (32- or 64-bit).
+# DryRun: If set, prints the command instead of executing it.
+# gcliPath: Optional path prepended to PATH for locating the g CLI.
 function InvokeCloseLabVIEW {
     [CmdletBinding()]
     param(
@@ -182,6 +246,10 @@ function InvokeCloseLabVIEW {
     return Run-OpenSourceActionScript -ScriptSegments @('close-labview','Close_LabVIEW.ps1') -Arguments $args -DryRun:$DryRun -gcliPath $gcliPath
 }
 
+# Generates a release notes file from the project's metadata.
+# OutputPath: Path where the release notes should be written.
+# DryRun: If set, prints the command instead of executing it.
+# gcliPath: Optional path prepended to PATH for locating the g CLI.
 function InvokeGenerateReleaseNotes {
     [CmdletBinding()]
     param(
@@ -194,6 +262,12 @@ function InvokeGenerateReleaseNotes {
     return Run-OpenSourceActionScript -ScriptSegments @('generate-release-notes','GenerateReleaseNotes.ps1') -Arguments $args -DryRun:$DryRun -gcliPath $gcliPath
 }
 
+# Lists files referenced in a LabVIEW project that are missing on disk.
+# LVVersion: LabVIEW version of the project.
+# Arch: Target architecture or bitness.
+# ProjectFile: Path to the .lvproj file to analyze.
+# DryRun: If set, prints the command instead of executing it.
+# gcliPath: Optional path prepended to PATH for locating the g CLI.
 function InvokeMissingInProject {
     [CmdletBinding()]
     param(
@@ -212,6 +286,21 @@ function InvokeMissingInProject {
     return Run-OpenSourceActionScript -ScriptSegments @('missing-in-project','Invoke-MissingInProjectCLI.ps1') -Arguments $args -DryRun:$DryRun -gcliPath $gcliPath
 }
 
+# Updates display information fields in a VIPB build specification.
+# SupportedBitness: Target LabVIEW bitness (32- or 64-bit).
+# RelativePath: Path to the project root relative to the working directory.
+# VIPBPath: Path to the VIPB build specification file.
+# MinimumSupportedLVVersion: Minimum LabVIEW version that the package supports.
+# LabVIEWMinorRevision: Minor revision of LabVIEW used for the build.
+# Major: Major version component.
+# Minor: Minor version component.
+# Patch: Patch version component.
+# Build: Build number component.
+# Commit: Commit identifier used for the build metadata.
+# DisplayInformationJSON: JSON string containing display information for the package.
+# ReleaseNotesFile: Optional path to a release notes file.
+# DryRun: If set, prints the command instead of executing it.
+# gcliPath: Optional path prepended to PATH for locating the g CLI.
 function InvokeModifyVIPBDisplayInfo {
     [CmdletBinding()]
     param(
@@ -248,6 +337,14 @@ function InvokeModifyVIPBDisplayInfo {
     return Run-OpenSourceActionScript -ScriptSegments @('modify-vipb-display-info','ModifyVIPBDisplayInfo.ps1') -Arguments $args -DryRun:$DryRun -gcliPath $gcliPath
 }
 
+# Prepares a LabVIEW project for source distribution.
+# MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports.
+# SupportedBitness: Target LabVIEW bitness (32- or 64-bit).
+# RelativePath: Path to the project root relative to the working directory.
+# LabVIEW_Project: Path to the LabVIEW project file.
+# Build_Spec: Name of the build specification within the project.
+# DryRun: If set, prints the command instead of executing it.
+# gcliPath: Optional path prepended to PATH for locating the g CLI.
 function InvokePrepareLabVIEWSource {
     [CmdletBinding()]
     param(
@@ -270,6 +367,11 @@ function InvokePrepareLabVIEWSource {
     return Run-OpenSourceActionScript -ScriptSegments @('prepare-labview-source','Prepare_LabVIEW_source.ps1') -Arguments $args -DryRun:$DryRun -gcliPath $gcliPath
 }
 
+# Renames a file on disk.
+# CurrentFilename: Existing path to the file.
+# NewFilename: New path for the file.
+# DryRun: If set, prints the command instead of executing it.
+# gcliPath: Optional path prepended to PATH for locating the g CLI.
 function InvokeRenameFile {
     [CmdletBinding()]
     param(
@@ -286,6 +388,14 @@ function InvokeRenameFile {
     return Run-OpenSourceActionScript -ScriptSegments @('rename-file','Rename-file.ps1') -Arguments $args -DryRun:$DryRun -gcliPath $gcliPath
 }
 
+# Restores the Setup LabVIEW source build specification.
+# MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports.
+# SupportedBitness: Target LabVIEW bitness (32- or 64-bit).
+# RelativePath: Path to the project root relative to the working directory.
+# LabVIEW_Project: Path to the LabVIEW project file.
+# Build_Spec: Name of the build specification within the project.
+# DryRun: If set, prints the command instead of executing it.
+# gcliPath: Optional path prepended to PATH for locating the g CLI.
 function InvokeRestoreSetupLVSource {
     [CmdletBinding()]
     param(
@@ -308,6 +418,10 @@ function InvokeRestoreSetupLVSource {
     return Run-OpenSourceActionScript -ScriptSegments @('restore-setup-lv-source','RestoreSetupLVSource.ps1') -Arguments $args -DryRun:$DryRun -gcliPath $gcliPath
 }
 
+# Returns a repository to its previous development mode state.
+# RelativePath: Path to the project root relative to the working directory.
+# DryRun: If set, prints the command instead of executing it.
+# gcliPath: Optional path prepended to PATH for locating the g CLI.
 function InvokeRevertDevelopmentMode {
     [CmdletBinding()]
     param(
@@ -320,6 +434,10 @@ function InvokeRevertDevelopmentMode {
     return Run-OpenSourceActionScript -ScriptSegments @('revert-development-mode','RevertDevelopmentMode.ps1') -Arguments $args -DryRun:$DryRun -gcliPath $gcliPath
 }
 
+# Runs Pester tests located in the specified working directory.
+# WorkingDirectory: Path containing the Pester tests to execute.
+# DryRun: If set, prints the command instead of executing it.
+# gcliPath: Optional path prepended to PATH for locating the g CLI.
 function InvokeRunPesterTests {
     [CmdletBinding()]
     param(
@@ -332,6 +450,11 @@ function InvokeRunPesterTests {
     return Run-OpenSourceActionScript -ScriptSegments @('run-pester-tests','RunPesterTests.ps1') -Arguments $args -DryRun:$DryRun -gcliPath $gcliPath
 }
 
+# Runs LabVIEW unit tests.
+# MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports.
+# SupportedBitness: Target LabVIEW bitness (32- or 64-bit).
+# DryRun: If set, prints the command instead of executing it.
+# gcliPath: Optional path prepended to PATH for locating the g CLI.
 function InvokeRunUnitTests {
     [CmdletBinding()]
     param(
@@ -348,6 +471,10 @@ function InvokeRunUnitTests {
     return Run-OpenSourceActionScript -ScriptSegments @('run-unit-tests','RunUnitTests.ps1') -Arguments $args -DryRun:$DryRun -gcliPath $gcliPath
 }
 
+# Configures the repository for development mode.
+# RelativePath: Path to the project root relative to the working directory.
+# DryRun: If set, prints the command instead of executing it.
+# gcliPath: Optional path prepended to PATH for locating the g CLI.
 function InvokeSetDevelopmentMode {
     [CmdletBinding()]
     param(

--- a/dispatchers.json
+++ b/dispatchers.json
@@ -1,6 +1,6 @@
 {
   "InvokeAddTokenToLabVIEW": {
-    "description": "",
+    "description": "Adds an authentication token to a LabVIEW installation. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Path to the project root relative to the working directory. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "DryRun": {
         "type": "boolean",
@@ -30,7 +30,7 @@
     }
   },
   "InvokeApplyVIPC": {
-    "description": "",
+    "description": "Applies a VI Package Configuration to a LabVIEW project. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. VIP_LVVersion: LabVIEW version used to build the VIPC. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Path to the project root relative to the working directory. VIPCPath: Optional path to the VIPC file. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "DryRun": {
         "type": "boolean",
@@ -70,7 +70,7 @@
     }
   },
   "InvokeBuild": {
-    "description": "",
+    "description": "Builds the project and records version information. RelativePath: Path to the project root relative to the working directory. Major: Major version component. Minor: Minor version component. Patch: Patch version component. Build: Build number component. Commit: Commit identifier used for the build metadata. LabVIEWMinorRevision: Minor revision of LabVIEW used for the build. CompanyName: Company name recorded in build metadata. AuthorName: Author name recorded in build metadata. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "AuthorName": {
         "type": "string",
@@ -130,7 +130,7 @@
     }
   },
   "InvokeBuildLvlibp": {
-    "description": "",
+    "description": "Builds a LabVIEW Packed Library using a project and build spec. MinimumSupportedLVVersion: Minimum LabVIEW version that the library supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Path to the project root relative to the working directory. LabVIEW_Project: Path to the LabVIEW project file. Build_Spec: Name of the build specification within the project. Major: Major version component. Minor: Minor version component. Patch: Patch version component. Build: Build number component. Commit: Commit identifier used for the build metadata. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "Build": {
         "type": "number",
@@ -195,7 +195,7 @@
     }
   },
   "InvokeBuildViPackage": {
-    "description": "",
+    "description": "Builds a VI Package using the provided VIPB file and version metadata. MinimumSupportedLVVersion: Minimum LabVIEW version that the package supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). LabVIEWMinorRevision: Minor revision of LabVIEW used to build the package. RelativePath: Path to the project root relative to the working directory. VIPBPath: Path to the VIPB build specification file. Major: Major version component. Minor: Minor version component. Patch: Patch version component. Build: Build number component. Commit: Commit identifier used for the build metadata. DisplayInformationJSON: JSON string containing display information for the package. ReleaseNotesFile: Optional path to a release notes file. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "Build": {
         "type": "number",
@@ -270,7 +270,7 @@
     }
   },
   "InvokeCloseLabVIEW": {
-    "description": "",
+    "description": "Closes any running instance of LabVIEW. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "DryRun": {
         "type": "boolean",
@@ -295,7 +295,7 @@
     }
   },
   "InvokeGenerateReleaseNotes": {
-    "description": "",
+    "description": "Generates a release notes file from the project's metadata. OutputPath: Path where the release notes should be written. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "DryRun": {
         "type": "boolean",
@@ -316,7 +316,7 @@
     }
   },
   "InvokeMissingInProject": {
-    "description": "",
+    "description": "Lists files referenced in a LabVIEW project that are missing on disk. LVVersion: LabVIEW version of the project. Arch: Target architecture or bitness. ProjectFile: Path to the .lvproj file to analyze. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "Arch": {
         "type": "string",
@@ -346,7 +346,7 @@
     }
   },
   "InvokeModifyVIPBDisplayInfo": {
-    "description": "",
+    "description": "Updates display information fields in a VIPB build specification. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Path to the project root relative to the working directory. VIPBPath: Path to the VIPB build specification file. MinimumSupportedLVVersion: Minimum LabVIEW version that the package supports. LabVIEWMinorRevision: Minor revision of LabVIEW used for the build. Major: Major version component. Minor: Minor version component. Patch: Patch version component. Build: Build number component. Commit: Commit identifier used for the build metadata. DisplayInformationJSON: JSON string containing display information for the package. ReleaseNotesFile: Optional path to a release notes file. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "Build": {
         "type": "number",
@@ -421,7 +421,7 @@
     }
   },
   "InvokePrepareLabVIEWSource": {
-    "description": "",
+    "description": "Prepares a LabVIEW project for source distribution. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Path to the project root relative to the working directory. LabVIEW_Project: Path to the LabVIEW project file. Build_Spec: Name of the build specification within the project. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "Build_Spec": {
         "type": "string",
@@ -461,7 +461,7 @@
     }
   },
   "InvokeRenameFile": {
-    "description": "",
+    "description": "Renames a file on disk. CurrentFilename: Existing path to the file. NewFilename: New path for the file. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "CurrentFilename": {
         "type": "string",
@@ -486,7 +486,7 @@
     }
   },
   "InvokeRestoreSetupLVSource": {
-    "description": "",
+    "description": "Restores the Setup LabVIEW source build specification. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). RelativePath: Path to the project root relative to the working directory. LabVIEW_Project: Path to the LabVIEW project file. Build_Spec: Name of the build specification within the project. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "Build_Spec": {
         "type": "string",
@@ -526,7 +526,7 @@
     }
   },
   "InvokeRevertDevelopmentMode": {
-    "description": "",
+    "description": "Returns a repository to its previous development mode state. RelativePath: Path to the project root relative to the working directory. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "DryRun": {
         "type": "boolean",
@@ -546,7 +546,7 @@
     }
   },
   "InvokeRunPesterTests": {
-    "description": "",
+    "description": "Runs Pester tests located in the specified working directory. WorkingDirectory: Path containing the Pester tests to execute. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "DryRun": {
         "type": "boolean",
@@ -566,7 +566,7 @@
     }
   },
   "InvokeRunUnitTests": {
-    "description": "",
+    "description": "Runs LabVIEW unit tests. MinimumSupportedLVVersion: Minimum LabVIEW version that the project supports. SupportedBitness: Target LabVIEW bitness (32- or 64-bit). DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "DryRun": {
         "type": "boolean",
@@ -591,7 +591,7 @@
     }
   },
   "InvokeSetDevelopmentMode": {
-    "description": "",
+    "description": "Configures the repository for development mode. RelativePath: Path to the project root relative to the working directory. DryRun: If set, prints the command instead of executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "DryRun": {
         "type": "boolean",
@@ -611,7 +611,7 @@
     }
   },
   "Run": {
-    "description": "",
+    "description": "Runs a helper script from the repository's scripts directory. ScriptSegments: Path segments under the scripts folder that locate the target script. Arguments: Hashtable of arguments forwarded to the script. DryRun: If set, writes the command without executing it. gcliPath: Optional path prepended to PATH for locating the g CLI.",
     "parameters": {
       "Arguments": {
         "type": "string",
@@ -636,7 +636,7 @@
     }
   },
   "Set": {
-    "description": "",
+    "description": "Sets the verbosity for informational and verbose messages. Level: Desired log level (ERROR, WARN, INFO, DEBUG).",
     "parameters": {
       "Level": {
         "type": "string",


### PR DESCRIPTION
## Summary
- document dispatcher and helper functions
- regenerate dispatcher registry with descriptions

## Testing
- `npm install`
- `npm run check:node`
- `npm test` *(fails: associates classname with requirement)*
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -CI -Configuration $cfg"` *(fails: New-PesterConfiguration not found)*
- `npm run derive:registry`


------
https://chatgpt.com/codex/tasks/task_e_68a24b9ec5cc8329917256917f6c5d15