### PR TITLE
Switch actions to JSON args

### DIFF
--- a/.github/workflows/run-pester-tests.json
+++ b/.github/workflows/run-pester-tests.json
@@ -35,7 +35,7 @@
         {
           "name": "Run Pester tests",
           "shell": "pwsh",
-          "run": "./actions/Invoke-OSAction.ps1 -ActionName run-pester-tests -WorkingDirectory \"${{ github.workspace }}/target\""
+          "run": "./actions/Invoke-OSAction.ps1 -ActionName run-pester-tests -ArgsJson '{}' -WorkingDirectory \"${{ github.workspace }}/target\""
         }
       ]
     }

--- a/.github/workflows/run-pester-tests.yml
+++ b/.github/workflows/run-pester-tests.yml
@@ -25,4 +25,4 @@ jobs:
           token: ${{ secrets.REPO_TOKEN }}
       - name: Run Pester tests
         shell: pwsh
-        run: ./actions/Invoke-OSAction.ps1 -ActionName run-pester-tests -WorkingDirectory "${{ github.workspace }}/target"
+        run: ./actions/Invoke-OSAction.ps1 -ActionName run-pester-tests -ArgsJson '{}' -WorkingDirectory "${{ github.workspace }}/target"

--- a/add-token-to-labview/action.yml
+++ b/add-token-to-labview/action.yml
@@ -39,7 +39,7 @@ runs:
         if ('${{ inputs.gcli_path }}') { $args['gcliPath'] = '${{ inputs.gcli_path }}' }
         $params = @{
           ActionName = 'add-token-to-labview'
-          ArgsYaml   = $args
+          ArgsJson   = $args
           LogLevel   = '${{ inputs.log_level }}'
         }
         if ('${{ inputs.dry_run }}' -eq 'true') { $params['DryRun'] = $true }

--- a/apply-vipc/action.yml
+++ b/apply-vipc/action.yml
@@ -47,7 +47,7 @@ runs:
         if ('${{ inputs.gcli_path }}') { $args['gcliPath'] = '${{ inputs.gcli_path }}' }
         $params = @{
           ActionName = 'apply-vipc'
-          ArgsYaml   = $args
+          ArgsJson   = $args
           LogLevel   = '${{ inputs.log_level }}'
         }
         if ('${{ inputs.dry_run }}' -eq 'true') { $params['DryRun'] = $true }

--- a/build-lvlibp/action.yml
+++ b/build-lvlibp/action.yml
@@ -67,7 +67,7 @@ runs:
         if ('${{ inputs.gcli_path }}') { $args['gcliPath'] = '${{ inputs.gcli_path }}' }
         $params = @{
           ActionName = 'build-lvlibp'
-          ArgsYaml   = $args
+          ArgsJson   = $args
           LogLevel   = '${{ inputs.log_level }}'
         }
         if ('${{ inputs.dry_run }}' -eq 'true') { $params['DryRun'] = $true }

--- a/build-vi-package/action.yml
+++ b/build-vi-package/action.yml
@@ -75,7 +75,7 @@ runs:
         if ('${{ inputs.gcli_path }}') { $args['gcliPath'] = '${{ inputs.gcli_path }}' }
         $params = @{
           ActionName = 'build-vi-package'
-          ArgsYaml   = $args
+          ArgsJson   = $args
           LogLevel   = '${{ inputs.log_level }}'
         }
         if ('${{ inputs.dry_run }}' -eq 'true') { $params['DryRun'] = $true }

--- a/build/action.yml
+++ b/build/action.yml
@@ -63,7 +63,7 @@ runs:
         if ('${{ inputs.gcli_path }}') { $args['gcliPath'] = '${{ inputs.gcli_path }}' }
         $params = @{
           ActionName = 'build'
-          ArgsYaml   = $args
+          ArgsJson   = $args
           LogLevel   = '${{ inputs.log_level }}'
         }
         if ('${{ inputs.dry_run }}' -eq 'true') { $params['DryRun'] = $true }

--- a/close-labview/action.yml
+++ b/close-labview/action.yml
@@ -35,7 +35,7 @@ runs:
         if ('${{ inputs.gcli_path }}') { $args['gcliPath'] = '${{ inputs.gcli_path }}' }
         $params = @{
           ActionName = 'close-labview'
-          ArgsYaml   = $args
+          ArgsJson   = $args
           LogLevel   = '${{ inputs.log_level }}'
         }
         if ('${{ inputs.dry_run }}' -eq 'true') { $params['DryRun'] = $true }

--- a/generate-release-notes/action.yml
+++ b/generate-release-notes/action.yml
@@ -30,7 +30,7 @@ runs:
         if ('${{ inputs.gcli_path }}') { $args['gcliPath'] = '${{ inputs.gcli_path }}' }
         $params = @{
           ActionName = 'generate-release-notes'
-          ArgsYaml   = $args
+          ArgsJson   = $args
           LogLevel   = '${{ inputs.log_level }}'
         }
         if ('${{ inputs.dry_run }}' -eq 'true') { $params['DryRun'] = $true }

--- a/missing-in-project/action.yml
+++ b/missing-in-project/action.yml
@@ -39,7 +39,7 @@ runs:
         if ('${{ inputs.gcli_path }}') { $args['gcliPath'] = '${{ inputs.gcli_path }}' }
         $params = @{
           ActionName = 'missing-in-project'
-          ArgsYaml   = $args
+          ArgsJson   = $args
           LogLevel   = '${{ inputs.log_level }}'
         }
         if ('${{ inputs.dry_run }}' -eq 'true') { $params['DryRun'] = $true }

--- a/modify-vipb-display-info/action.yml
+++ b/modify-vipb-display-info/action.yml
@@ -75,7 +75,7 @@ runs:
         if ('${{ inputs.gcli_path }}') { $args['gcliPath'] = '${{ inputs.gcli_path }}' }
         $params = @{
           ActionName = 'modify-vipb-display-info'
-          ArgsYaml   = $args
+          ArgsJson   = $args
           LogLevel   = '${{ inputs.log_level }}'
         }
         if ('${{ inputs.dry_run }}' -eq 'true') { $params['DryRun'] = $true }

--- a/prepare-labview-source/action.yml
+++ b/prepare-labview-source/action.yml
@@ -47,7 +47,7 @@ runs:
         if ('${{ inputs.gcli_path }}') { $args['gcliPath'] = '${{ inputs.gcli_path }}' }
         $params = @{
           ActionName = 'prepare-labview-source'
-          ArgsYaml   = $args
+          ArgsJson   = $args
           LogLevel   = '${{ inputs.log_level }}'
         }
         if ('${{ inputs.dry_run }}' -eq 'true') { $params['DryRun'] = $true }

--- a/rename-file/action.yml
+++ b/rename-file/action.yml
@@ -35,7 +35,7 @@ runs:
         if ('${{ inputs.gcli_path }}') { $args['gcliPath'] = '${{ inputs.gcli_path }}' }
         $params = @{
           ActionName = 'rename-file'
-          ArgsYaml   = $args
+          ArgsJson   = $args
           LogLevel   = '${{ inputs.log_level }}'
         }
         if ('${{ inputs.dry_run }}' -eq 'true') { $params['DryRun'] = $true }

--- a/restore-setup-lv-source/action.yml
+++ b/restore-setup-lv-source/action.yml
@@ -47,7 +47,7 @@ runs:
         if ('${{ inputs.gcli_path }}') { $args['gcliPath'] = '${{ inputs.gcli_path }}' }
         $params = @{
           ActionName = 'restore-setup-lv-source'
-          ArgsYaml   = $args
+          ArgsJson   = $args
           LogLevel   = '${{ inputs.log_level }}'
         }
         if ('${{ inputs.dry_run }}' -eq 'true') { $params['DryRun'] = $true }

--- a/revert-development-mode/action.yml
+++ b/revert-development-mode/action.yml
@@ -29,7 +29,7 @@ runs:
         if ('${{ inputs.gcli_path }}') { $args['gcliPath'] = '${{ inputs.gcli_path }}' }
         $params = @{
           ActionName = 'revert-development-mode'
-          ArgsYaml   = $args
+          ArgsJson   = $args
           LogLevel   = '${{ inputs.log_level }}'
         }
         if ('${{ inputs.dry_run }}' -eq 'true') { $params['DryRun'] = $true }

--- a/run-pester-tests/action.yml
+++ b/run-pester-tests/action.yml
@@ -24,7 +24,7 @@ runs:
         }
         $params = @{
           ActionName = 'run-pester-tests'
-          ArgsYaml   = $args
+          ArgsJson   = $args
           LogLevel   = '${{ inputs.log_level }}'
         }
         if ('${{ inputs.dry_run }}' -eq 'true') { $params['DryRun'] = $true }

--- a/run-unit-tests/action.yml
+++ b/run-unit-tests/action.yml
@@ -35,7 +35,7 @@ runs:
         if ('${{ inputs.gcli_path }}') { $args['gcliPath'] = '${{ inputs.gcli_path }}' }
         $params = @{
           ActionName = 'run-unit-tests'
-          ArgsYaml   = $args
+          ArgsJson   = $args
           LogLevel   = '${{ inputs.log_level }}'
         }
         if ('${{ inputs.dry_run }}' -eq 'true') { $params['DryRun'] = $true }

--- a/scripts/generate-ci-summary.ts
+++ b/scripts/generate-ci-summary.ts
@@ -341,7 +341,7 @@ async function generateActionDocs(dispatcherRegistryFile: string, wrapperDirs: s
       }
       lines.push(tbl.join('\n'));
       lines.push('\n```powershell');
-      lines.push(`pwsh ./actions/Invoke-OSAction.ps1 -ActionName ${fn} -ArgsYaml '{}'`);
+      lines.push(`pwsh ./actions/Invoke-OSAction.ps1 -ActionName ${fn} -ArgsJson '{}'`);
       lines.push('```');
     }
   }

--- a/set-development-mode/action.yml
+++ b/set-development-mode/action.yml
@@ -29,7 +29,7 @@ runs:
         if ('${{ inputs.gcli_path }}') { $args['gcliPath'] = '${{ inputs.gcli_path }}' }
         $params = @{
           ActionName = 'set-development-mode'
-          ArgsYaml   = $args
+          ArgsJson   = $args
           LogLevel   = '${{ inputs.log_level }}'
         }
         if ('${{ inputs.dry_run }}' -eq 'true') { $params['DryRun'] = $true }


### PR DESCRIPTION
## Summary
- pass dispatch arguments as JSON in all composite actions
- update Pester workflows to supply explicit JSON config
- adjust documentation generator for JSON examples

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg"` *(fails: Tests Passed: 89, Failed: 16)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c55bbb8c83298c8678d6fe22eb72