### PR TITLE
Handle malformed JUnit XML

### DIFF
--- a/scripts/__tests__/junit-parser.test.js
+++ b/scripts/__tests__/junit-parser.test.js
@@ -24,6 +24,7 @@ const xml = `<?xml version="1.0" encoding="utf-8"?>
 const xmlMissing = `<testsuites><testsuite><testcase /></testsuite></testsuites>`;
 
 const xmlExtra = `<testsuites name="X" tests="0" errors="0" failures="0" disabled="0" time="0"><testsuite name="S" tests="0" errors="0" failures="0" skipped="0" disabled="0" hostname="h" id="1" package="p" time="0"><testcase name="t" foo="bar" time="0"/></testsuite></testsuites>`;
+const xmlBad = `<testsuites><testsuite>`;
 
 test('[REQ-023] parses nested JUnit structures', async () => {
   const report = await parseJUnit(xml);
@@ -85,4 +86,8 @@ test('[REQ-031] validates missing fields', async () => {
 test('[REQ-032] preserves unknown attributes', async () => {
   const report = await parseJUnit(xmlExtra);
   assert.strictEqual(report.suites[0].testcases[0].attributes.foo, 'bar');
+});
+
+test('[REQ-033] throws error for malformed XML', async () => {
+  await assert.rejects(() => parseJUnit(xmlBad), { message: 'Invalid JUnit XML' });
 });

--- a/scripts/junit-parser.ts
+++ b/scripts/junit-parser.ts
@@ -31,7 +31,12 @@ function extractAttributes(obj: any): Record<string, string> {
 }
 
 export async function parseJUnit(xml: string): Promise<JUnitReport> {
-  const parsed = await parseStringPromise(xml, { explicitArray: false, mergeAttrs: true });
+  let parsed;
+  try {
+    parsed = await parseStringPromise(xml, { explicitArray: false, mergeAttrs: true });
+  } catch {
+    throw new Error('Invalid JUnit XML');
+  }
   const root = parsed.testsuites ?? parsed.testsuite;
   const reportAttrs = extractAttributes(root);
   const rawSuites = root.testsuite


### PR DESCRIPTION
## Summary
- raise a clear `Invalid JUnit XML` error when `parseStringPromise` fails in the JUnit parser
- test parsing with malformed XML to confirm the new error message

## Testing
- `npm run check:node`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command 'Invoke-Pester -CI -Script ./tests/pester'` *(fails: Expected 0, but got 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a2557f17f883298bcf8e896be611cb