### PR TITLE
docs: remove ConvertFrom-Yaml note

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ $json = @'
 '@
 pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsJson $json
 ```
-YAML conversion via `ConvertFrom-Yaml` is no longer required. You can also load arguments from a JSON file:
+Alternatively, load arguments from a JSON file:
 
 ```powershell
 pwsh ./actions/Invoke-OSAction.ps1 -ActionName run-unit-tests -ArgsFile ./config/run-tests.json


### PR DESCRIPTION
## Summary
- remove legacy ConvertFrom-Yaml instructions in favor of JSON args files

## Testing
- `npm run check:node` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm install`
- `npm test` *(fails: Node.js >=24 required, but 20.19.4 found)*
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command '$cfg = New-PesterConfiguration; $cfg.Run.Path = "./tests/pester"; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg'` *(fails: Tests Passed: 89, Failed: 16, Skipped: 15)*

------
https://chatgpt.com/codex/tasks/task_e_68a2cc088b688329a9906cabd4f3c983