### PR TITLE
Document PowerShell MSI install on Windows runners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,17 @@
 - Install `actionlint` and ensure it is on your `PATH`:
   - `go install github.com/rhysd/actionlint/cmd/actionlint@latest`
 - Ensure PowerShell 7.5.1 is installed and accessible.
+  - Linux runners rely on preinstalled `pwsh`.
+  - On Windows Server 2022 (build 10.0.20348), download the MSI and verify its SHA256 checksum before installing:
+
+    ```powershell
+    $url = 'https://github.com/PowerShell/PowerShell/releases/download/v7.5.1/PowerShell-7.5.1-win-x64.msi'
+    Invoke-WebRequest -Uri $url -OutFile pwsh.msi
+    $expected = (Invoke-WebRequest -Uri "$url.sha256").Content.Split()[0]
+    if ((Get-FileHash pwsh.msi -Algorithm SHA256).Hash -ne $expected) { throw 'Checksum mismatch' }
+    Start-Process msiexec.exe -Wait -ArgumentList '/i', 'pwsh.msi', '/qn', '/norestart'
+    Remove-Item pwsh.msi
+    ```
 - PowerShell 7.5.1 includes native YAML support; external modules such as `powershell-yaml` are no longer required.
 
 ## Testing


### PR DESCRIPTION
## Summary
- detail PowerShell MSI download and checksum verification process for Windows Server 2022 runners
- clarify that Linux runners rely on the preinstalled `pwsh`

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npm run link:check`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'` *(fails: ConvertFrom-Yaml not recognized, 75 passed, 30 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b4fa56f88329881c539860ce6857