### PR TITLE
Add self-hosted missing-in-project workflow

### DIFF
--- a/.github/workflows/missing-in-project-self-hosted.yml
+++ b/.github/workflows/missing-in-project-self-hosted.yml
@@ -1,0 +1,26 @@
+name: Missing in project (self-hosted test)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  missing-in-project:
+    runs-on: [self-hosted, icon-editor-windows]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: LabVIEW-Community-CI-CD/labview-icon-editor
+          path: ../../labview-icon-editor/labview-icon-editor
+      - name: Run missing-in-project action
+        uses: ./missing-in-project/action.yml
+        with:
+          lv_version: '2021'
+          arch: '64'
+          project_file: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\source\\lv_icon.lvproj'
+          relative_path: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor'
+      - name: Upload missing findings
+        uses: actions/upload-artifact@v4
+        with:
+          name: missing-files
+          path: 'C:\\actions-runner\\_work\\open-source-actions\\open-source-actions\\scripts\\missing-in-project\\missing_files.txt'


### PR DESCRIPTION
## Summary
- add self-hosted workflow to run missing-in-project check and upload findings

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'` *(fails: labview-icon-editor repository not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a270e787c483298757730f434e77f5