### PR TITLE
docs: document Pester setup

### DIFF
--- a/docs/testing-pester.md
+++ b/docs/testing-pester.md
@@ -1,5 +1,37 @@
 # Pester Testing
 
+## Setup
+
+Clone the [`labview-icon-editor`](https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor) repository under
+`open-source-actions/labview-icon-editor`:
+
+```bash
+git clone https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor.git labview-icon-editor
+```
+
+Alternatively, set `LABVIEW_ICON_EDITOR_PATH` to the location of an existing clone:
+
+```bash
+export LABVIEW_ICON_EDITOR_PATH=/path/to/labview-icon-editor
+```
+
+Required tooling:
+
+- PowerShell 7.5.1
+- Node.js 24 or newer
+- [`actionlint`](https://github.com/rhysd/actionlint)
+
+Sample command sequence to run the suite:
+
+```powershell
+npm install
+actionlint
+$cfg = New-PesterConfiguration
+$cfg.Run.Path = './tests/pester'
+$cfg.TestResult.Enabled = $false
+Invoke-Pester -Configuration $cfg
+```
+
 ## Canonical argument helper
 
 Pester tests share a small helper module, `tests/pester/Helper/ArgsJson.psm1`, which exposes `Get-LabVIEWIconEditorArgsJson`. The function returns a canonical set of dispatcher arguments and the project root so every test starts from the same baseline. Using the helper avoids repeating boilerplate and keeps tests resilient to environment differences.


### PR DESCRIPTION
## Summary
- document how to configure labview-icon-editor for Pester tests
- note required tooling and show commands to run the suite

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command 'Import-Module Pester; $cfg=New-PesterConfiguration; $cfg.Run.Path="./tests/pester"; $cfg.TestResult.Enabled=$false; Invoke-Pester -Configuration $cfg'` *(fails: labview-icon-editor repository not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a26d847104832981262d4bc600253d