### PR TITLE
Allow Pester helper to run without labview-icon-editor

### DIFF
--- a/docs/testing-pester.md
+++ b/docs/testing-pester.md
@@ -2,18 +2,21 @@
 
 ## Setup
 
-Clone the [`labview-icon-editor`](https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor) repository under
-`open-source-actions/labview-icon-editor`:
+Most tests run without cloning the [`labview-icon-editor`](https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor) repository. The helper defaults to the repository root as the project directory.
+
+Tests that need the example project can either clone it under `open-source-actions/labview-icon-editor`:
 
 ```bash
 git clone https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor.git labview-icon-editor
 ```
 
-Alternatively, set `LABVIEW_ICON_EDITOR_PATH` to the location of an existing clone:
+or set `LABVIEW_ICON_EDITOR_PATH` to the location of an existing clone:
 
 ```bash
 export LABVIEW_ICON_EDITOR_PATH=/path/to/labview-icon-editor
 ```
+
+To enforce that the project exists, set `LABVIEW_ICON_EDITOR_REQUIRED=1` or call `Get-LabVIEWIconEditorArgsJson -RequireProject` in your test.
 
 Required tooling:
 
@@ -38,7 +41,7 @@ Pester tests share a small helper module, `tests/pester/Helper/ArgsJson.psm1`, w
 
 ## labview-icon-editor reference project
 
-The helper points at the **labview-icon-editor** project. This open-source repository is tiny, exercises common LabVIEW project layouts and does not require NI components to execute in dry-run mode. Using it as the reference project gives all tests a consistent, real-world example without adding heavy dependencies.
+When available, the helper points at the **labview-icon-editor** project. This open-source repository is tiny, exercises common LabVIEW project layouts and does not require NI components to execute in dry-run mode. Using it as the reference project gives all tests a consistent, real-world example without adding heavy dependencies.
 
 ## Adding new tests
 

--- a/tests/pester/Helper/ArgsJson.Tests.ps1
+++ b/tests/pester/Helper/ArgsJson.Tests.ps1
@@ -5,6 +5,25 @@ $ErrorActionPreference = 'Stop'
 Import-Module (Join-Path $PSScriptRoot 'ArgsJson.psm1')
 
 Describe 'Get-LabVIEWIconEditorArgsJson' {
+    It 'defaults to repo root when not requiring project' {
+        $orig = $env:LABVIEW_ICON_EDITOR_PATH
+        try {
+            Remove-Item Env:LABVIEW_ICON_EDITOR_PATH -ErrorAction SilentlyContinue
+            $env:LABVIEW_ICON_EDITOR_REQUIRED = $null
+            $params = Get-LabVIEWIconEditorArgsJson
+            $expected = (Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..')).Path
+            $params.WorkingDirectory | Should -Be $expected
+        }
+        finally {
+            if ($null -eq $orig) {
+                Remove-Item Env:LABVIEW_ICON_EDITOR_PATH -ErrorAction SilentlyContinue
+            } else {
+                $env:LABVIEW_ICON_EDITOR_PATH = $orig
+            }
+            Remove-Item Env:LABVIEW_ICON_EDITOR_REQUIRED -ErrorAction SilentlyContinue
+        }
+    }
+
     It 'throws when LABVIEW_ICON_EDITOR_PATH is invalid' {
         $orig = $env:LABVIEW_ICON_EDITOR_PATH
         try {
@@ -21,4 +40,3 @@ Describe 'Get-LabVIEWIconEditorArgsJson' {
         }
     }
 }
-

--- a/tests/pester/Helper/ArgsJson.psm1
+++ b/tests/pester/Helper/ArgsJson.psm1
@@ -1,21 +1,23 @@
 function Get-LabVIEWIconEditorArgsJson {
     [OutputType([pscustomobject])]
-    param()
+    param(
+        [switch]$RequireProject
+    )
 
     $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..')).Path
+
+    $require = $RequireProject -or [bool]$env:LABVIEW_ICON_EDITOR_REQUIRED
+
     if ($env:LABVIEW_ICON_EDITOR_PATH) {
         $workingDir = $env:LABVIEW_ICON_EDITOR_PATH
-    } elseif ($IsWindows) {
-        $workingDir = Join-Path $repoRoot 'labview-icon-editor'
-    } elseif ($IsLinux) {
-        $workingDir = Join-Path $repoRoot 'labview-icon-editor'
-    } elseif ($IsMacOS) {
+        $require = $true
+    } elseif ($require) {
         $workingDir = Join-Path $repoRoot 'labview-icon-editor'
     } else {
-        throw 'Unsupported platform'
+        $workingDir = $repoRoot
     }
 
-    if (-not (Test-Path -Path $workingDir)) {
+    if ($require -and -not (Test-Path -Path $workingDir)) {
         throw 'labview-icon-editor repository not found. Clone https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor or set LABVIEW_ICON_EDITOR_PATH to its location.'
     }
 
@@ -26,7 +28,7 @@ function Get-LabVIEWIconEditorArgsJson {
     }
 
     return [pscustomobject]@{
-        ArgsJson        = ($args | ConvertTo-Json -Compress)
+        ArgsJson         = ($args | ConvertTo-Json -Compress)
         WorkingDirectory = $workingDir
     }
 }


### PR DESCRIPTION
## Summary
- Allow default dispatcher args when labview-icon-editor repo is absent
- Add RequireProject switch and LABVIEW_ICON_EDITOR_REQUIRED env var for strict checks
- Document optional labview-icon-editor usage in Pester guide

## Testing
- `apt-get update && apt-get install -y apt-utils`
- `PATH=/usr/bin:$PATH npm run check:node`
- `PATH=/usr/bin:$PATH npm install`
- `PATH=/usr/bin:$PATH npm test`
- `PATH=/usr/bin:$PATH npm run lint:md`
- `PATH=/usr/bin:$PATH npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `/root/.local/share/mise/installs/go/1.24.3/bin/actionlint`
- `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg"` *(fails: ConvertFrom-Yaml cmdlet missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ad24673c8329bd0ba2ec785b9221