### PR TITLE
docs: add run-pester-tests and setup-mkdocs action docs

### DIFF
--- a/docs/action-call-reference.md
+++ b/docs/action-call-reference.md
@@ -184,6 +184,16 @@ See [revert-development-mode](actions/revert-development-mode.md) for all parame
     relative_path: '.'
 ```
 
+## run-pester-tests
+
+See [run-pester-tests](actions/run-pester-tests.md) for all parameters.
+
+```yaml
+- uses: LabVIEW-Community-CI-CD/open-source-actions/run-pester-tests@v1
+  with:
+    working_directory: '.'
+```
+
 ## run-unit-tests
 
 See [run-unit-tests](actions/run-unit-tests.md) for all parameters.
@@ -203,4 +213,12 @@ See [set-development-mode](actions/set-development-mode.md) for all parameters.
 - uses: LabVIEW-Community-CI-CD/open-source-actions/set-development-mode@v1
   with:
     relative_path: '.'
+```
+
+## setup-mkdocs
+
+See [setup-mkdocs](actions/setup-mkdocs.md) for all parameters.
+
+```yaml
+- uses: LabVIEW-Community-CI-CD/open-source-actions/setup-mkdocs@v1
 ```

--- a/docs/actions/run-pester-tests.md
+++ b/docs/actions/run-pester-tests.md
@@ -1,0 +1,53 @@
+# run-pester-tests
+
+## Purpose
+
+Run PowerShell Pester tests in a repository.
+
+## Parameters
+
+Common parameters are described in [Common parameters](../common-parameters.md).
+
+### Required
+
+- **WorkingDirectory** (`string`): Path to the repository containing tests under `tests/pester`.
+
+### Optional
+
+None.
+
+## CLI example
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-pester-tests -ArgsJson '{
+  "WorkingDirectory": "."
+}'
+```
+
+## GitHub Action inputs
+
+GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).
+
+| Input | CLI parameter | Description |
+| --- | --- | --- |
+| `working_directory` | `WorkingDirectory` | Directory containing the repository under test. |
+| `log_level` | `LogLevel` | Verbosity level (ERROR\|WARN\|INFO\|DEBUG). |
+| `dry_run` | `DryRun` | If true, simulate the action without side effects. |
+
+## GitHub Action example
+
+```yaml
+- name: Run Pester tests
+  uses: LabVIEW-Community-CI-CD/open-source-actions/run-pester-tests@v1
+  with:
+    working_directory: '.'
+```
+
+## Return Codes
+
+- `0` – all tests passed
+- non‑zero – tests failed or Pester error
+
+See [run-pester-tests/action.yml](../../run-pester-tests/action.yml) and [scripts/run-pester-tests/RunPesterTests.ps1](../../scripts/run-pester-tests/RunPesterTests.ps1) for implementation details.
+
+For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).

--- a/docs/actions/setup-mkdocs.md
+++ b/docs/actions/setup-mkdocs.md
@@ -1,0 +1,29 @@
+# setup-mkdocs
+
+## Purpose
+
+Install a pinned MkDocs with caching.
+
+## Parameters
+
+None.
+
+## GitHub Action inputs
+
+This action has no inputs.
+
+## GitHub Action example
+
+```yaml
+- name: Setup MkDocs
+  uses: LabVIEW-Community-CI-CD/open-source-actions/setup-mkdocs@v1
+```
+
+## Return Codes
+
+- `0` – MkDocs installed
+- non‑zero – install failed
+
+See [setup-mkdocs/action.yml](../../setup-mkdocs/action.yml) for implementation details.
+
+For troubleshooting tips, see the [troubleshooting guide](../troubleshooting.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,8 +29,10 @@ Open Source LabVIEW Actions unifies LabVIEW CI/CD scripts behind a single PowerS
 | [rename-file](actions/rename-file.md) | Rename a file if it exists. |
 | [restore-setup-lv-source](actions/restore-setup-lv-source.md) | Restore the LabVIEW source setup by unzipping the LabVIEW Icon API and removing the INI token. |
 | [revert-development-mode](actions/revert-development-mode.md) | Restore the repository from development mode by restoring packaged sources and closing LabVIEW. |
+| [run-pester-tests](actions/run-pester-tests.md) | Run PowerShell Pester tests in a repository. |
 | [run-unit-tests](actions/run-unit-tests.md) | Run LabVIEW unit tests via the LabVIEW Unit Test Framework CLI and report pass/fail/error using standard exit codes. |
 | [set-development-mode](actions/set-development-mode.md) | Configure the repository for development mode by removing packed libraries, adding tokens, preparing sources, and closing LabVIEW. |
+| [setup-mkdocs](actions/setup-mkdocs.md) | Install a pinned MkDocs with caching. |
 
 ## Workflow Examples
 

--- a/docs/workflows/run-pester-tests.md
+++ b/docs/workflows/run-pester-tests.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Run Pester tests in a target repository by dispatching the `run-pester-tests` action through `Invoke-OSAction.ps1`.
+Run Pester tests in a target repository by dispatching the [`run-pester-tests`](../actions/run-pester-tests.md) action through `Invoke-OSAction.ps1`.
 
 ## Inputs
 


### PR DESCRIPTION
## Summary
- document run-pester-tests action and link to its script
- add setup-mkdocs action docs
- reference new actions from index, call reference, and workflow docs

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -CI -Configuration $cfg"` *(fails: Parameter set cannot be resolved / missing paths)*

------
https://chatgpt.com/codex/tasks/task_e_68a25e018c6883298be6b71aba9d4fa6