### PR TITLE
Refactor workflow tests to load preconverted JSON

### DIFF
--- a/.github/workflows/add-token-to-labview-self-hosted.json
+++ b/.github/workflows/add-token-to-labview-self-hosted.json
@@ -1,0 +1,33 @@
+{
+  "name": "Add token to LabVIEW (ubuntu test)",
+  "on": {
+    "workflow_dispatch": null
+  },
+  "jobs": {
+    "add-token": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "name": "Run add-token-to-labview action",
+          "uses": "./add-token-to-labview/action.yml",
+          "with": {
+            "minimum_supported_lv_version": "2021",
+            "supported_bitness": "64",
+            "relative_path": "scripts/add-token-to-labview"
+          }
+        },
+        {
+          "name": "Upload token artifact",
+          "uses": "actions/upload-artifact@v4",
+          "with": {
+            "name": "token-artifact",
+            "path": "scripts/add-token-to-labview/LabVIEW.ini"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.github/workflows/apply-vipc-self-hosted.json
+++ b/.github/workflows/apply-vipc-self-hosted.json
@@ -1,0 +1,28 @@
+{
+  "name": "Apply VIPC (ubuntu test)",
+  "on": {
+    "workflow_dispatch": null
+  },
+  "jobs": {
+    "apply-vipc": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "name": "Run apply-vipc action (dry_run=true)",
+          "uses": "./apply-vipc/action.yml",
+          "with": {
+            "minimum_supported_lv_version": "2021",
+            "vip_lv_version": "2021",
+            "supported_bitness": "64",
+            "relative_path": ".",
+            "vipc_path": "scripts/apply-vipc/runner_dependencies.vipc",
+            "dry_run": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.github/workflows/build-lvlibp-self-hosted.json
+++ b/.github/workflows/build-lvlibp-self-hosted.json
@@ -1,0 +1,40 @@
+{
+  "name": "Build LVLIBP (ubuntu test)",
+  "on": {
+    "workflow_dispatch": null
+  },
+  "jobs": {
+    "build-lvlibp": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "name": "Run build-lvlibp action",
+          "uses": "./build-lvlibp/action.yml",
+          "with": {
+            "minimum_supported_lv_version": "2021",
+            "supported_bitness": "64",
+            "relative_path": "scripts/build-lvlibp",
+            "labview_project": "scripts/build-lvlibp/lv_icon.lvproj",
+            "build_spec": "PackedLib Build",
+            "major": "1",
+            "minor": "0",
+            "patch": "0",
+            "build": "1",
+            "commit": "abcdef"
+          }
+        },
+        {
+          "name": "Upload lvlibp artifact",
+          "uses": "actions/upload-artifact@v4",
+          "with": {
+            "name": "build-lvlibp-artifact",
+            "path": "scripts/build-lvlibp/lv_icon.lvlibp"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.github/workflows/build-self-hosted.json
+++ b/.github/workflows/build-self-hosted.json
@@ -1,0 +1,39 @@
+{
+  "name": "Build (ubuntu test)",
+  "on": {
+    "workflow_dispatch": null
+  },
+  "jobs": {
+    "build": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "name": "Run build action",
+          "uses": "./build/action.yml",
+          "with": {
+            "relative_path": "scripts/build",
+            "major": "1",
+            "minor": "0",
+            "patch": "0",
+            "build": "1",
+            "commit": "abcdef",
+            "labview_minor_revision": "3",
+            "company_name": "Acme Corp",
+            "author_name": "Jane Doe"
+          }
+        },
+        {
+          "name": "Upload build artifact",
+          "uses": "actions/upload-artifact@v4",
+          "with": {
+            "name": "build-artifact",
+            "path": "scripts/build/lv_icon_x64.lvlibp"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.github/workflows/build-vi-package-self-hosted.json
+++ b/.github/workflows/build-vi-package-self-hosted.json
@@ -1,0 +1,41 @@
+{
+  "name": "Build VI package (ubuntu test)",
+  "on": {
+    "workflow_dispatch": null
+  },
+  "jobs": {
+    "build-vi-package": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "name": "Run build-vi-package action",
+          "uses": "./build-vi-package/action.yml",
+          "with": {
+            "minimum_supported_lv_version": "2021",
+            "supported_bitness": "64",
+            "labview_minor_revision": "0",
+            "relative_path": "scripts/build-vi-package",
+            "vipb_path": "scripts/build-vi-package/NI Icon editor.vipb",
+            "major": "1",
+            "minor": "0",
+            "patch": "0",
+            "build": "1",
+            "commit": "abcdef",
+            "display_information_json": "{\"Name\":\"Test\"}"
+          }
+        },
+        {
+          "name": "Upload VI package",
+          "uses": "actions/upload-artifact@v4",
+          "with": {
+            "name": "vi-package",
+            "path": "scripts/build-vi-package/lv_icon.vip"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.github/workflows/ci.json
+++ b/.github/workflows/ci.json
@@ -1,0 +1,196 @@
+{
+  "name": "CI",
+  "on": {
+    "push": {
+      "branches": [
+        "actions"
+      ]
+    },
+    "pull_request": {
+      "branches": [
+        "actions"
+      ]
+    }
+  },
+  "jobs": {
+    "node-ci": {
+      "runs-on": "ubuntu-24.04",
+      "env": {
+        "ARTIFACT_DIR": "artifacts/linux"
+      },
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "uses": "actions/setup-node@v4",
+          "with": {
+            "node-version": 24
+          }
+        },
+        {
+          "run": "npm run check:node"
+        },
+        {
+          "run": "npm install"
+        },
+        {
+          "run": "npm run link:check"
+        },
+        {
+          "run": "npm run test:ci"
+        },
+        {
+          "run": "npm run derive:registry"
+        },
+        {
+          "run": "npm run generate:summary",
+          "env": {
+            "TEST_RESULTS_GLOB": "test-results/*junit*.xml"
+          }
+        },
+        {
+          "uses": "actions/upload-artifact@v4",
+          "if": "always()",
+          "with": {
+            "name": "traceability",
+            "path": "${{ env.ARTIFACT_DIR }}/traceability.*"
+          }
+        },
+        {
+          "uses": "actions/upload-artifact@v4",
+          "if": "always()",
+          "with": {
+            "name": "action-docs",
+            "path": "${{ env.ARTIFACT_DIR }}/action-docs.*"
+          }
+        },
+        {
+          "uses": "actions/upload-artifact@v4",
+          "if": "always()",
+          "with": {
+            "name": "evidence",
+            "path": "${{ env.ARTIFACT_DIR }}/evidence/**",
+            "if-no-files-found": "ignore"
+          }
+        }
+      ]
+    },
+    "ps-ci": {
+      "strategy": {
+        "matrix": {
+          "include": [
+            {
+              "os": "ubuntu-24.04",
+              "runs-on": "ubuntu-24.04",
+              "runner_type": "default"
+            },
+            {
+              "os": "windows-latest",
+              "runs-on": "windows-latest",
+              "runner_type": "integration"
+            }
+          ]
+        }
+      },
+      "runs-on": "${{ matrix.runs-on }}",
+      "env": {
+        "RUNNER_TYPE": "${{ matrix.runner_type }}"
+      },
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "name": "Install PowerShell 7.5.1",
+          "if": "matrix.os == 'windows-latest'",
+          "shell": "pwsh",
+          "run": "$expectedBuild = '10.0.20348'\n$build = (Get-ComputerInfo).OsVersion\nif ($build -ne $expectedBuild) {\n  throw \"Unexpected OS build: $build\"\n}\n$msiUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.5.1/PowerShell-7.5.1-win-x64.msi'\n$msiPath = Join-Path $env:RUNNER_TEMP 'PowerShell-7.5.1-win-x64.msi'\nInvoke-WebRequest -Uri $msiUrl -OutFile $msiPath\n$expectedHash = 'b110eccaf55bb53ae5e6b6de478587ed8203570b0bda9bd374a0998e24d4033a'\n$actualHash = (Get-FileHash $msiPath -Algorithm SHA256).Hash\nif ($actualHash -ne $expectedHash) {\n  throw \"SHA256 mismatch: $actualHash\"\n}\nStart-Process msiexec -Wait -ArgumentList '/i', $msiPath, '/qn', 'ADD_PATH=1'\n$version = (pwsh --version).Trim() -replace '^PowerShell '\nif ($version -ne '7.5.1') {\n  throw \"PowerShell version $version is not 7.5.1\"\n}\n"
+        },
+        {
+          "name": "Capture setup info",
+          "shell": "pwsh",
+          "run": "$data = [ordered]@{\n  'Current runner version' = $env:RUNNER_VERSION\n  'Runner Image'          = $env:ImageOS\n  'ImageVersion'          = $env:ImageVersion\n  'RUNNER_NAME'           = $env:RUNNER_NAME\n  'RUNNER_OS'             = $env:RUNNER_OS\n  'RUNNER_ARCH'           = $env:RUNNER_ARCH\n}\n$file = \"setup-info-${{ matrix.os }}.md\"\n\"was captured from the set up job.\" | Out-File -FilePath $file -Encoding utf8\nforeach ($k in $data.Keys) {\n  if ($data[$k]) {\n    \"${k}: $($data[$k])\" | Out-File -FilePath $file -Encoding utf8 -Append\n  }\n}\n"
+        },
+        {
+          "uses": "actions/upload-artifact@v4",
+          "if": "always()",
+          "with": {
+            "name": "setup-info-${{ matrix.os }}",
+            "path": "setup-info-${{ matrix.os }}.md"
+          }
+        },
+        {
+          "name": "Install Pester",
+          "shell": "pwsh",
+          "run": "if (-not (Get-Module -ListAvailable -Name Pester |\n          Where-Object { $_.Version -ge [Version]'5.0.0' })) {\n  Remove-Module Pester -ErrorAction SilentlyContinue\n  Install-Module -Name Pester -MinimumVersion 5.0.0 -Scope CurrentUser -Force -SkipPublisherCheck\n}\n"
+        },
+        {
+          "name": "Validate native YAML parsing",
+          "shell": "pwsh",
+          "run": "$parsed = ConvertFrom-Yaml 'a: 1'\nif ($parsed.a -ne 1) { throw 'YAML parsing failed' }\n"
+        },
+        {
+          "name": "Run Pester",
+          "shell": "pwsh",
+          "run": "if (Test-Path \"tests/pester\") {\n  $cfg = New-PesterConfiguration\n  $cfg.Run.Path = './tests/pester'\n  $cfg.TestResult.Enabled = $false\n  $cfg.Run.Exit = $true\n  Invoke-Pester -Configuration $cfg\n}\n"
+        },
+        {
+          "uses": "actions/upload-artifact@v4",
+          "if": "always()",
+          "with": {
+            "name": "pester-junit-${{ matrix.os }}",
+            "path": "pester-results/pester-junit.xml",
+            "if-no-files-found": "error"
+          }
+        }
+      ]
+    },
+    "report": {
+      "needs": [
+        "node-ci",
+        "ps-ci"
+      ],
+      "runs-on": "ubuntu-24.04",
+      "if": "always()",
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "uses": "actions/setup-node@v4",
+          "with": {
+            "node-version": 24
+          }
+        },
+        {
+          "run": "npm run check:node"
+        },
+        {
+          "run": "npm install"
+        },
+        {
+          "uses": "actions/download-artifact@v4",
+          "with": {
+            "path": "./downloaded"
+          }
+        },
+        {
+          "run": "npm run derive:registry"
+        },
+        {
+          "run": "npm run generate:summary",
+          "env": {
+            "TEST_RESULTS_GLOBS": "downloaded/test-results/**/*junit*.xml\ndownloaded/pester-junit-*/pester-junit.xml\n",
+            "REQ_MAPPING_FILE": "requirements.json",
+            "DISPATCHER_REGISTRY": "dispatchers.json",
+            "EVIDENCE_DIR": "test-screenshots"
+          }
+        },
+        {
+          "run": "npx tsx scripts/print-pester-traceability.ts >> \"$GITHUB_STEP_SUMMARY\""
+        }
+      ]
+    }
+  }
+}

--- a/.github/workflows/close-labview-external.json
+++ b/.github/workflows/close-labview-external.json
@@ -1,0 +1,54 @@
+{
+  "name": "Close LabVIEW (external test)",
+  "on": {
+    "workflow_dispatch": null
+  },
+  "jobs": {
+    "close-labview": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "name": "Close LabVIEW (32-bit)",
+          "uses": "./close-labview/action.yml",
+          "with": {
+            "minimum_supported_lv_version": "2021",
+            "supported_bitness": "32",
+            "working_directory": "${{ github.workspace }}/scripts/close-labview",
+            "dry_run": true
+          }
+        },
+        {
+          "name": "Upload log (32-bit)",
+          "uses": "actions/upload-artifact@v4",
+          "with": {
+            "name": "close-labview-32.log",
+            "path": "${{ github.workspace }}/scripts/close-labview/close-labview.log",
+            "if-no-files-found": "ignore"
+          }
+        },
+        {
+          "name": "Close LabVIEW (64-bit)",
+          "uses": "./close-labview/action.yml",
+          "with": {
+            "minimum_supported_lv_version": "2021",
+            "supported_bitness": "64",
+            "working_directory": "${{ github.workspace }}/scripts/close-labview",
+            "dry_run": true
+          }
+        },
+        {
+          "name": "Upload log (64-bit)",
+          "uses": "actions/upload-artifact@v4",
+          "with": {
+            "name": "close-labview-64.log",
+            "path": "${{ github.workspace }}/scripts/close-labview/close-labview.log",
+            "if-no-files-found": "ignore"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.github/workflows/missing-in-project-self-hosted.json
+++ b/.github/workflows/missing-in-project-self-hosted.json
@@ -1,0 +1,34 @@
+{
+  "name": "Missing in project (ubuntu test)",
+  "on": {
+    "workflow_dispatch": null
+  },
+  "jobs": {
+    "missing-in-project": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "name": "Run missing-in-project action",
+          "uses": "./missing-in-project/action.yml",
+          "with": {
+            "lv_version": "2021",
+            "arch": "64",
+            "project_file": "scripts/missing-in-project/Missing in Project.lvproj",
+            "relative_path": "scripts/missing-in-project"
+          }
+        },
+        {
+          "name": "Upload missing findings",
+          "uses": "actions/upload-artifact@v4",
+          "with": {
+            "name": "missing-files",
+            "path": "scripts/missing-in-project/missing_files.txt"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.github/workflows/modify-vipb-display-info-self-hosted.json
+++ b/.github/workflows/modify-vipb-display-info-self-hosted.json
@@ -1,0 +1,41 @@
+{
+  "name": "Modify VIPB display info (ubuntu test)",
+  "on": {
+    "workflow_dispatch": null
+  },
+  "jobs": {
+    "modify-vipb-display-info": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "name": "Run modify-vipb-display-info action",
+          "uses": "./modify-vipb-display-info/action.yml",
+          "with": {
+            "supported_bitness": "64",
+            "relative_path": "scripts/modify-vipb-display-info",
+            "vipb_path": "scripts/modify-vipb-display-info/lv_icon.vipb",
+            "minimum_supported_lv_version": "2021",
+            "labview_minor_revision": "0",
+            "major": "1",
+            "minor": "0",
+            "patch": "0",
+            "build": "1",
+            "commit": "abcdef",
+            "display_information_json": "{\"Name\":\"Test\"}"
+          }
+        },
+        {
+          "name": "Upload vipb artifact",
+          "uses": "actions/upload-artifact@v4",
+          "with": {
+            "name": "vipb-display-info",
+            "path": "scripts/modify-vipb-display-info/lv_icon.vipb"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.github/workflows/prepare-labview-source-self-hosted.json
+++ b/.github/workflows/prepare-labview-source-self-hosted.json
@@ -1,0 +1,35 @@
+{
+  "name": "Prepare LabVIEW source (ubuntu test)",
+  "on": {
+    "workflow_dispatch": null
+  },
+  "jobs": {
+    "prepare-labview-source": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "name": "Run prepare-labview-source action",
+          "uses": "./prepare-labview-source/action.yml",
+          "with": {
+            "minimum_supported_lv_version": "2021",
+            "supported_bitness": "64",
+            "relative_path": "scripts/prepare-labview-source",
+            "labview_project": "scripts/prepare-labview-source/lv_icon.lvproj",
+            "build_spec": "PackageSource"
+          }
+        },
+        {
+          "name": "Upload prepared source",
+          "uses": "actions/upload-artifact@v4",
+          "with": {
+            "name": "prepared-source",
+            "path": "scripts/prepare-labview-source/prepared-source.zip"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.github/workflows/rename-file-self-hosted.json
+++ b/.github/workflows/rename-file-self-hosted.json
@@ -1,0 +1,32 @@
+{
+  "name": "Rename file (ubuntu test)",
+  "on": {
+    "workflow_dispatch": null
+  },
+  "jobs": {
+    "rename-file": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "name": "Run rename-file action",
+          "uses": "./rename-file/action.yml",
+          "with": {
+            "current_filename": "scripts/rename-file/README.md",
+            "new_filename": "scripts/rename-file/README-renamed.md"
+          }
+        },
+        {
+          "name": "Upload renamed file",
+          "uses": "actions/upload-artifact@v4",
+          "with": {
+            "name": "renamed-file",
+            "path": "scripts/rename-file/README-renamed.md"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.github/workflows/restore-setup-lv-source-self-hosted.json
+++ b/.github/workflows/restore-setup-lv-source-self-hosted.json
@@ -1,0 +1,38 @@
+{
+  "name": "Restore setup LV source (ubuntu test)",
+  "on": {
+    "workflow_dispatch": null
+  },
+  "jobs": {
+    "restore-setup-lv-source": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "name": "Run restore-setup-lv-source action",
+          "uses": "./restore-setup-lv-source/action.yml",
+          "with": {
+            "minimum_supported_lv_version": "2021",
+            "supported_bitness": "64",
+            "relative_path": "scripts/restore-setup-lv-source",
+            "labview_project": "scripts/restore-setup-lv-source/lv_icon.lvproj",
+            "build_spec": "PackageSource"
+          },
+          "env": {
+            "GCLI_SUPPRESS_PROMPTS": "1"
+          }
+        },
+        {
+          "name": "Upload restore logs",
+          "uses": "actions/upload-artifact@v4",
+          "with": {
+            "name": "restore-logs",
+            "path": "scripts/restore-setup-lv-source/restore.log"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.github/workflows/revert-development-mode-self-hosted.json
+++ b/.github/workflows/revert-development-mode-self-hosted.json
@@ -1,0 +1,31 @@
+{
+  "name": "Revert development mode (ubuntu test)",
+  "on": {
+    "workflow_dispatch": null
+  },
+  "jobs": {
+    "revert-development-mode": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "name": "Run revert-development-mode action",
+          "uses": "./revert-development-mode/action.yml",
+          "with": {
+            "relative_path": "./"
+          }
+        },
+        {
+          "name": "Upload config artifact",
+          "uses": "actions/upload-artifact@v4",
+          "with": {
+            "name": "devmode-config",
+            "path": "devmode-config.txt"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.github/workflows/run-pester-tests.json
+++ b/.github/workflows/run-pester-tests.json
@@ -1,0 +1,43 @@
+{
+  "name": "Run Pester tests",
+  "on": {
+    "workflow_dispatch": {
+      "inputs": {
+        "repository": {
+          "description": "owner/repo of the repository to test",
+          "required": true
+        },
+        "ref": {
+          "description": "Branch or tag to check out",
+          "required": false,
+          "default": "main"
+        }
+      }
+    }
+  },
+  "jobs": {
+    "run-pester-tests": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "name": "Checkout target repository",
+          "uses": "actions/checkout@v4",
+          "with": {
+            "repository": "${{ inputs.repository }}",
+            "ref": "${{ inputs.ref }}",
+            "path": "target",
+            "token": "${{ secrets.REPO_TOKEN }}"
+          }
+        },
+        {
+          "name": "Run Pester tests",
+          "shell": "pwsh",
+          "run": "./actions/Invoke-OSAction.ps1 -ActionName run-pester-tests -WorkingDirectory \"${{ github.workspace }}/target\""
+        }
+      ]
+    }
+  }
+}

--- a/.github/workflows/run-unit-tests-self-hosted.json
+++ b/.github/workflows/run-unit-tests-self-hosted.json
@@ -1,0 +1,35 @@
+{
+  "name": "Run unit tests (ubuntu test)",
+  "on": {
+    "workflow_dispatch": null
+  },
+  "jobs": {
+    "run-unit-tests": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "name": "Run unit tests action",
+          "uses": "./run-unit-tests/action.yml",
+          "with": {
+            "minimum_supported_lv_version": "2021",
+            "supported_bitness": "64",
+            "project_path": "scripts/run-unit-tests/lv_icon.lvproj",
+            "test_config": "scripts/run-unit-tests/unittest-config.cfg",
+            "working_directory": "scripts/run-unit-tests"
+          }
+        },
+        {
+          "name": "Upload unit test results",
+          "uses": "actions/upload-artifact@v4",
+          "with": {
+            "name": "unit-test-results",
+            "path": "scripts/run-unit-tests/UnitTestReport.xml"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.github/workflows/set-development-mode-self-hosted.json
+++ b/.github/workflows/set-development-mode-self-hosted.json
@@ -1,0 +1,35 @@
+{
+  "name": "Set development mode (ubuntu test)",
+  "on": {
+    "workflow_dispatch": null
+  },
+  "jobs": {
+    "set-development-mode": {
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "name": "Run set-development-mode action",
+          "uses": "./set-development-mode/action.yml",
+          "with": {
+            "relative_path": "scripts/set-development-mode",
+            "gcli_path": "scripts/set-development-mode/g-cli.exe",
+            "working_directory": "scripts/set-development-mode",
+            "log_level": "INFO",
+            "dry_run": "true"
+          }
+        },
+        {
+          "name": "Upload dev mode logs",
+          "uses": "actions/upload-artifact@v4",
+          "with": {
+            "name": "dev-mode-config",
+            "path": "scripts/set-development-mode/dev-mode.log"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -97,17 +97,19 @@ Chain the [apply-vipc](docs/actions/apply-vipc.md), [set-development-mode](docs/
 If you prefer or need to run tasks directly, call the dispatcher script [actions/Invoke-OSAction.ps1](actions/Invoke-OSAction.ps1) yourself:
 
 ```powershell
-$yaml = @'
-MinimumSupportedLVVersion: "2021"
-SupportedBitness: "64"
+$json = @'
+{
+  "MinimumSupportedLVVersion": "2021",
+  "SupportedBitness": "64"
+}
 '@
-pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsYaml (ConvertFrom-Yaml $yaml)
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson $json
 ```
 
 You can also load arguments from a file:
 
 ```powershell
-pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsFile ./config/run-tests.yaml
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsFile ./config/run-tests.json
 ```
 
 ### Discovering actions

--- a/docs/UnifiedDispatcher.md
+++ b/docs/UnifiedDispatcher.md
@@ -13,17 +13,19 @@ See [Common Parameters](common-parameters.md) for a complete list of dispatcher 
 
 ## Cross‑platform
 
-Works on **Windows and Linux** as long as LabVIEW and [g-cli](https://github.com/ni/g-cli) are installed and available on `PATH`. For non‑standard installs, pass `gcliPath` in `args_yaml`.
+Works on **Windows and Linux** as long as LabVIEW and [g-cli](https://github.com/ni/g-cli) are installed and available on `PATH`. For non‑standard installs, pass `gcliPath` in `args_json`.
 
 ## Example (CLI)
 
 ```powershell
-$yaml = @'
-MinimumSupportedLVVersion: "2021"
-SupportedBitness: "64"
-gcliPath: "/opt/gcli/bin"
+$json = @'
+{
+  "MinimumSupportedLVVersion": "2021",
+  "SupportedBitness": "64",
+  "gcliPath": "/opt/gcli/bin"
+}
 '@
-pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsYaml (ConvertFrom-Yaml $yaml) -LogLevel INFO
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson $json -LogLevel INFO
 ```
 
 ## Wrapper action usage

--- a/docs/actions/run-unit-tests.md
+++ b/docs/actions/run-unit-tests.md
@@ -20,11 +20,13 @@ None.
 ## CLI example
 
 ```powershell
-$yaml = @'
-MinimumSupportedLVVersion: "2020"
-SupportedBitness: "64"
+$json = @'
+{
+  "MinimumSupportedLVVersion": "2020",
+  "SupportedBitness": "64"
+}
 '@
-pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsYaml (ConvertFrom-Yaml $yaml)
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson $json
 ```
 
 ## GitHub Action inputs

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -29,20 +29,22 @@ In this step, the wrapper action invokes the dispatcher to run the **build-lvlib
 3. **Invoke via PowerShell (CLI):** You can also call the dispatcher script directly. For example, the above build can be run in a PowerShell session or script:
 
 ```powershell
-$yaml = @'
-MinimumSupportedLVVersion: "2019"
-SupportedBitness: "32"
-WorkingDirectory: .
-RelativePath: .
-LabVIEW_Project: MyProject.lvproj
-Build_Spec: "My Build"
-Major: 1
-Minor: 0
-Patch: 0
-Build: 123
-Commit: abcdef
+$json = @'
+{
+  "MinimumSupportedLVVersion": "2019",
+  "SupportedBitness": "32",
+  "WorkingDirectory": ".",
+  "RelativePath": ".",
+  "LabVIEW_Project": "MyProject.lvproj",
+  "Build_Spec": "My Build",
+  "Major": 1,
+  "Minor": 0,
+  "Patch": 0,
+  "Build": 123,
+  "Commit": "abcdef"
+}
 '@
-pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -ArgsYaml (ConvertFrom-Yaml $yaml)
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -ArgsJson $json
 ```
 
 This will import the **OpenSourceActions** module and run the **Build** adapter. On completion, the script returns with an exit code (0 for success or a non-zero error code). You can include optional flags like `-WorkingDirectory` to change directory before execution, or `-DryRun` to simulate the action (see below). For details on these and other dispatcher flags, see [Common Parameters](common-parameters.md).

--- a/tests/pester/AddTokenToLabview.Workflow.Tests.ps1
+++ b/tests/pester/AddTokenToLabview.Workflow.Tests.ps1
@@ -12,8 +12,8 @@ Describe 'AddTokenToLabview.Workflow' {
 
     It 'runs add-token-to-labview action and uploads token artifact' -Tag 'REQ-008' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
-        $workflowPath = Join-Path $repoRoot '.github/workflows/add-token-to-labview-self-hosted.yml'
-        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml
+        $workflowPath = Join-Path $repoRoot '.github/workflows/add-token-to-labview-self-hosted.json'
+        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable
         $job = $wf.jobs.'add-token'
         $addStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_.uses -eq './add-token-to-labview/action.yml' } | Select-Object -First 1
         $checkoutSteps = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_.uses -eq 'actions/checkout@v4' }

--- a/tests/pester/ApplyVipc.Workflow.Tests.ps1
+++ b/tests/pester/ApplyVipc.Workflow.Tests.ps1
@@ -11,8 +11,8 @@ Describe 'ApplyVipc.DryRunTrue.Workflow' {
 
     It 'runs apply-vipc action with dry_run true' -Tag 'REQ-006' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
-        $workflowPath = Join-Path $repoRoot '.github/workflows/apply-vipc-self-hosted.yml'
-        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml
+        $workflowPath = Join-Path $repoRoot '.github/workflows/apply-vipc-self-hosted.json'
+        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable
         $job = $wf.jobs.'apply-vipc'
         $applyStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq './apply-vipc/action.yml' } | Select-Object -First 1
         $checkoutSteps = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq 'actions/checkout@v4' }

--- a/tests/pester/Build.Workflow.Tests.ps1
+++ b/tests/pester/Build.Workflow.Tests.ps1
@@ -11,8 +11,8 @@ Describe 'Build.Workflow' {
 
     It 'runs build action with required inputs' -Tag 'REQ-009' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
-        $workflowPath = Join-Path $repoRoot '.github/workflows/build-self-hosted.yml'
-        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml
+        $workflowPath = Join-Path $repoRoot '.github/workflows/build-self-hosted.json'
+        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable
         $job = $wf.jobs.'build'
         $buildStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq './build/action.yml' } | Select-Object -First 1
         $artifactStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq 'actions/upload-artifact@v4' -and $_['with']['path'] -match 'lv_icon_x64\.lvlibp' } | Select-Object -First 1

--- a/tests/pester/BuildLvlibp.Workflow.Tests.ps1
+++ b/tests/pester/BuildLvlibp.Workflow.Tests.ps1
@@ -11,8 +11,8 @@ Describe 'BuildLvlibp.Workflow' {
 
     It 'runs build-lvlibp action and uploads lvlibp artifact' -Tag 'REQ-010' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
-        $workflowPath = Join-Path $repoRoot '.github/workflows/build-lvlibp-self-hosted.yml'
-        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml
+        $workflowPath = Join-Path $repoRoot '.github/workflows/build-lvlibp-self-hosted.json'
+        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable
         $job = $wf.jobs.'build-lvlibp'
         $buildStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq './build-lvlibp/action.yml' } | Select-Object -First 1
         $artifactStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq 'actions/upload-artifact@v4' -and $_['with']['path'] -match '\.lvlibp$' } | Select-Object -First 1

--- a/tests/pester/BuildViPackage.Workflow.Tests.ps1
+++ b/tests/pester/BuildViPackage.Workflow.Tests.ps1
@@ -11,12 +11,12 @@ Describe 'BuildViPackage.Workflow' {
 
     It 'runs build-vi-package action and uploads vi package artifact' -Tag 'REQ-011' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
-        $workflowPath = Join-Path $repoRoot '.github/workflows/build-vi-package-self-hosted.yml'
+        $workflowPath = Join-Path $repoRoot '.github/workflows/build-vi-package-self-hosted.json'
         if (-not (Test-Path $workflowPath)) {
             Set-ItResult -Skipped -Because 'Workflow file not found'
             return
         }
-        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml
+        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable
         $job = $wf.jobs.'build-vi-package'
         $buildStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq './build-vi-package/action.yml' } | Select-Object -First 1
         $artifactStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq 'actions/upload-artifact@v4' -and $_['with']['path'] -match '\.vip$' } | Select-Object -First 1

--- a/tests/pester/CloseLabview.Workflow.Tests.ps1
+++ b/tests/pester/CloseLabview.Workflow.Tests.ps1
@@ -11,14 +11,14 @@ Describe 'CloseLabview.Workflow' {
 
     It 'runs close-labview action for 32-bit and 64-bit and uploads logs' -Tag 'REQ-012' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
-        $wfFile = Join-Path $repoRoot '.github/workflows/close-labview-external.yml'
+        $wfFile = Join-Path $repoRoot '.github/workflows/close-labview-external.json'
 
         if (-not (Test-Path $wfFile)) {
             Set-ItResult -Skipped -Because 'close-labview-external workflow not found'
             return
         }
 
-        $wf = Get-Content -Raw $wfFile | ConvertFrom-Yaml
+        $wf = Get-Content -Raw $wfFile | ConvertFrom-Json -AsHashtable
         $jobFound = $false
 
         foreach ($jobEntry in $wf.jobs.GetEnumerator()) {
@@ -51,7 +51,7 @@ Describe 'CloseLabview.Workflow' {
         }
 
         if (-not $jobFound) {
-            Set-ItResult -Failed -Because 'No steps found using close-labview action in close-labview-external.yml'
+            Set-ItResult -Failed -Because 'No steps found using close-labview action in close-labview-external.json'
         }
     }
 }

--- a/tests/pester/Dispatcher.Tests.ps1
+++ b/tests/pester/Dispatcher.Tests.ps1
@@ -86,9 +86,10 @@ Describe 'ArgsFile handling' {
     @{ MinimumSupportedLVVersion = '2021'; SupportedBitness = '32' } | ConvertTo-Json -Compress | Set-Content -Path $jsonFile
 
     $override = @{ SupportedBitness = '64' }
+    $overrideJson = $override | ConvertTo-Json -Compress
 
     $projectRoot = (Get-LabVIEWIconEditorArgsJson).WorkingDirectory
-    $out = & $global:dispatcher -ActionName close-labview -ArgsFile $jsonFile -ArgsYaml $override -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
+    $out = & $global:dispatcher -ActionName close-labview -ArgsFile $jsonFile -ArgsJson $overrideJson -WorkingDirectory $projectRoot -DryRun *>&1 | Out-String
     $LASTEXITCODE | Should -Be 0
     $out | Should -Match '"SupportedBitness":"64"'
   }

--- a/tests/pester/MissingInProject.Workflow.Tests.ps1
+++ b/tests/pester/MissingInProject.Workflow.Tests.ps1
@@ -11,8 +11,8 @@ Describe 'MissingInProject.Workflow' {
 
     It 'runs missing-in-project action and uploads findings report' -Tag 'REQ-014' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
-        $workflowPath = Join-Path $repoRoot '.github/workflows/missing-in-project-self-hosted.yml'
-        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml
+        $workflowPath = Join-Path $repoRoot '.github/workflows/missing-in-project-self-hosted.json'
+        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable
         $job = $wf.jobs.'missing-in-project'
         $missingStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_.uses -eq './missing-in-project/action.yml' } | Select-Object -First 1
         $artifactStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_.uses -like 'actions/upload-artifact@*' } | Select-Object -First 1

--- a/tests/pester/ModifyVipbDisplayInfo.Workflow.Tests.ps1
+++ b/tests/pester/ModifyVipbDisplayInfo.Workflow.Tests.ps1
@@ -11,8 +11,8 @@ Describe 'ModifyVipbDisplayInfo.Workflow' {
 
     It 'runs modify-vipb-display-info action and uploads VIPB artifact' -Tag 'REQ-015' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
-        $workflowPath = Join-Path $repoRoot '.github/workflows/modify-vipb-display-info-self-hosted.yml'
-        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml
+        $workflowPath = Join-Path $repoRoot '.github/workflows/modify-vipb-display-info-self-hosted.json'
+        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable
         $job = $wf.jobs.'modify-vipb-display-info'
         $modStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_.uses -eq './modify-vipb-display-info/action.yml' } | Select-Object -First 1
         $artifactStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_.uses -like 'actions/upload-artifact@*' } | Select-Object -First 1

--- a/tests/pester/PrepareLabviewSource.Workflow.Tests.ps1
+++ b/tests/pester/PrepareLabviewSource.Workflow.Tests.ps1
@@ -11,8 +11,8 @@ Describe 'PrepareLabviewSource.Workflow' {
 
     It 'runs prepare-labview-source action and uploads prepared source artifact' -Tag 'REQ-016' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
-        $workflowPath = Join-Path $repoRoot '.github/workflows/prepare-labview-source-self-hosted.yml'
-        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml
+        $workflowPath = Join-Path $repoRoot '.github/workflows/prepare-labview-source-self-hosted.json'
+        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable
         $job = $wf.jobs.'prepare-labview-source'
         $prepareStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_.uses -eq './prepare-labview-source/action.yml' } | Select-Object -First 1
         $artifactStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_.uses -like 'actions/upload-artifact@*' } | Select-Object -First 1

--- a/tests/pester/RenameFile.Workflow.Tests.ps1
+++ b/tests/pester/RenameFile.Workflow.Tests.ps1
@@ -11,8 +11,8 @@ Describe 'RenameFile.Workflow' {
 
     It 'runs rename-file action and uploads renamed file artifact' -Tag 'REQ-017' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
-        $workflowPath = Join-Path $repoRoot '.github/workflows/rename-file-self-hosted.yml'
-        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml
+        $workflowPath = Join-Path $repoRoot '.github/workflows/rename-file-self-hosted.json'
+        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable
         $job = $wf.jobs.'rename-file'
         $renameStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_.uses -eq './rename-file/action.yml' } | Select-Object -First 1
         $uploadStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_.uses -like 'actions/upload-artifact@*' } | Select-Object -First 1

--- a/tests/pester/RestoreSetupLvSource.Workflow.Tests.ps1
+++ b/tests/pester/RestoreSetupLvSource.Workflow.Tests.ps1
@@ -11,8 +11,8 @@ Describe 'RestoreSetupLvSource.Workflow' {
 
     It 'runs restore-setup-lv-source action and uploads restoration artifacts' -Tag 'REQ-018' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
-        $workflowPath = Join-Path $repoRoot '.github/workflows/restore-setup-lv-source-self-hosted.yml'
-        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml
+        $workflowPath = Join-Path $repoRoot '.github/workflows/restore-setup-lv-source-self-hosted.json'
+        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable
         $job = $wf.jobs.'restore-setup-lv-source'
         $restoreStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_.uses -eq './restore-setup-lv-source/action.yml' } | Select-Object -First 1
         $artifactStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_.uses -like 'actions/upload-artifact@*' } | Select-Object -First 1

--- a/tests/pester/RevertDevelopmentMode.Workflow.Tests.ps1
+++ b/tests/pester/RevertDevelopmentMode.Workflow.Tests.ps1
@@ -12,11 +12,11 @@ Describe 'RevertDevelopmentMode.Workflow' {
     It 'runs revert-development-mode action and uploads configuration artifact' -Tag 'REQ-019' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
         $wfDir = Join-Path $repoRoot '.github/workflows'
-        $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.yml'
+        $workflowFiles = Get-ChildItem -Path $wfDir -Filter '*.json'
         $workflowFound = $false
 
         foreach ($wfFile in $workflowFiles) {
-            $wf = Get-Content -Raw $wfFile.FullName | ConvertFrom-Yaml
+            $wf = Get-Content -Raw $wfFile.FullName | ConvertFrom-Json -AsHashtable
             foreach ($jobEntry in $wf.jobs.GetEnumerator()) {
                 $job = $jobEntry.Value
                 $revertStep = $job.steps | Where-Object { $_.uses -eq './revert-development-mode/action.yml' } | Select-Object -First 1

--- a/tests/pester/RunUnitTests.Workflow.Tests.ps1
+++ b/tests/pester/RunUnitTests.Workflow.Tests.ps1
@@ -11,8 +11,8 @@ Describe 'RunUnitTests.Workflow' {
 
     It 'runs run-unit-tests action and uploads unit-test results' -Tag 'REQ-011' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
-        $workflowPath = Join-Path $repoRoot '.github/workflows/run-unit-tests-self-hosted.yml'
-        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml
+        $workflowPath = Join-Path $repoRoot '.github/workflows/run-unit-tests-self-hosted.json'
+        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable
         $job = $wf.jobs.'run-unit-tests'
         $testStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq './run-unit-tests/action.yml' } | Select-Object -First 1
         $artifactStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_['uses'] -eq 'actions/upload-artifact@v4' -and $_['with']['path'] -match 'UnitTestReport\.xml' } | Select-Object -First 1

--- a/tests/pester/SetDevelopmentMode.Workflow.Tests.ps1
+++ b/tests/pester/SetDevelopmentMode.Workflow.Tests.ps1
@@ -11,8 +11,8 @@ Describe 'SetDevelopmentMode.Workflow' {
 
     It 'runs set-development-mode action and uploads logs' -Tag 'REQ-021' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
-        $workflowPath = Join-Path $repoRoot '.github/workflows/set-development-mode-self-hosted.yml'
-        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Yaml
+        $workflowPath = Join-Path $repoRoot '.github/workflows/set-development-mode-self-hosted.json'
+        $wf = Get-Content -Raw $workflowPath | ConvertFrom-Json -AsHashtable
         $job = $wf.jobs.'set-development-mode'
         $setStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_.uses -eq './set-development-mode/action.yml' } | Select-Object -First 1
         $artifactStep = $job.steps | Where-Object { $_.ContainsKey('uses') -and $_.uses -like 'actions/upload-artifact@*' } | Select-Object -First 1


### PR DESCRIPTION
## Summary
- convert workflow YAML files to JSON and update Pester tests to parse JSON
- document JSON-based dispatcher usage and remove ConvertFrom-Yaml references

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'` *(fails: Expected 0, but got 1 in Dispatcher.DryRun tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a2bfb772448329ba7f34f8087f876d