### PR TITLE
Limit dry-run exclusions to REQIE requirements

### DIFF
--- a/requirements.json
+++ b/requirements.json
@@ -6,11 +6,11 @@
       "runner_type": "integration",
       "skip_dry_run": false
     },
-    "self-hosted-windows-lv": {
+      "self-hosted-windows-lv": {
       "owner": "self-hosted-windows-lv",
       "runner_label": "self-hosted-windows-lv",
       "runner_type": "integration",
-      "skip_dry_run": true
+      "skip_dry_run": false
     }
   },
   "requirements": [
@@ -265,6 +265,7 @@
     {
       "id": "REQIE-001",
       "description": "PreSequence: The sequencer shall enumerate and record the build matrix used by the workflow (LabVIEW versions and bitness). Acceptance: a 'matrix.json' file exists listing each tuple {\"lv-version\": \"2021\"|\"2023\", \"bitness\": \"32\"|\"64\"} with at least [ [\"2021\",\"32\"], [\"2021\",\"64\"], [\"2023\",\"64\"] ].",
+      "skip_dry_run": true,
       "tests": [
         "BuildProfile1.IconEditor.PreSequence.matrix-enumeration"
       ]
@@ -272,6 +273,7 @@
     {
       "id": "REQIE-002",
       "description": "Setup: For each matrix entry, the sequencer shall apply VIPC dependencies using the canonical action inputs (minimum_supported_lv_version, vip_lv_version, supported_bitness, relative_path). Evidence: a 'vipc-apply.json' summary per matrix entry capturing inputs, start/end timestamps, exit code, and status. Acceptance: all entries report exit_code == 0 and status == 'success'.",
+      "skip_dry_run": true,
       "tests": [
         "BuildProfile1.IconEditor.Setup.apply-vipc-succeeds"
       ]
@@ -279,6 +281,7 @@
     {
       "id": "REQIE-003",
       "description": "Setup: The sequencer shall compute and persist semantic version information. Evidence: a 'version.json' containing VERSION, MAJOR, MINOR, PATCH, BUILD, IS_PRERELEASE and the commit SHA used. Acceptance: VERSION conforms to SemVer and all numeric components are present.",
+      "skip_dry_run": true,
       "tests": [
         "BuildProfile1.IconEditor.Setup.version-outputs-captured"
       ]
@@ -286,6 +289,7 @@
     {
       "id": "REQIE-004",
       "description": "Setup: The 'missing-in-project' check shall be executed for the specified LabVIEW version(s) and both 32-bit and 64-bit bitness as applicable. Evidence: 'missing-in-project.json' including project-file, lv-version, bitness, and result. Acceptance: result == 'present' for expected module paths.",
+      "skip_dry_run": true,
       "tests": [
         "BuildProfile1.IconEditor.Setup.missing-in-project-matrix"
       ]
@@ -293,6 +297,7 @@
     {
       "id": "REQIE-005",
       "description": "Main: Unit tests shall be executed (Pester) across the configured matrix. Evidence: a 'pester-summary.json' file containing total, passed, failed, skipped, duration_ms, and per-test results; XML output is not required. Acceptance: failed == 0 and total >= 1.",
+      "skip_dry_run": true,
       "tests": [
         "BuildProfile1.IconEditor.Main.unit-tests-pass"
       ]
@@ -300,6 +305,7 @@
     {
       "id": "REQIE-006",
       "description": "Main: Build Packed Libraries (PPL) shall succeed for both 32-bit and 64-bit targets. Evidence: existence of 'resource/plugins/lv_icon_x86.lvlibp' and 'resource/plugins/lv_icon_x64.lvlibp' and a 'ppl.hash' file containing SHA256 for each artifact. Acceptance: non-zero artifact sizes and matching SHA256 re-computation.",
+      "skip_dry_run": true,
       "tests": [
         "BuildProfile1.IconEditor.Main.ppl-built-and-hashed",
         "BuildProfile1.IconEditor.Main.artifact-size-nonzero"
@@ -308,6 +314,7 @@
     {
       "id": "REQIE-007",
       "description": "Main: Renaming and artifact upload steps shall complete. Evidence: an 'artifact-manifest.json' listing uploaded artifact names ('lv_icon_x86.lvlibp', 'lv_icon_x64.lvlibp'), paths, and sizes. Acceptance: manifest entries match on-disk files and GitHub Artifacts report success.",
+      "skip_dry_run": true,
       "tests": [
         "BuildProfile1.IconEditor.Main.artifacts-renamed-and-uploaded"
       ]
@@ -315,6 +322,7 @@
     {
       "id": "REQIE-008",
       "description": "Main: The workflow shall generate a VI Package (.vip) using the prescribed actions and inputs. Evidence: 'vi-package.hash' (SHA256 of produced .vip), and a 'vi-package.json' summarizing package metadata (name, version, company, build). Acceptance: at least one .vip exists, size > 0, and hash is recorded.",
+      "skip_dry_run": true,
       "tests": [
         "BuildProfile1.IconEditor.Main.vi-package-built-and-hashed"
       ]
@@ -322,6 +330,7 @@
     {
       "id": "REQIE-009",
       "description": "Main: The workflow shall produce a display information JSON for the VI Package and inject it prior to packaging. Evidence: 'display-info.json' containing the exact keys used by the action (Package Version.major/minor/patch/build, Product/Company/Author fields, etc.). Acceptance: all required keys exist and reflect the computed version (REQ-011).",
+      "skip_dry_run": true,
       "tests": [
         "BuildProfile1.IconEditor.Main.display-info-generated"
       ]
@@ -329,6 +338,7 @@
     {
       "id": "REQIE-010",
       "description": "Cleanup: The workflow shall terminate any LabVIEW processes via the 'close-labview' step for each applicable bitness. Evidence: 'close-labview.log' including bitness, attempts, and final process list. Acceptance: no LabVIEW process remains after the step.",
+      "skip_dry_run": true,
       "tests": [
         "BuildProfile1.IconEditor.Cleanup.labview-closed"
       ]
@@ -336,6 +346,7 @@
     {
       "id": "REQIE-011",
       "description": "PostSequence: The sequencer shall assemble a canonical single-line CI evidence string summarizing statuses and key facts for REQ-001..REQ-018. The string SHALL be a minified JSON assigned to a step output named 'CI_EVIDENCE' and saved as 'ci_evidence.txt'. Acceptance: the string parses as JSON and includes {\"pipeline\":\"IconEditor\", \"git_sha\":..., \"matrix\":[...], \"version\":{...}, \"artifacts\":{...}, \"req_status\":{\"REQ-001\":\"PASS\"|\"FAIL\", ...}}.",
+      "skip_dry_run": true,
       "tests": [
         "BuildProfile1.IconEditor.PostSequence.ci-evidence-assembled",
         "BuildProfile1.IconEditor.PostSequence.ci-evidence-output"
@@ -344,6 +355,7 @@
     {
       "id": "REQIE-012",
       "description": "PostSequence: The CI evidence string shall be logged succinctly to the job summary and made available to downstream jobs via $GITHUB_OUTPUT. Evidence: the step output 'CI_EVIDENCE' is present and a 'summary.md' contains a redacted preview. Acceptance: dependent jobs can read 'needs.<job>.outputs.CI_EVIDENCE' and parse it successfully.",
+      "skip_dry_run": true,
       "tests": [
         "BuildProfile1.IconEditor.PostSequence.ci-evidence-published"
       ]


### PR DESCRIPTION
## Summary
- allow self-hosted Windows runner to participate in dry runs
- mark REQIE-001 through REQIE-012 to skip execution during dry runs

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'` *(fails: labview-icon-editor repository not found; expected regex mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68a278b8083c8329ae35caaf362c0d6b