### PR TITLE
Validate LabVIEW Icon Editor path in helper

### DIFF
--- a/tests/pester/Helper/ArgsJson.Tests.ps1
+++ b/tests/pester/Helper/ArgsJson.Tests.ps1
@@ -1,0 +1,25 @@
+#requires -Version 7.0
+$env:PSModulePath = (Join-Path $PSScriptRoot 'Modules') + [System.IO.Path]::PathSeparator + $env:PSModulePath
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'ArgsJson.psm1')
+
+Describe 'Get-LabVIEWIconEditorArgsJson' {
+    It 'throws when LABVIEW_ICON_EDITOR_PATH is invalid' {
+        $orig = $env:LABVIEW_ICON_EDITOR_PATH
+        try {
+            $env:LABVIEW_ICON_EDITOR_PATH = Join-Path $PSScriptRoot 'NoSuchDir'
+            $err = { Get-LabVIEWIconEditorArgsJson } | Should -Throw -PassThru
+            $err.Exception.Message | Should -Match 'Clone.*LABVIEW_ICON_EDITOR_PATH'
+        }
+        finally {
+            if ($null -eq $orig) {
+                Remove-Item Env:LABVIEW_ICON_EDITOR_PATH -ErrorAction SilentlyContinue
+            } else {
+                $env:LABVIEW_ICON_EDITOR_PATH = $orig
+            }
+        }
+    }
+}
+

--- a/tests/pester/Helper/ArgsJson.psm1
+++ b/tests/pester/Helper/ArgsJson.psm1
@@ -15,6 +15,10 @@ function Get-LabVIEWIconEditorArgsJson {
         throw 'Unsupported platform'
     }
 
+    if (-not (Test-Path -Path $workingDir)) {
+        throw 'labview-icon-editor repository not found. Clone https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor or set LABVIEW_ICON_EDITOR_PATH to its location.'
+    }
+
     $args = @{
         MinimumSupportedLVVersion = '2021'
         SupportedBitness          = '64'


### PR DESCRIPTION
## Summary
- ensure `Get-LabVIEWIconEditorArgsJson` throws when the LabVIEW Icon Editor repo is missing
- add test covering invalid `LABVIEW_ICON_EDITOR_PATH`

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint` *(fails: command not found)*
- `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg"` *(fails: 16 failed, 23 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a26abfc7f483298dc5655a92ef73ea