### PR TITLE
feat: simplify YAML parsing in dispatcher

### DIFF
--- a/actions/Invoke-OSAction.ps1
+++ b/actions/Invoke-OSAction.ps1
@@ -148,25 +148,28 @@ try {
     if (-not (Test-Path $ArgsFile)) { throw "ArgsFile '$ArgsFile' not found" }
     $ext = [System.IO.Path]::GetExtension($ArgsFile).ToLowerInvariant()
     $content = Get-Content -Path $ArgsFile -Raw
-    try {
-      switch ($ext) {
-        '.json' {
-          $fileArgs = ConvertFrom-Json -InputObject $content -AsHashtable -ErrorAction Stop
+      try {
+        switch ($ext) {
+          '.json' {
+            $fileArgs = ConvertFrom-Json -InputObject $content -AsHashtable -ErrorAction Stop
+          }
+          '.yaml' {
+            $fileArgs = ConvertFrom-Yaml -Yaml $content -AsHashtable -ErrorAction Stop
+          }
+          '.yml' {
+            $fileArgs = ConvertFrom-Yaml -Yaml $content -AsHashtable -ErrorAction Stop
+          }
+          default {
+            throw "Unsupported ArgsFile extension '$ext'. Use .json, .yaml, or .yml."
+          }
         }
-        '.yaml' {
-          $fileArgs = ConvertFrom-Yaml -Yaml $content -ErrorAction Stop | ConvertTo-Json -Depth 32 | ConvertFrom-Json -AsHashtable
-        }
-        '.yml' {
-          $fileArgs = ConvertFrom-Yaml -Yaml $content -ErrorAction Stop | ConvertTo-Json -Depth 32 | ConvertFrom-Json -AsHashtable
-        }
-        default {
-          throw "Unsupported ArgsFile extension '$ext'. Use .json, .yaml, or .yml."
+        if ($fileArgs -isnot [hashtable]) {
+          throw 'ArgsFile root node must be a mapping/object'
         }
       }
-    }
-    catch {
-      throw "ArgsFile could not be parsed: $($_.Exception.Message)"
-    }
+      catch {
+        throw "ArgsFile could not be parsed: $($_.Exception.Message)"
+      }
     foreach ($k in $fileArgs.Keys) { $argsHash[$k] = $fileArgs[$k] }
   }
 


### PR DESCRIPTION
## Summary
- use `ConvertFrom-Yaml -AsHashtable` for ArgsFile yaml/yml cases
- validate that YAML args resolve to a mapping

## Testing
- `npm run check:node` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'` *(fails: labview-icon-editor repository not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a0a2f1488329a2746dc495d2c16b