### PR TITLE
test: add error handler coverage

### DIFF
--- a/scripts/__tests__/error-handler.test.js
+++ b/scripts/__tests__/error-handler.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { formatError } from '../error-handler.ts';
+
+test('formatError handles real Error objects', () => {
+  const err = new Error('boom');
+  const result = formatError(err);
+  assert.strictEqual(result, err.stack);
+});
+
+test('formatError handles plain objects', () => {
+  const obj = { message: 'oops' };
+  const result = formatError(obj);
+  assert.strictEqual(result, JSON.stringify(obj));
+});
+
+test('formatError handles primitives', () => {
+  assert.strictEqual(formatError(42), '42');
+});
+
+test('formatError handles unstringifiable values', () => {
+  const obj = {};
+  obj.self = obj;
+  obj.toString = () => { throw new Error('fail'); };
+  const result = formatError(obj);
+  assert.strictEqual(result, 'Unknown error');
+});


### PR DESCRIPTION
## Summary
- add unit tests for `formatError` covering Error objects, plain objects, primitives, and unstringifiable values

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "\$cfg = New-PesterConfiguration; \$cfg.Run.Path = './tests/pester'; \$cfg.TestResult.Enabled = \$false; Invoke-Pester -Configuration \$cfg"` *(fails: Parameter set cannot be resolved using the specified named parameters)*


------
https://chatgpt.com/codex/tasks/task_e_68a2515f728c8329b7b02152ea83f9be