### PR TITLE
docs: replace ConvertFrom-Yaml examples with JSON usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Chain the [apply-vipc](docs/actions/apply-vipc.md), [set-development-mode](docs/
 
 ## CLI/dispatcher usage
 
-If you prefer or need to run tasks directly, call the dispatcher script [actions/Invoke-OSAction.ps1](actions/Invoke-OSAction.ps1) yourself:
+If you prefer or need to run tasks directly, serialize arguments as JSON and call the dispatcher script [actions/Invoke-OSAction.ps1](actions/Invoke-OSAction.ps1) yourself:
 
 ```powershell
 $json = @'
@@ -105,8 +105,7 @@ $json = @'
 '@
 pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson $json
 ```
-
-You can also load arguments from a file:
+YAML conversion via `ConvertFrom-Yaml` is no longer required. You can also load arguments from a JSON file:
 
 ```powershell
 pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsFile ./config/run-tests.json

--- a/docs/UnifiedDispatcher.md
+++ b/docs/UnifiedDispatcher.md
@@ -28,6 +28,12 @@ $json = @'
 pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson $json -LogLevel INFO
 ```
 
+Arguments can also be read from a JSON file:
+
+```powershell
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsFile ./config/run-tests.json -LogLevel INFO
+```
+
 ## Wrapper action usage
 
 ```yaml

--- a/docs/actions/run-unit-tests.md
+++ b/docs/actions/run-unit-tests.md
@@ -29,6 +29,12 @@ $json = @'
 pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson $json
 ```
 
+Alternatively, load arguments from a JSON file:
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsFile ./config/run-tests.json
+```
+
 ## GitHub Action inputs
 
 GitHub Action inputs are provided in `snake_case`, while CLI parameters use `PascalCase`. The table below maps each input to its corresponding CLI parameter. For details on shared CLI flags, see [Common parameters](../common-parameters.md).

--- a/docs/common-parameters.md
+++ b/docs/common-parameters.md
@@ -11,7 +11,7 @@ Controls logging verbosity. Allowed values: `ERROR`, `WARN`, `INFO` (default), `
 Example:
 
 ```powershell
-pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsYaml '{}' -LogLevel DEBUG
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{}' -LogLevel DEBUG
 ```
 
 ### `-DryRun`
@@ -21,7 +21,7 @@ Prints the adapter invocation without executing it.
 Example:
 
 ```powershell
-pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsYaml '{}' -DryRun
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{}' -DryRun
 ```
 
 ### `-WorkingDirectory`
@@ -31,7 +31,7 @@ Runs the adapter after changing to the specified directory using `-WorkingDirect
 Example:
 
 ```powershell
-pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsYaml '{}' -WorkingDirectory src
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{}' -WorkingDirectory src
 ```
 
 ### `-ListActions`
@@ -58,12 +58,12 @@ pwsh ./actions/Invoke-OSAction.ps1 -Describe run-unit-tests
 
 ### `gcliPath`
 
-Optional path to the NI g-cli executable. When provided in `args_yaml`, the dispatcher prepends it to `PATH`. Default: assumes `g-cli` is already on `PATH`.
+Optional path to the NI g-cli executable. When provided in `args_json`, the dispatcher prepends it to `PATH`. Default: assumes `g-cli` is already on `PATH`.
 
 Example:
 
 ```powershell
-pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsYaml '{"gcliPath":"/opt/gcli/bin"}'
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{"gcliPath":"/opt/gcli/bin"}'
 ```
 
 ### `PSModulePath`
@@ -74,5 +74,5 @@ Example:
 
 ```powershell
 $env:PSModulePath = "$PWD/modules"
-pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsYaml '{}'
+pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson '{}'
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -47,6 +47,12 @@ $json = @'
 pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -ArgsJson $json
 ```
 
+Arguments can also be loaded from a JSON file:
+
+```powershell
+pwsh -File actions/Invoke-OSAction.ps1 -ActionName build-lvlibp -ArgsFile ./config/build.json
+```
+
 This will import the **OpenSourceActions** module and run the **Build** adapter. On completion, the script returns with an exit code (0 for success or a non-zero error code). You can include optional flags like `-WorkingDirectory` to change directory before execution, or `-DryRun` to simulate the action (see below). For details on these and other dispatcher flags, see [Common Parameters](common-parameters.md).
 4. **Confirm Results:** After running, check the console output and exit code. The unified dispatcher prints informative logs (at INFO level by default) and any errors encountered. For GitHub Actions, a non-zero exit code will mark the step as failed, surfacing any error messages thrown by the adapter or underlying script.
 


### PR DESCRIPTION
## Summary
- clarify in README that ConvertFrom-Yaml is no longer required
- show JSON ArgsFile examples for run-unit-tests, quickstart, and dispatcher docs
- update common parameters to use ArgsJson instead of ArgsYaml

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'` *(fails: Tests Passed: 89, Failed: 16, Skipped: 15, Inconclusive: 0, NotRun: 0)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c32408548329a659a7919d4e9171