### PR TITLE
Add README for run-pester-tests script

### DIFF
--- a/scripts/run-pester-tests/README.md
+++ b/scripts/run-pester-tests/README.md
@@ -1,0 +1,22 @@
+# Run Pester Tests ✅
+
+Invoke **`RunPesterTests.ps1`** to execute PowerShell Pester tests under `tests/pester`.
+For full documentation, see [run-pester-tests action](../../docs/actions/run-pester-tests.md).
+
+## Inputs
+
+| Name | Required | Example | Description |
+|------|----------|---------|-------------|
+| `working_directory` | **Yes** | `.` | Path to the repository containing tests under `tests/pester`. |
+
+## Quick-start
+
+```yaml
+- uses: ./.github/actions/run-pester-tests
+  with:
+    working_directory: '.'
+```
+
+## License
+
+This directory inherits the root repository’s license (MIT, unless otherwise noted).


### PR DESCRIPTION
## Summary
- document `RunPesterTests.ps1` purpose, inputs, and usage

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg"` *(fails: Cannot find path '/workspace/open-source-actions/labview-icon-editor')*

------
https://chatgpt.com/codex/tasks/task_e_68a26205835c8329bbed71800ce40e59