### PR TITLE
Remove YAML arg support

### DIFF
--- a/actions/Invoke-OSAction.ps1
+++ b/actions/Invoke-OSAction.ps1
@@ -2,7 +2,7 @@
 param(
   [Parameter(Position=0)] [string] $ActionName,
   [Parameter()] [string] $ArgsJson = '{}',
-  [Parameter()] [hashtable] $ArgsYaml,
+  [Parameter()] [hashtable] $ArgsHashtable,
   [Parameter()] [string] $ArgsFile,
   [Parameter()] [string] $WorkingDirectory,
   [Parameter()] [ValidateSet('ERROR','WARN','INFO','DEBUG')] [string] $LogLevel = 'INFO',
@@ -142,7 +142,7 @@ try {
   if (-not $Registry.Contains($key)) { throw "Unknown ActionName '$ActionName'. Use -ListActions to see options." }
   $funcName = $Registry[$key]
 
-  # Parse ArgsFile/ArgsJson/ArgsYaml → case-insensitive hashtable
+  # Parse ArgsFile/ArgsJson/ArgsHashtable → case-insensitive hashtable
   $argsHash = @{}
   if ($ArgsFile) {
     if (-not (Test-Path $ArgsFile)) { throw "ArgsFile '$ArgsFile' not found" }
@@ -153,14 +153,8 @@ try {
           '.json' {
             $fileArgs = ConvertFrom-Json -InputObject $content -AsHashtable -ErrorAction Stop
           }
-          '.yaml' {
-            $fileArgs = ConvertFrom-Yaml -Yaml $content -AsHashtable -ErrorAction Stop
-          }
-          '.yml' {
-            $fileArgs = ConvertFrom-Yaml -Yaml $content -AsHashtable -ErrorAction Stop
-          }
           default {
-            throw "Unsupported ArgsFile extension '$ext'. Use .json, .yaml, or .yml."
+            throw "Unsupported ArgsFile extension '$ext'. Use .json."
           }
         }
         if ($fileArgs -isnot [hashtable]) {
@@ -193,9 +187,9 @@ try {
     }
     foreach ($k in $jsonHash.Keys) { $argsHash[$k] = $jsonHash[$k] }
   }
-  if ($ArgsYaml) {
-    foreach ($k in $ArgsYaml.Keys) {
-      $argsHash[$k] = $ArgsYaml[$k]
+  if ($ArgsHashtable) {
+    foreach ($k in $ArgsHashtable.Keys) {
+      $argsHash[$k] = $ArgsHashtable[$k]
     }
   }
 


### PR DESCRIPTION
## Summary
- streamline Invoke-OSAction argument parsing to JSON or hashtable inputs

## Testing
- `npm run check:node` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required)*
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = ''./tests/pester''; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'` *(fails: multiple tests due to missing ConvertFrom-Yaml and failing dry run expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68a2bd146e448329a97ad4d200ca6ea5