### PR TITLE
test: add self-hosted workflows for additional actions

### DIFF
--- a/.github/workflows/add-token-to-labview-self-hosted.yml
+++ b/.github/workflows/add-token-to-labview-self-hosted.yml
@@ -1,0 +1,25 @@
+name: Add token to LabVIEW (self-hosted test)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  add-token:
+    runs-on: [self-hosted, icon-editor-windows]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: LabVIEW-Community-CI-CD/labview-icon-editor
+          path: ../../labview-icon-editor/labview-icon-editor
+      - name: Run add-token-to-labview action
+        uses: ./add-token-to-labview/action.yml
+        with:
+          minimum_supported_lv_version: '2021'
+          supported_bitness: '64'
+          relative_path: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor'
+      - name: Upload token artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: token-artifact
+          path: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\LabVIEW.ini'

--- a/.github/workflows/build-vi-package-self-hosted.yml
+++ b/.github/workflows/build-vi-package-self-hosted.yml
@@ -1,0 +1,33 @@
+name: Build VI package (self-hosted test)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-vi-package:
+    runs-on: [self-hosted, icon-editor-windows]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: LabVIEW-Community-CI-CD/labview-icon-editor
+          path: ../../labview-icon-editor/labview-icon-editor
+      - name: Run build-vi-package action
+        uses: ./build-vi-package/action.yml
+        with:
+          minimum_supported_lv_version: '2021'
+          supported_bitness: '64'
+          labview_minor_revision: '0'
+          relative_path: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor'
+          vipb_path: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\source\\lv_icon.vipb'
+          major: '1'
+          minor: '0'
+          patch: '0'
+          build: '1'
+          commit: 'abcdef'
+          display_information_json: '{"Name":"Test"}'
+      - name: Upload VI package
+        uses: actions/upload-artifact@v4
+        with:
+          name: vi-package
+          path: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\build\\lv_icon.vip'

--- a/.github/workflows/modify-vipb-display-info-self-hosted.yml
+++ b/.github/workflows/modify-vipb-display-info-self-hosted.yml
@@ -1,0 +1,33 @@
+name: Modify VIPB display info (self-hosted test)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  modify-vipb-display-info:
+    runs-on: [self-hosted, icon-editor-windows]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: LabVIEW-Community-CI-CD/labview-icon-editor
+          path: ../../labview-icon-editor/labview-icon-editor
+      - name: Run modify-vipb-display-info action
+        uses: ./modify-vipb-display-info/action.yml
+        with:
+          supported_bitness: '64'
+          relative_path: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor'
+          vipb_path: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\source\\lv_icon.vipb'
+          minimum_supported_lv_version: '2021'
+          labview_minor_revision: '0'
+          major: '1'
+          minor: '0'
+          patch: '0'
+          build: '1'
+          commit: 'abcdef'
+          display_information_json: '{"Name":"Test"}'
+      - name: Upload vipb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vipb-display-info
+          path: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\source\\lv_icon.vipb'

--- a/.github/workflows/prepare-labview-source-self-hosted.yml
+++ b/.github/workflows/prepare-labview-source-self-hosted.yml
@@ -1,0 +1,27 @@
+name: Prepare LabVIEW source (self-hosted test)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  prepare-labview-source:
+    runs-on: [self-hosted, icon-editor-windows]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: LabVIEW-Community-CI-CD/labview-icon-editor
+          path: ../../labview-icon-editor/labview-icon-editor
+      - name: Run prepare-labview-source action
+        uses: ./prepare-labview-source/action.yml
+        with:
+          minimum_supported_lv_version: '2021'
+          supported_bitness: '64'
+          relative_path: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor'
+          labview_project: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\source\\lv_icon.lvproj'
+          build_spec: 'PackageSource'
+      - name: Upload prepared source
+        uses: actions/upload-artifact@v4
+        with:
+          name: prepared-source
+          path: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\prepared-source.zip'

--- a/.github/workflows/rename-file-self-hosted.yml
+++ b/.github/workflows/rename-file-self-hosted.yml
@@ -1,0 +1,24 @@
+name: Rename file (self-hosted test)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  rename-file:
+    runs-on: [self-hosted, icon-editor-windows]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: LabVIEW-Community-CI-CD/labview-icon-editor
+          path: ../../labview-icon-editor/labview-icon-editor
+      - name: Run rename-file action
+        uses: ./rename-file/action.yml
+        with:
+          current_filename: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\README.md'
+          new_filename: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\README-renamed.md'
+      - name: Upload renamed file
+        uses: actions/upload-artifact@v4
+        with:
+          name: renamed-file
+          path: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\README-renamed.md'

--- a/.github/workflows/restore-setup-lv-source-self-hosted.yml
+++ b/.github/workflows/restore-setup-lv-source-self-hosted.yml
@@ -1,0 +1,29 @@
+name: Restore setup LV source (self-hosted test)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  restore-setup-lv-source:
+    runs-on: [self-hosted, icon-editor-windows]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: LabVIEW-Community-CI-CD/labview-icon-editor
+          path: ../../labview-icon-editor/labview-icon-editor
+      - name: Run restore-setup-lv-source action
+        uses: ./restore-setup-lv-source/action.yml
+        with:
+          minimum_supported_lv_version: '2021'
+          supported_bitness: '64'
+          relative_path: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor'
+          labview_project: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\source\\lv_icon.lvproj'
+          build_spec: 'PackageSource'
+        env:
+          GCLI_SUPPRESS_PROMPTS: '1'
+      - name: Upload restore logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: restore-logs
+          path: 'C:\\actions-runner\\_work\\labview-icon-editor\\labview-icon-editor\\restore.log'

--- a/.github/workflows/revert-development-mode-self-hosted.yml
+++ b/.github/workflows/revert-development-mode-self-hosted.yml
@@ -1,0 +1,19 @@
+name: Revert development mode (self-hosted test)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  revert-development-mode:
+    runs-on: [self-hosted, icon-editor-windows]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run revert-development-mode action
+        uses: ./revert-development-mode/action.yml
+        with:
+          relative_path: 'C:\\actions-runner\\_work\\open-source-actions\\open-source-actions'
+      - name: Upload config artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: devmode-config
+          path: 'C:\\actions-runner\\_work\\open-source-actions\\open-source-actions\\devmode-config.txt'

--- a/.github/workflows/set-development-mode-self-hosted.yml
+++ b/.github/workflows/set-development-mode-self-hosted.yml
@@ -1,0 +1,23 @@
+name: Set development mode (self-hosted test)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  set-development-mode:
+    runs-on: [self-hosted, icon-editor-windows]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run set-development-mode action
+        uses: ./set-development-mode/action.yml
+        with:
+          relative_path: 'C:\\actions-runner\\_work\\open-source-actions\\open-source-actions'
+          gcli_path: 'g-cli.exe'
+          working_directory: 'C:\\actions-runner\\_work\\open-source-actions\\open-source-actions'
+          log_level: 'INFO'
+          dry_run: 'true'
+      - name: Upload dev mode logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-mode-config
+          path: 'C:\\actions-runner\\_work\\open-source-actions\\open-source-actions\\dev-mode.log'


### PR DESCRIPTION
## Summary
- add self-hosted test workflow for add-token-to-labview
- cover modify-vipb-display-info and build-vi-package with self-hosted workflows
- add additional self-hosted workflows for prepare-labview-source, rename-file, restore-setup-lv-source, revert-development-mode, and set-development-mode

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = ''./tests/pester''; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'` *(fails: labview-icon-editor repository not found, build spec mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68a26f7c99188329a46badd1731ff217