### PR TITLE
docs: remove deprecated Pester CI flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,4 +14,4 @@
 - Run `npm run lint:md` to lint Markdown files.
 - Run `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')` to verify links.
 - Run `actionlint` to validate GitHub Actions workflows.
-- Run `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -CI -Configuration $cfg"` (XML output is intentionally disabled).
+- Run `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg"` (XML output is intentionally disabled).

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Pester tests cover the dispatcher and helper modules. See [docs/testing-pester.m
 $cfg = New-PesterConfiguration
 $cfg.Run.Path = './tests/pester'
 $cfg.TestResult.Enabled = $false
-Invoke-Pester -CI -Configuration $cfg
+Invoke-Pester -Configuration $cfg
 ```
 
 XML test result output is intentionally disabled.

--- a/docs/testing-pester.md
+++ b/docs/testing-pester.md
@@ -23,7 +23,7 @@ The helper points at the **labview-icon-editor** project. This open-source repos
    $cfg = New-PesterConfiguration
    $cfg.Run.Path = './tests/pester'
    $cfg.TestResult.Enabled = $false
-   Invoke-Pester -CI -Configuration $cfg
+   Invoke-Pester -Configuration $cfg
    ```
 
    XML test result output is intentionally disabled.

--- a/scripts/run-pester-tests/RunPesterTests.ps1
+++ b/scripts/run-pester-tests/RunPesterTests.ps1
@@ -3,7 +3,7 @@
     Run Pester tests located in a repository.
 
 .DESCRIPTION
-    Invokes Pester in CI mode against the tests under the provided working directory.
+    Invokes Pester against the tests under the provided working directory.
 
 .PARAMETER WorkingDirectory
     Path to the repository containing tests under `tests/pester`.
@@ -29,7 +29,7 @@ $cfg.TestResult.Enabled = $false
 $ansiPattern = '\x1B\[[0-9;]*[A-Za-z]'
 
 $output = & {
-    Invoke-Pester -CI -Configuration $cfg 2>&1
+    Invoke-Pester -Configuration $cfg 2>&1
 }
 $exitCode = $LASTEXITCODE
 $output | ForEach-Object { $_ -replace $ansiPattern, '' }

--- a/tests/pester/Dispatcher.DryRun.Tests.ps1
+++ b/tests/pester/Dispatcher.DryRun.Tests.ps1
@@ -5,7 +5,7 @@ $env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::Path
 #   $cfg = New-PesterConfiguration
 #   $cfg.Run.Path = './tests/pester'
 #   $cfg.TestResult.Enabled = $false
-#   Invoke-Pester -CI -Configuration $cfg
+#   Invoke-Pester -Configuration $cfg
 # Requirement: REQ-002 - Dispatcher dry-run mode prints descriptions and warns on unknown arguments without executing actions.
 
 Set-StrictMode -Version Latest

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -5,7 +5,7 @@ $env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::Path
 #   $cfg = New-PesterConfiguration
 #   $cfg.Run.Path = './tests/pester'
 #   $cfg.TestResult.Enabled = $false
-#   Invoke-Pester -CI -Configuration $cfg
+#   Invoke-Pester -Configuration $cfg
 # Requirement: REQ-001 - Dispatcher discovers available actions, describes them, and validates arguments.
 
 Set-StrictMode -Version Latest


### PR DESCRIPTION
## Summary
- drop removed `-CI` flag from Pester commands
- update run-pester-tests script and docs accordingly

## Testing
- `npm run check:node` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg"` *(fails: missing labview-icon-editor project; 32 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a25b7a2334832996c7ff48230c1d5f