### PR TITLE
fix: handle invalid requirements mapping

### DIFF
--- a/scripts/__tests__/generate-ci-summary.test.js
+++ b/scripts/__tests__/generate-ci-summary.test.js
@@ -57,6 +57,27 @@ test('associates classname with requirement', async () => {
   await fs.rm(dir, { recursive: true, force: true });
 });
 
+test('loadRequirements logs warning on invalid JSON', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'req-'));
+  const badPath = path.join(dir, 'bad.json');
+  await fs.writeFile(badPath, '{');
+  const tmpSummary = path.join(dir, 'summary.md');
+  process.env.GITHUB_STEP_SUMMARY = tmpSummary;
+  let warned = '';
+  const origWarn = console.warn;
+  console.warn = (msg, ...args) => {
+    warned += String(msg);
+    if (args.length) warned += ' ' + args.join(' ');
+  };
+  const { map, meta } = await loadRequirements(badPath);
+  console.warn = origWarn;
+  delete process.env.GITHUB_STEP_SUMMARY;
+  await fs.rm(dir, { recursive: true, force: true });
+  assert.deepEqual(map, {});
+  assert.deepEqual(meta, {});
+  assert.match(warned, /Failed to load requirements mapping/);
+});
+
 test('collectTestCases uses machine-name property for owner', async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'owner-'));
   const xmlProp = `<testsuite><testcase name="foo" time="0"><properties><property name="machine-name" value="ci-bot"/></properties></testcase></testsuite>`;

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -63,7 +63,10 @@ export async function loadRequirements(mappingFile: string) {
       }
     }
     return { map, meta };
-  } catch {
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`Failed to load requirements mapping from ${mappingFile}: ${msg}`);
+    await writeErrorSummary(err);
     return { map: {}, meta: {} };
   }
 }


### PR DESCRIPTION
## Summary
- warn and summarize when failing to parse requirement mappings
- add test to verify warning on invalid JSON

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'` *(fails: Expected 0, but got 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a2536468b083299604a26c7f382262