### PR TITLE
fix: remove invalid CI switch from Pester step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,8 @@ jobs:
             $cfg = New-PesterConfiguration
             $cfg.Run.Path = './tests/pester'
             $cfg.TestResult.Enabled = $false
-            Invoke-Pester -CI -Configuration $cfg
+            $cfg.Run.Exit = $true
+            Invoke-Pester -Configuration $cfg
           }
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
## Summary
- remove unsupported `-CI` flag when invoking Pester with a configuration

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'` *(fails: Tests Passed: 79, Failed: 16)*

------
https://chatgpt.com/codex/tasks/task_e_68a267042ffc83299ffd8a9cf147e424