### PR TITLE
ci: remove OS build check for PowerShell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,11 +62,6 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: |
-          $expectedBuild = '10.0.20348'
-          $build = (Get-ComputerInfo).OsVersion
-          if ($build -ne $expectedBuild) {
-            throw "Unexpected OS build: $build"
-          }
           $msiUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.5.1/PowerShell-7.5.1-win-x64.msi'
           $msiPath = Join-Path $env:RUNNER_TEMP 'PowerShell-7.5.1-win-x64.msi'
           Invoke-WebRequest -Uri $msiUrl -OutFile $msiPath


### PR DESCRIPTION
## Summary
- remove strict OS build check when installing PowerShell 7.5.1

## Testing
- `npm run check:node`
- `npm install`
- `npm test`
- `npm run lint:md`
- `npx --yes markdown-link-check -q -c .markdown-link-check.json README.md $(find docs scripts -name '*.md')`
- `actionlint`
- `pwsh -NoLogo -Command "$cfg = New-PesterConfiguration; $cfg.Run.Path = './tests/pester'; $cfg.TestResult.Enabled = $false; Invoke-Pester -Configuration $cfg"` *(fails: 88 passed, 17 failed, 15 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d7fc13ec8329b41c95112c9a3c24